### PR TITLE
DUI3-38 Clarify and Support valid fallback value types

### DIFF
--- a/src/Speckle.Objects/BuiltElements/AdvanceSteel/AsteelPlate.cs
+++ b/src/Speckle.Objects/BuiltElements/AdvanceSteel/AsteelPlate.cs
@@ -6,7 +6,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements.AdvanceSteel;
 
-public class AsteelPlate : Area, IDisplayValue<List<Mesh>>, IHasArea, IHasVolume, IAsteelObject
+public class AsteelPlate : Area, IHasArea, IHasVolume, IAsteelObject
 {
   [DetachProperty]
   public StructuralMaterial? material { get; set; }

--- a/src/Speckle.Objects/BuiltElements/AdvanceSteel/AsteelSlab.cs
+++ b/src/Speckle.Objects/BuiltElements/AdvanceSteel/AsteelSlab.cs
@@ -6,7 +6,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements.AdvanceSteel;
 
-public class AsteelSlab : Area, IDisplayValue<List<Mesh>>, IHasArea, IHasVolume, IAsteelObject
+public class AsteelSlab : Area, IHasArea, IHasVolume, IAsteelObject
 {
   [DetachProperty]
   public StructuralMaterial? material { get; set; }

--- a/src/Speckle.Objects/BuiltElements/Alignment.cs
+++ b/src/Speckle.Objects/BuiltElements/Alignment.cs
@@ -6,7 +6,7 @@ using Speckle.Newtonsoft.Json;
 
 namespace Objects.BuiltElements;
 
-public class Alignment : Base, IDisplayValue<Polyline>
+public class Alignment : Base, IDisplayValue<List<Polyline>>
 {
   [JsonIgnore, Obsolete("Use curves property")]
   public ICurve baseCurve { get; set; }
@@ -34,5 +34,5 @@ public class Alignment : Base, IDisplayValue<Polyline>
   public string units { get; set; }
 
   [DetachProperty]
-  public Polyline displayValue { get; set; }
+  public List<Polyline> displayValue { get; set; }
 }

--- a/src/Speckle.Objects/BuiltElements/Area.cs
+++ b/src/Speckle.Objects/BuiltElements/Area.cs
@@ -5,7 +5,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements;
 
-public class Area : Base, IHasArea, IHasVolume, IDisplayValue<List<Mesh>>
+public class Area : Base, IHasArea, IHasVolume, IDisplayValue<IEnumerable<Mesh>>
 {
   public Area() { }
 
@@ -31,7 +31,7 @@ public class Area : Base, IHasArea, IHasVolume, IDisplayValue<List<Mesh>>
   public string units { get; set; }
 
   [DetachProperty]
-  public List<Mesh> displayValue { get; set; }
+  public IEnumerable<Mesh> displayValue { get; set; }
 
   public double area { get; set; }
   public double volume { get; set; }

--- a/src/Speckle.Objects/BuiltElements/Beam.cs
+++ b/src/Speckle.Objects/BuiltElements/Beam.cs
@@ -5,7 +5,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements;
 
-public class Beam : Base, IDisplayValue<IReadOnlyList<Base>>
+public class Beam : Base, IDisplayValue<IReadOnlyList<IBasicGeometryType>>
 {
   public Beam() { }
 
@@ -14,7 +14,24 @@ public class Beam : Base, IDisplayValue<IReadOnlyList<Base>>
     this.baseLine = baseLine;
     this.level = level;
     this.units = units;
-    this.displayValue = ((IReadOnlyList<Base>?)displayValue) ?? new[] { (Base)baseLine };
+    IReadOnlyList<IBasicGeometryType>? calculatedDisplayValue = displayValue;
+    if (displayValue is null)
+    {
+      switch (baseLine)
+      {
+        case Line l:
+          calculatedDisplayValue = new[] { l };
+          break;
+        case Curve c:
+          calculatedDisplayValue = c.displayValue;
+          break;
+      }
+    }
+
+    if (calculatedDisplayValue is not null)
+    {
+      this.displayValue = calculatedDisplayValue;
+    }
   }
 
   public ICurve baseLine { get; set; }
@@ -24,7 +41,7 @@ public class Beam : Base, IDisplayValue<IReadOnlyList<Base>>
   public string? units { get; set; }
 
   [DetachProperty]
-  public IReadOnlyList<Base> displayValue { get; set; }
+  public IReadOnlyList<IBasicGeometryType> displayValue { get; set; }
 
   #region Schema Info Constructors
   [SchemaInfo("Beam", "Creates a Speckle beam", "BIM", "Structure")]

--- a/src/Speckle.Objects/BuiltElements/Brace.cs
+++ b/src/Speckle.Objects/BuiltElements/Brace.cs
@@ -5,7 +5,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements;
 
-public class Brace : Base, IDisplayValue<IReadOnlyList<Base>>
+public class Brace : Base, IDisplayValue<IReadOnlyList<IBasicGeometryType>>
 {
   public Brace() { }
 
@@ -13,7 +13,24 @@ public class Brace : Base, IDisplayValue<IReadOnlyList<Base>>
   {
     this.baseLine = baseLine;
     this.units = units;
-    this.displayValue = ((IReadOnlyList<Base>?)displayValue) ?? new[] { (Base)baseLine };
+    IReadOnlyList<IBasicGeometryType>? calculatedDisplayValue = displayValue;
+    if (displayValue is null)
+    {
+      switch (baseLine)
+      {
+        case Line l:
+          calculatedDisplayValue = new[] { l };
+          break;
+        case Curve c:
+          calculatedDisplayValue = c.displayValue;
+          break;
+      }
+    }
+
+    if (calculatedDisplayValue is not null)
+    {
+      this.displayValue = calculatedDisplayValue;
+    }
   }
 
   public ICurve baseLine { get; set; }
@@ -21,7 +38,7 @@ public class Brace : Base, IDisplayValue<IReadOnlyList<Base>>
   public string? units { get; set; }
 
   [DetachProperty]
-  public IReadOnlyList<Base> displayValue { get; set; }
+  public IReadOnlyList<IBasicGeometryType> displayValue { get; set; }
 
   [SchemaInfo("Brace", "Creates a Speckle brace", "BIM", "Structure")]
   public Brace([SchemaMainParam] ICurve baseLine)

--- a/src/Speckle.Objects/BuiltElements/Column.cs
+++ b/src/Speckle.Objects/BuiltElements/Column.cs
@@ -6,7 +6,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements;
 
-public class Column : Base, IDisplayValue<IReadOnlyList<Base>>
+public class Column : Base, IDisplayValue<IReadOnlyList<IBasicGeometryType>>
 {
   public Column() { }
 
@@ -15,7 +15,24 @@ public class Column : Base, IDisplayValue<IReadOnlyList<Base>>
     this.baseLine = baseLine;
     this.units = units;
     this.level = level;
-    this.displayValue = ((IReadOnlyList<Base>?)displayValue) ?? new[] { (Base)baseLine };
+    IReadOnlyList<IBasicGeometryType>? calculatedDisplayValue = displayValue;
+    if (displayValue is null)
+    {
+      switch (baseLine)
+      {
+        case Line l:
+          calculatedDisplayValue = new[] { l };
+          break;
+        case Curve c:
+          calculatedDisplayValue = c.displayValue;
+          break;
+      }
+    }
+
+    if (calculatedDisplayValue is not null)
+    {
+      this.displayValue = calculatedDisplayValue;
+    }
   }
 
   public ICurve baseLine { get; set; }
@@ -25,7 +42,7 @@ public class Column : Base, IDisplayValue<IReadOnlyList<Base>>
   public string? units { get; set; }
 
   [DetachProperty]
-  public IReadOnlyList<Base> displayValue { get; set; }
+  public IReadOnlyList<IBasicGeometryType> displayValue { get; set; }
 
   #region Schema Info Constructors
 

--- a/src/Speckle.Objects/BuiltElements/Duct.cs
+++ b/src/Speckle.Objects/BuiltElements/Duct.cs
@@ -7,7 +7,7 @@ using Speckle.Newtonsoft.Json;
 
 namespace Objects.BuiltElements;
 
-public class Duct : Base, IDisplayValue<IReadOnlyList<Base>>
+public class Duct : Base, IDisplayValue<IReadOnlyList<IBasicGeometryType>>
 {
   public Duct() { }
 
@@ -29,7 +29,24 @@ public class Duct : Base, IDisplayValue<IReadOnlyList<Base>>
     this.length = length;
     this.units = units;
     this.velocity = velocity;
-    this.displayValue = ((IReadOnlyList<Base>?)displayValue) ?? new[] { (Base)baseCurve };
+    IReadOnlyList<IBasicGeometryType>? calculatedDisplayValue = displayValue;
+    if (displayValue is null)
+    {
+      switch (baseCurve)
+      {
+        case Line l:
+          calculatedDisplayValue = new[] { l };
+          break;
+        case Curve c:
+          calculatedDisplayValue = c.displayValue;
+          break;
+      }
+    }
+
+    if (calculatedDisplayValue is not null)
+    {
+      this.displayValue = calculatedDisplayValue;
+    }
   }
 
   [JsonIgnore, Obsolete("Replaced with baseCurve property")]
@@ -45,7 +62,7 @@ public class Duct : Base, IDisplayValue<IReadOnlyList<Base>>
   public string? units { get; set; }
 
   [DetachProperty]
-  public IReadOnlyList<Base> displayValue { get; set; }
+  public IReadOnlyList<IBasicGeometryType> displayValue { get; set; }
 
   #region Schema Info Constructors
   /// <summary>

--- a/src/Speckle.Objects/BuiltElements/GridLine.cs
+++ b/src/Speckle.Objects/BuiltElements/GridLine.cs
@@ -4,7 +4,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements;
 
-public class GridLine : Base, IDisplayValue<List<Base>>
+public class GridLine : Base, IDisplayValue<IEnumerable<IBasicGeometryType>>
 {
   public GridLine() { }
 
@@ -32,5 +32,5 @@ public class GridLine : Base, IDisplayValue<List<Base>>
   public string units { get; set; }
 
   [DetachProperty]
-  public List<Base> displayValue { get; set; }
+  public IEnumerable<IBasicGeometryType> displayValue { get; set; }
 }

--- a/src/Speckle.Objects/BuiltElements/Profile.cs
+++ b/src/Speckle.Objects/BuiltElements/Profile.cs
@@ -4,7 +4,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements;
 
-public class Profile : Base, IDisplayValue<Polyline>
+public class Profile : Base, IDisplayValue<List<Polyline>>
 {
   public List<ICurve> curves { get; set; }
 
@@ -17,5 +17,5 @@ public class Profile : Base, IDisplayValue<Polyline>
   public string units { get; set; }
 
   [DetachProperty]
-  public Polyline displayValue { get; set; }
+  public List<Polyline> displayValue { get; set; }
 }

--- a/src/Speckle.Objects/BuiltElements/Rebar.cs
+++ b/src/Speckle.Objects/BuiltElements/Rebar.cs
@@ -11,7 +11,7 @@ namespace Objects.BuiltElements;
 /// <remarks>
 /// This class is not suitable for freeform rebar, which can have multiple shapes.
 /// </remarks>
-public class RebarGroup<T> : Base, IHasVolume, IDisplayValue<List<ICurve>>
+public class RebarGroup<T> : Base, IHasVolume, IDisplayValue<List<Line>>
   where T : RebarShape
 {
   public RebarGroup() { }
@@ -68,7 +68,7 @@ public class RebarGroup<T> : Base, IHasVolume, IDisplayValue<List<ICurve>>
   /// The display representation of the rebar group as centerline curves
   /// </summary>
   [DetachProperty]
-  public List<ICurve> displayValue { get; set; }
+  public List<Line> displayValue { get; set; }
 
   /// <summary>
   /// The total volume of the rebar group.

--- a/src/Speckle.Objects/BuiltElements/Revit/DirectShape.cs
+++ b/src/Speckle.Objects/BuiltElements/Revit/DirectShape.cs
@@ -6,7 +6,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements.Revit;
 
-public class DirectShape : Base, IDisplayValue<List<Base>>
+public class DirectShape : Base, IDisplayValue<List<IBasicGeometryType>>
 {
   public DirectShape() { }
 
@@ -52,7 +52,7 @@ public class DirectShape : Base, IDisplayValue<List<Base>>
   public string units { get; set; }
 
   [DetachProperty]
-  public List<Base> displayValue { get; set; }
+  public List<IBasicGeometryType> displayValue { get; set; }
 
   public bool IsValidObject(Base @base)
   {

--- a/src/Speckle.Objects/BuiltElements/Revit/FreeformElement.cs
+++ b/src/Speckle.Objects/BuiltElements/Revit/FreeformElement.cs
@@ -9,7 +9,7 @@ using Speckle.Newtonsoft.Json;
 
 namespace Objects.BuiltElements.Revit;
 
-public class FreeformElement : Base, IDisplayValue<List<Base>>
+public class FreeformElement : Base, IDisplayValue<List<Mesh>>
 {
   public FreeformElement() { }
 
@@ -74,7 +74,7 @@ public class FreeformElement : Base, IDisplayValue<List<Base>>
   public string units { get; set; }
 
   [DetachProperty]
-  public List<Base> displayValue { get; set; }
+  public List<Mesh> displayValue { get; set; }
 
   public bool IsValid()
   {

--- a/src/Speckle.Objects/BuiltElements/Wall.cs
+++ b/src/Speckle.Objects/BuiltElements/Wall.cs
@@ -5,7 +5,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements;
 
-public class Wall : Base, IDisplayValue<IReadOnlyList<Base>>
+public class Wall : Base, IDisplayValue<IReadOnlyList<IBasicGeometryType>>
 {
   public Wall() { }
 
@@ -22,7 +22,25 @@ public class Wall : Base, IDisplayValue<IReadOnlyList<Base>>
     this.units = units;
     this.baseLine = baseLine;
     this.level = level;
-    this.displayValue = ((IReadOnlyList<Base>?)displayValue) ?? new[] { (Base)baseLine };
+    IReadOnlyList<IBasicGeometryType>? calculatedDisplayValue = displayValue;
+    if (displayValue is null)
+    {
+      switch (baseLine)
+      {
+        case Line l:
+          calculatedDisplayValue = new[] { l };
+          break;
+        case Curve c:
+          calculatedDisplayValue = c.displayValue;
+          break;
+      }
+    }
+
+    if (calculatedDisplayValue is not null)
+    {
+      this.displayValue = calculatedDisplayValue;
+    }
+
     this.elements = elements;
   }
 
@@ -36,7 +54,7 @@ public class Wall : Base, IDisplayValue<IReadOnlyList<Base>>
   public List<Base>? elements { get; set; }
 
   [DetachProperty]
-  public IReadOnlyList<Base> displayValue { get; set; }
+  public IReadOnlyList<IBasicGeometryType> displayValue { get; set; }
 
   #region SchemaInfo Ctors
 

--- a/src/Speckle.Objects/Geometry/Curve.cs
+++ b/src/Speckle.Objects/Geometry/Curve.cs
@@ -9,7 +9,7 @@ using Speckle.Core.Models;
 
 namespace Objects.Geometry;
 
-public class Curve : Base, ICurve, IHasBoundingBox, IHasArea, ITransformable<Curve>, IDisplayValue<Polyline>
+public class Curve : Base, ICurve, IHasBoundingBox, IHasArea, ITransformable<Curve>, IDisplayValue<List<Polyline>>
 {
   /// <summary>
   /// Constructs an empty <see cref="Curve"/> instance.
@@ -24,7 +24,7 @@ public class Curve : Base, ICurve, IHasBoundingBox, IHasArea, ITransformable<Cur
   /// <param name="applicationId">The unique ID of this curve in a specific application</param>
   public Curve(Polyline poly, string units = Units.Meters, string? applicationId = null)
   {
-    displayValue = poly;
+    displayValue = new() { poly };
     this.applicationId = applicationId;
     this.units = units;
   }
@@ -68,7 +68,7 @@ public class Curve : Base, ICurve, IHasBoundingBox, IHasArea, ITransformable<Cur
 
   /// <inheritdoc/>
   [DetachProperty]
-  public Polyline displayValue { get; set; }
+  public List<Polyline> displayValue { get; set; }
 
   /// <inheritdoc/>
   public double area { get; set; }
@@ -86,8 +86,15 @@ public class Curve : Base, ICurve, IHasBoundingBox, IHasArea, ITransformable<Cur
       point.TransformTo(transform, out Point transformedPoint);
       transformedPoints.Add(transformedPoint);
     }
+    List<Polyline> transformedDisplay = new();
+    bool result = true;
+    foreach (Polyline poly in displayValue)
+    {
+      bool polyResult = poly.TransformTo(transform, out ITransformable transformedPoly);
+      transformedDisplay.Add((Polyline)transformedPoly);
+      result = false ? false : polyResult;
+    }
 
-    var result = displayValue.TransformTo(transform, out ITransformable polyline);
     transformed = new Curve
     {
       degree = degree,
@@ -96,7 +103,7 @@ public class Curve : Base, ICurve, IHasBoundingBox, IHasArea, ITransformable<Cur
       points = transformedPoints.SelectMany(o => o.ToList()).ToList(),
       weights = weights,
       knots = knots,
-      displayValue = (Polyline)polyline,
+      displayValue = transformedDisplay,
       closed = closed,
       units = units,
       applicationId = applicationId,

--- a/src/Speckle.Objects/Geometry/Line.cs
+++ b/src/Speckle.Objects/Geometry/Line.cs
@@ -10,7 +10,7 @@ using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry;
 
-public class Line : Base, ICurve, IHasBoundingBox, ITransformable<Line>
+public class Line : Base, ICurve, IHasBoundingBox, ITransformable<Line>, IBasicGeometryType
 {
   public Line() { }
 

--- a/src/Speckle.Objects/Geometry/Mesh.cs
+++ b/src/Speckle.Objects/Geometry/Mesh.cs
@@ -9,7 +9,7 @@ using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry;
 
-public class Mesh : Base, IHasBoundingBox, IHasVolume, IHasArea, ITransformable<Mesh>
+public class Mesh : Base, IHasBoundingBox, IHasVolume, IHasArea, ITransformable<Mesh>, IBasicGeometryType
 {
   public Mesh() { }
 

--- a/src/Speckle.Objects/Geometry/Polyline.cs
+++ b/src/Speckle.Objects/Geometry/Polyline.cs
@@ -13,7 +13,7 @@ namespace Objects.Geometry;
 /// <summary>
 /// A polyline curve, defined by a set of vertices.
 /// </summary>
-public class Polyline : Base, ICurve, IHasArea, IHasBoundingBox, IConvertible, ITransformable
+public class Polyline : Base, ICurve, IHasArea, IHasBoundingBox, IConvertible, ITransformable, IBasicGeometryType
 {
   /// <summary>
   /// Constructs an empty <see cref="Polyline"/>

--- a/src/Speckle.Objects/Geometry/Spiral.cs
+++ b/src/Speckle.Objects/Geometry/Spiral.cs
@@ -17,7 +17,7 @@ public enum SpiralType
   Unknown
 }
 
-public class Spiral : Base, ICurve, IHasBoundingBox, IDisplayValue<Polyline>
+public class Spiral : Base, ICurve, IHasBoundingBox, IDisplayValue<List<Polyline>>
 {
   public Point startPoint { get; set; }
   public Point endPoint { get; set; }
@@ -34,7 +34,7 @@ public class Spiral : Base, ICurve, IHasBoundingBox, IDisplayValue<Polyline>
   public Interval domain { get; set; }
 
   [DetachProperty]
-  public Polyline displayValue { get; set; }
+  public List<Polyline> displayValue { get; set; }
 
   public Box bbox { get; set; }
 }

--- a/src/Speckle.Objects/Interfaces.cs
+++ b/src/Speckle.Objects/Interfaces.cs
@@ -85,6 +85,11 @@ public interface ITransformable
   bool TransformTo(Transform transform, out ITransformable transformed);
 }
 
+/// <summary>
+/// Indicates when a geometry is considered a basic type, to be used for displayvalues
+/// </summary>
+public interface IBasicGeometryType { }
+
 #endregion
 
 #region Built elements
@@ -100,13 +105,14 @@ public interface ITransformable
 /// </example>
 /// <typeparam name="T">
 /// Type of display value.
-/// Expected to be either a <see cref="Base"/> type or a <see cref="List{T}"/> of <see cref="Base"/>s,
+/// Expected to be either a <see cref="IBasicGeometryType"/> type or a <see cref="List{T}"/> of <see cref="IBasicGeometryType"/>s,
 /// most likely <see cref="Mesh"/> or <see cref="Polyline"/>.
 /// </typeparam>
 public interface IDisplayValue<out T>
+  where T : IEnumerable<IBasicGeometryType>
 {
   /// <summary>
-  /// <see cref="displayValue"/> <see cref="Base"/>(s) will be used to display this <see cref="Base"/>
+  /// <see cref="displayValue"/> <see cref="IBasicGeometryType"/>(s) will be used to display this <see cref="Base"/>
   /// if a native displayable object cannot be converted.
   /// </summary>
   T displayValue { get; }

--- a/src/Speckle.Objects/Other/Dimension.cs
+++ b/src/Speckle.Objects/Other/Dimension.cs
@@ -7,7 +7,7 @@ namespace Objects.Other;
 /// <summary>
 /// Dimension class
 /// </summary>
-public class Dimension : Base, IDisplayValue<List<ICurve>>
+public class Dimension : Base, IDisplayValue<List<Polyline>>
 {
   /// <summary>
   /// The measurement of the dimension.
@@ -39,7 +39,7 @@ public class Dimension : Base, IDisplayValue<List<ICurve>>
   /// <summary>
   /// Curves representing the annotation
   /// </summary>
-  public List<ICurve> displayValue { get; set; } = new();
+  public List<Polyline> displayValue { get; set; } = new();
 }
 
 /// <summary>

--- a/src/Speckle.Objects/Structural/Geometry/Element1D.cs
+++ b/src/Speckle.Objects/Structural/Geometry/Element1D.cs
@@ -6,7 +6,7 @@ using Speckle.Core.Models;
 
 namespace Objects.Structural.Geometry;
 
-public class Element1D : Base, IDisplayValue<IReadOnlyList<Base>>
+public class Element1D : Base, IDisplayValue<IReadOnlyList<IBasicGeometryType>>
 {
   public Element1D() { }
 
@@ -38,7 +38,16 @@ public class Element1D : Base, IDisplayValue<IReadOnlyList<Base>>
     this.localAxis = localAxis;
     this.orientationNode = orientationNode;
     this.orientationAngle = orientationAngle;
-    this.displayValue = ((IReadOnlyList<Base>?)displayValue) ?? new[] { (Base)baseLine };
+    IReadOnlyList<IBasicGeometryType>? calculatedDisplayValue = displayValue;
+    if (displayValue is null)
+    {
+      calculatedDisplayValue = new[] { baseLine };
+    }
+
+    if (calculatedDisplayValue is not null)
+    {
+      this.displayValue = calculatedDisplayValue;
+    }
   }
 
   public string? name { get; set; } //add unique id as base identifier, name can change too easily
@@ -71,7 +80,7 @@ public class Element1D : Base, IDisplayValue<IReadOnlyList<Base>>
   public string? units { get; set; }
 
   [DetachProperty]
-  public IReadOnlyList<Base> displayValue { get; set; }
+  public IReadOnlyList<IBasicGeometryType> displayValue { get; set; }
 
   #region Schema Info Constructors
   [SchemaInfo(


### PR DESCRIPTION
Do not merge - record of Interfacing work done to constrain fallback displayvalue types

Key points:
- New `IBasicGeometryType` interface implemented by `Point`, `Line`, `Polyline`, `Mesh`
- `IDisplayValue` updated to only accept `IEnumerable<IBasicGeometryType>`
- POC updating classes to new display values - breaking change here for eg classes that were previously not `List`

Blocking:
- probably will want to remove structural classes, and GH constructors before making this change
- discuss `IBase` first