### PR TITLE
Don't use Serilog global static logger in v3

### DIFF
--- a/src/Speckle.Sdk.Logging/LogBuilder.cs
+++ b/src/Speckle.Sdk.Logging/LogBuilder.cs
@@ -69,7 +69,7 @@ public static class LogBuilder
       serilogLogConfiguration = InitializeOtelLogging(serilogLogConfiguration, speckleLogging.Otel, resourceBuilder);
     }
     var logger = serilogLogConfiguration.CreateLogger();
-    Log.Logger = logger;
+    SpeckleLog.SpeckleLogger = logger;
 
     logger
       .ForContext("hostApplication", applicationAndVersion)

--- a/src/Speckle.Sdk.Logging/SpeckleLog.cs
+++ b/src/Speckle.Sdk.Logging/SpeckleLog.cs
@@ -4,7 +4,7 @@ namespace Speckle.Sdk.Logging;
 
 public static class SpeckleLog
 {
-  public static Serilog.ILogger SpeckleLogger { get; set; } = Serilog.Core.Logger.None;
+  internal static Serilog.ILogger SpeckleLogger { get; set; } = Serilog.Core.Logger.None;
   public static ISpeckleLogger Logger => new SpeckleLogger(SpeckleLogger);
 
   public static ISpeckleLogger Create(string name) =>

--- a/src/Speckle.Sdk.Logging/SpeckleLog.cs
+++ b/src/Speckle.Sdk.Logging/SpeckleLog.cs
@@ -1,12 +1,12 @@
-using Serilog;
 using Serilog.Core;
 
 namespace Speckle.Sdk.Logging;
 
 public static class SpeckleLog
 {
-  public static ISpeckleLogger Logger => new SpeckleLogger(Serilog.Log.Logger);
+  public static Serilog.ILogger SpeckleLogger { get; set; } = Serilog.Core.Logger.None;
+  public static ISpeckleLogger Logger => new SpeckleLogger(SpeckleLogger);
 
   public static ISpeckleLogger Create(string name) =>
-    new SpeckleLogger(Log.Logger.ForContext(Constants.SourceContextPropertyName, name));
+    new SpeckleLogger(SpeckleLogger.ForContext(Constants.SourceContextPropertyName, name));
 }


### PR DESCRIPTION
Remove usage of Serilog static logger.  By default it's the same null logger for serilog