### PR TITLE
Removed total children count

### DIFF
--- a/src/Speckle.Core/Models/Base.cs
+++ b/src/Speckle.Core/Models/Base.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using Speckle.Core.Api;
 using Speckle.Core.Common;
 using Speckle.Core.Helpers;
 using Speckle.Core.Kits;
@@ -39,12 +38,6 @@ public class Base : DynamicBase
   public virtual string id { get; set; }
 
 #nullable enable //Starting nullability syntax here so that `id` null oblivious,
-
-  /// <summary>
-  /// This property will only be populated if the object is retreieved from storage. Use <see cref="GetTotalChildrenCount"/> otherwise.
-  /// </summary>
-  [SchemaIgnore]
-  public virtual long totalChildrenCount { get; set; }
 
   /// <summary>
   /// Secondary, ideally host application driven, object identifier.


### PR DESCRIPTION
`totalChildrenCount`  was unused, and only ever being set from the specklepy SDK.

Lets remove it since its not reliable, and we already have a reliable way to get children count, the __closure table length.