### PR TITLE
Re added revit wall level setter

### DIFF
--- a/src/Speckle.Objects/BuiltElements/Revit/RevitWall.cs
+++ b/src/Speckle.Objects/BuiltElements/Revit/RevitWall.cs
@@ -56,7 +56,7 @@ public class RevitWall : Wall
     get => base.level;
     set => base.level = value;
   }
-  
+
   #region Schema Info Constructors
 
   [SchemaInfo(

--- a/src/Speckle.Objects/BuiltElements/Revit/RevitWall.cs
+++ b/src/Speckle.Objects/BuiltElements/Revit/RevitWall.cs
@@ -51,6 +51,12 @@ public class RevitWall : Wall
   public Base? parameters { get; set; }
   public string? elementId { get; set; }
 
+  public new Level? level
+  {
+    get => base.level;
+    set => base.level = value;
+  }
+  
   #region Schema Info Constructors
 
   [SchemaInfo(


### PR DESCRIPTION
We were relying on `RevitWall` having a public setter for the `Level` property, which I removed in https://github.com/specklesystems/speckle-sharp/pull/3451 (wasn't needed for DUI2) ... but for DUI3, looks like we had already started using it.

More to discuss on this topic, since I want to move away from us mutating objects in favour of constructing them with all required properties. But we have [a ticket](https://spockle.atlassian.net/browse/DUI3-64) to discuss this post release.