### PR TITLE
add initial log statement and fix log path

### DIFF
--- a/src/Speckle.Sdk.Logging/LogBuilder.cs
+++ b/src/Speckle.Sdk.Logging/LogBuilder.cs
@@ -50,7 +50,7 @@ public static class LogBuilder
     if (speckleLogging?.File is not null)
     {
       // TODO: check if we have write permissions to the file.
-      var logFilePath = SpecklePathProvider.LogFolderPath(applicationAndVersion, slug);
+      var logFilePath = SpecklePathProvider.LogFolderPath(applicationAndVersion);
       logFilePath = Path.Combine(logFilePath, speckleLogging.File.Path ?? "SpeckleCoreLog.txt");
       serilogLogConfiguration = serilogLogConfiguration.WriteTo.File(
         logFilePath,
@@ -71,6 +71,13 @@ public static class LogBuilder
     var logger = serilogLogConfiguration.CreateLogger();
     Log.Logger = logger;
 
+    logger
+      .ForContext("hostApplication", applicationAndVersion)
+      .ForContext("userApplicationDataPath", SpecklePathProvider.UserApplicationDataPath())
+      .ForContext("installApplicationDataPath", SpecklePathProvider.InstallApplicationDataPath)
+      .Information(
+        "Initialized logger inside {hostApplication}/{productVersion}/{version} for user {id}. Path info {userApplicationDataPath} {installApplicationDataPath}."
+      );
     return InitializeOtelTracing(speckleTracing, resourceBuilder);
   }
 

--- a/src/Speckle.Sdk.Logging/Path.cs
+++ b/src/Speckle.Sdk.Logging/Path.cs
@@ -150,23 +150,13 @@ public static class SpecklePathProvider
     return EnsureFolderExists(path ?? UserSpeckleFolderPath, s_blobFolderName);
   }
 
-  private static string EnsureFolderExists(string basePath, string folderName)
+  private static string EnsureFolderExists(params string[] folderName)
   {
-    var path = System.IO.Path.Combine(basePath, folderName);
+    var path = System.IO.Path.Combine(folderName);
     Directory.CreateDirectory(path);
     return path;
   }
 
-  /// <summary>
-  /// Get the folder where the Speckle logs should be stored.
-  /// </summary>
-  /// <param name="hostApplicationName">Name of the application using this SDK ie.: "Rhino"</param>
-  /// <param name="hostApplicationVersion">Public version slug of the application using this SDK ie.: "2023"</param>
-  public static string LogFolderPath(string hostApplicationName, string? hostApplicationVersion)
-  {
-    return EnsureFolderExists(
-      EnsureFolderExists(UserSpeckleFolderPath, LOG_FOLDER_NAME),
-      $"{hostApplicationName}{hostApplicationVersion ?? ""}"
-    );
-  }
+  internal static string LogFolderPath(string applicationAndVersion) =>
+    EnsureFolderExists(UserSpeckleFolderPath, LOG_FOLDER_NAME, applicationAndVersion);
 }


### PR DESCRIPTION
For https://linear.app/speckle/issue/CXPLA-31/v3-connector-slugs-are-misaligned-with-v2 and https://linear.app/speckle/issue/CXPLA-32/add-initial-log-call-for-global-context