### PR TITLE
chore(tests): introduce toxiproxy to integration tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,27 @@ services:
       POSTGRES_DB: "speckle"
       ENABLE_MP: "false"
 
+  ####
+  # Testing and development tools
+  #######
+
+  toxiproxy:
+    ###
+    # Toxiproxy is a tool to simulate network conditions https://github.com/Shopify/toxiproxy
+    # Instead of connecting to speckle-server on port 3000, connect to ToxiProxy on port 3001
+    # Toxiproxy will forward the connection to speckle-server
+    # Use the ToxiProxy API to simulate network conditions as necessary
+    ###
+    image: ghcr.io/shopify/toxiproxy:2.9.0
+    command: |
+      toxiproxy-cli -config /config/toxiproxy.json
+    volumes:
+      - ./toxiproxy.json:/config/toxiproxy.json
+    ports:
+      # open ports need to match the 'listen' ports in the toxiproxy.json file
+       - "0.0.0.0:3001:3001" # Speckle server
+
+
 networks:
   default:
     name: speckle-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       retries: 3
       start_period: 90s
     ports:
-      - "0.0.0.0:3000:3000"
+      - "3000:3000"
     depends_on:
       postgres:
         condition: service_healthy
@@ -116,13 +116,17 @@ services:
     # Use the ToxiProxy API to simulate network conditions as necessary
     ###
     image: ghcr.io/shopify/toxiproxy:2.9.0
-    command: |
-      toxiproxy-cli -config /config/toxiproxy.json
     volumes:
+      # This mounts the toxiproxy.json file into the container at /config/toxiproxy.json
       - ./toxiproxy.json:/config/toxiproxy.json
+    # This command starts toxiproxy with the configuration file
+    entrypoint: /toxiproxy -config /config/toxiproxy.json
     ports:
-      # open ports need to match the 'listen' ports in the toxiproxy.json file
-       - "0.0.0.0:3001:3001" # Speckle server
+      # open ports to match the 'listen' ports in the toxiproxy.json file
+      - 8474:8474 # Toxiproxy API
+      - 3001:3001 # Speckle server
+    environment:
+      - LOG_LEVEL=trace
 
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       retries: 3
       start_period: 90s
     ports:
-      - "3000:3000"
+      - "0.0.0.0:3000:3000"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,9 +125,6 @@ services:
       # open ports to match the 'listen' ports in the toxiproxy.json file
       - 8474:8474 # Toxiproxy API
       - 3001:3001 # Speckle server
-    environment:
-      - LOG_LEVEL=trace
-
 
 networks:
   default:

--- a/tests/Speckle.Core.Tests.Integration/Credentials/UserServerInfoTests.cs
+++ b/tests/Speckle.Core.Tests.Integration/Credentials/UserServerInfoTests.cs
@@ -33,8 +33,8 @@ public class UserServerInfoTests
   }
 
   /// <remarks>
-  /// We get ServerInfo from "http://localhost:3000/graphql",
-  /// Then we mutate the `frontend2` property of ServerInfo by trying to fetch header from "http://localhost:3000/",
+  /// We get ServerInfo from "http://localhost:3001/graphql",
+  /// Then we mutate the `frontend2` property of ServerInfo by trying to fetch header from "http://localhost:3001/",
   /// This is not doable in local server because there is no end-point on this to ping.
   /// This is a bad sign for mutation.
   /// </remarks>

--- a/tests/Speckle.Core.Tests.Integration/Fixtures.cs
+++ b/tests/Speckle.Core.Tests.Integration/Fixtures.cs
@@ -32,7 +32,7 @@ public class SetUp
 
 public static class Fixtures
 {
-  public static readonly ServerInfo Server = new() { url = "http://localhost:3000", name = "Docker Server" };
+  public static readonly ServerInfo Server = new() { url = "http://localhost:3001", name = "Docker Server" };
 
   public static Client Unauthed => new Client(new Account { serverInfo = Server, userInfo = new UserInfo() });
 

--- a/toxiproxy.json
+++ b/toxiproxy.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "speckle_test_speckle-server",
-    "listen": "localhost:3001",
+    "listen": "0.0.0.0:3001",
     "upstream": "speckle-server:3000",
     "enabled": true
   }

--- a/toxiproxy.json
+++ b/toxiproxy.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "speckle_test_speckle-server",
+    "listen": "localhost:3001",
+    "upstream": "speckle-server:3000",
+    "enabled": true
+  }
+]


### PR DESCRIPTION
This PR introduces ToxiProxy to Docker Compose file for use in integration tests.

ToxiProxy can be used to simulate failures in a network.

The proxy can be controlled from tests by using the [SDK for .Net](https://github.com/mdevilliers/Toxiproxy.Net)

```
using (var connection = new Connection(true)) //this will ensure all proxies & toxics are reset on dispose.
{
  var client = connection.Client();
  var proxy = client.FindProxy("speckle_test_speckle-server");

  // do stuff with the proxy by adding toxics: e.g. latency, returning error status codes, or dropping the connection. In this example, causing a timeout.
  var timeoutProxy = new TimeoutToxic();
  timeoutProxy.Attributes.Timeout = 100;
  timeoutProxy.Toxicity = 1.0;
  proxy.Add(timeoutProxy);

  // then apply the changes
  proxy.Update();
  
  //now run your tests and experience timeout problems connecting to speckle server
}
```