### PR TITLE
Sha256 hash with spans

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,7 +7,7 @@
             CS0618;CA1034;CA2201;CA1051;CA1040;CA1724;
             IDE0044;IDE0130;CA1508;
             <!-- Analysers that provide no tangeable value to a test project -->
-            CA5394;CA2007;CA1852;CA1819;CA1711;CA1063;CA1816;CA2234;CS8618;CA1054;CA1810;CA2208;CA1019;
+            CA5394;CA2007;CA1852;CA1819;CA1711;CA1063;CA1816;CA2234;CS8618;CA1054;CA1810;CA2208;CA1019;CA1831;
         </NoWarn>
         <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
     </PropertyGroup>

--- a/src/Speckle.Sdk/Helpers/Crypt.cs
+++ b/src/Speckle.Sdk/Helpers/Crypt.cs
@@ -2,6 +2,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Security.Cryptography;
 using System.Text;
+#if NET6_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
 
 namespace Speckle.Sdk.Helpers;
 
@@ -19,8 +22,7 @@ public static class Crypt
     int length = SHA256.HashSizeInBytes * sizeof(char)
   )
   {
-    Span<byte> inputBytes = stackalloc byte[Encoding.UTF8.GetByteCount(input)];
-    Encoding.UTF8.GetBytes(input, inputBytes);
+    ReadOnlySpan<byte> inputBytes = MemoryMarshal.AsBytes(input);
 
     Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
     SHA256.HashData(inputBytes, hash);
@@ -49,7 +51,7 @@ public static class Crypt
     int length = 64
   )
   {
-    var inputBytes = Encoding.UTF8.GetBytes(input);
+    var inputBytes = Encoding.Unicode.GetBytes(input);
 #if NET6_0_OR_GREATER
     byte[] hash = SHA256.HashData(inputBytes);
 #else

--- a/src/Speckle.Sdk/Helpers/Crypt.cs
+++ b/src/Speckle.Sdk/Helpers/Crypt.cs
@@ -11,7 +11,7 @@ public static class Crypt
   /// <param name="input">the value to hash</param>
   /// <param name="format"><c>"x2"</c> for lower case, <c>"X2"</c> for uppercase.</param>
   /// <param name="length">Desired length of the returned string. Must be 2 &#x2264; Length &#x2264; 64, and must be a multiple of 2</param>
-  /// <returns>the hash string</returns>
+  /// <returns><inheritdoc cref="Sha256(string, string?, int)"/></returns>
   [Pure]
   public static string Sha256(
     ReadOnlySpan<char> input,
@@ -37,13 +37,17 @@ public static class Crypt
 #endif
 
   /// <param name="input">the value to hash</param>
-  /// <param name="format">NumericFormat</param>
-  /// <param name="length"></param>
+  /// <param name="format"><c>"x2"</c> for lower case, <c>"X2"</c> for uppercase.</param>
+  /// <param name="length">Desired length of the returned string</param>
   /// <returns>the hash string</returns>
   /// <exception cref="FormatException"><paramref name="format"/> is not a recognised numeric format</exception>
   /// <exception cref="ArgumentOutOfRangeException"><inheritdoc cref="StringBuilder.ToString(int, int)"/></exception>
   [Pure]
-  public static string Sha256(string input, string? format = "x2", int length = 64)
+  public static string Sha256(
+    string input,
+    [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = "x2",
+    int length = 64
+  )
   {
     var inputBytes = Encoding.UTF8.GetBytes(input);
 #if NET6_0_OR_GREATER
@@ -66,7 +70,11 @@ public static class Crypt
   /// <remarks>MD5 is a broken cryptographic algorithm and should be used subject to review see CA5351</remarks>
   [Pure]
   [SuppressMessage("Security", "CA5351:Do Not Use Broken Cryptographic Algorithms")]
-  public static string Md5(string input, string? format = "x2", int length = 32)
+  public static string Md5(
+    string input,
+    [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = "x2",
+    int length = 32
+  )
   {
     byte[] inputBytes = Encoding.ASCII.GetBytes(input.ToLowerInvariant());
 #if NETSTANDARD2_0

--- a/src/Speckle.Sdk/Helpers/Crypt.cs
+++ b/src/Speckle.Sdk/Helpers/Crypt.cs
@@ -22,7 +22,7 @@ public static class Crypt
     Encoding.UTF8.GetBytes(input, inputBytes);
 
     Span<byte> hash = stackalloc byte[32]; // SHA256 produces 32-byte hash
-    SHA256.TryHashData(inputBytes, hash, out _);
+    SHA256.HashData(inputBytes, hash);
 
     int outputLength = Math.Min(length, hash.Length - startIndex);
     Span<char> output = stackalloc char[outputLength * 2]; // Each byte is represented by two hex characters

--- a/src/Speckle.Sdk/Helpers/Crypt.cs
+++ b/src/Speckle.Sdk/Helpers/Crypt.cs
@@ -12,11 +12,14 @@ public static class Crypt
   /// <param name="startIndex"></param>
   /// <param name="length"></param>
   /// <returns>the hash string</returns>
-  /// <exception cref="FormatException"><paramref name="format"/> is not a recognised numeric format</exception>
-  /// <exception cref="ArgumentOutOfRangeException"><inheritdoc cref="StringBuilder.ToString(int, int)"/></exception>
 #if NET6_0_OR_GREATER
   [Pure]
-  public static string Sha256(ReadOnlySpan<char> input, string? format = "x2", int startIndex = 0, int length = 64)
+  public static string Sha256(
+    ReadOnlySpan<char> input,
+    [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = "x2",
+    int startIndex = 0,
+    int length = 64
+  )
   {
     Span<byte> inputBytes = stackalloc byte[Encoding.UTF8.GetByteCount(input)];
     Encoding.UTF8.GetBytes(input, inputBytes);
@@ -26,6 +29,7 @@ public static class Crypt
 
     int outputLength = Math.Min(length, hash.Length - startIndex);
     Span<char> output = stackalloc char[outputLength * 2]; // Each byte is represented by two hex characters
+
     for (int i = 0; i < outputLength; i++)
     {
       hash[startIndex + i].TryFormat(output[(i * 2)..], out _, format);
@@ -34,6 +38,8 @@ public static class Crypt
     return new string(output);
   }
 #else
+  /// <exception cref="FormatException"><paramref name="format"/> is not a recognised numeric format</exception>
+  /// <exception cref="ArgumentOutOfRangeException"><inheritdoc cref="StringBuilder.ToString(int, int)"/></exception>
   [Pure]
   public static string Sha256(string input, string? format = "x2", int startIndex = 0, int length = 64)
   {

--- a/src/Speckle.Sdk/Serialisation/SpeckleObjectSerializer.cs
+++ b/src/Speckle.Sdk/Serialisation/SpeckleObjectSerializer.cs
@@ -465,7 +465,11 @@ public class SpeckleObjectSerializer
   [Pure]
   private static string ComputeId(IReadOnlyDictionary<string, object?> obj)
   {
+#if NET6_0_OR_GREATER
+    ReadOnlySpan<char> serialized = JsonConvert.SerializeObject(obj).AsSpan();
+#else
     string serialized = JsonConvert.SerializeObject(obj);
+#endif
     string hash = Crypt.Sha256(serialized, length: HashUtility.HASH_LENGTH);
     return hash;
   }

--- a/tests/Speckle.Sdk.Tests.Performance/Benchmarks/CryptSha256Hash.cs
+++ b/tests/Speckle.Sdk.Tests.Performance/Benchmarks/CryptSha256Hash.cs
@@ -1,0 +1,31 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Speckle.Sdk.Helpers;
+
+namespace Speckle.Sdk.Tests.Performance.Benchmarks;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput)]
+public class CryptSha256Hash
+{
+  private string testData;
+
+  [GlobalSetup]
+  public void Setup()
+  {
+    var random = new Random(420);
+    testData = new string(Enumerable.Range(0, 10_000_000).Select(_ => (char)random.Next(32, 127)).ToArray());
+  }
+
+  [Benchmark]
+  public string Sha256()
+  {
+    return Crypt.Sha256(testData);
+  }
+
+  [Benchmark]
+  public string Sha256_Span()
+  {
+    return Crypt.Sha256(testData.AsSpan());
+  }
+}

--- a/tests/Speckle.Sdk.Tests.Performance/Benchmarks/GeneralDeserializerTest.cs
+++ b/tests/Speckle.Sdk.Tests.Performance/Benchmarks/GeneralDeserializerTest.cs
@@ -27,10 +27,11 @@ public class GeneralDeserializer : IDisposable
   }
 
   [Benchmark]
-  public Base RunTest()
+  public async Task<Base> RunTest()
   {
-    BaseObjectDeserializerV2 sut = new() { ReadTransport = _dataSource.Transport };
-    return sut.Deserialize(_dataSource.Transport.GetObject(_dataSource.ObjectId)!);
+    SpeckleObjectDeserializer sut = new() { ReadTransport = _dataSource.Transport };
+    string data = await _dataSource.Transport.GetObject(_dataSource.ObjectId)!;
+    return await sut.DeserializeJsonAsync(data);
   }
 
   [GlobalCleanup]

--- a/tests/Speckle.Sdk.Tests.Performance/Speckle.Sdk.Tests.Performance.csproj
+++ b/tests/Speckle.Sdk.Tests.Performance/Speckle.Sdk.Tests.Performance.csproj
@@ -10,9 +10,10 @@
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" />
-      <PackageReference Include="Speckle.Objects" VersionOverride="3.1.0-dev.109"/> <!--Latest-->
+      
+      <ProjectReference Include="..\..\src\Speckle.Objects\Speckle.Objects.csproj" />
+<!--      <PackageReference Include="Speckle.Objects" VersionOverride="3.1.0-dev.109"/> &lt;!&ndash;Latest&ndash;&gt;-->
 <!--      <PackageReference Include="Speckle.Objects" VersionOverride="3.0.0-dev.51"/> &lt;!&ndash;Pre-optimisation&ndash;&gt;-->
     </ItemGroup>
-  
   
 </Project>

--- a/tests/Speckle.Sdk.Tests.Performance/packages.lock.json
+++ b/tests/Speckle.Sdk.Tests.Performance/packages.lock.json
@@ -48,15 +48,6 @@
         "resolved": "0.9.6",
         "contentHash": "HKH7tYrYYlCK1ct483hgxERAdVdMtl7gUKW9ijWXxA1UsYR4Z+TrRHYmzZ9qmpu1NnTycSrp005NYM78GDKV1w=="
       },
-      "Speckle.Objects": {
-        "type": "Direct",
-        "requested": "[3.1.0-dev.109, )",
-        "resolved": "3.1.0-dev.109",
-        "contentHash": "RJNSq9GgPYrf3SZqnBSLxn7uwYSH7Df2WvKq1Q2itrPw+tBMHQ3mco1KpM0IyTYXEMc42qjeT/3JL9R3ZJFSvg==",
-        "dependencies": {
-          "Speckle.Sdk": "3.1.0-dev.109"
-        }
-      },
       "BenchmarkDotNet.Annotations": {
         "type": "Transitive",
         "resolved": "0.14.0",
@@ -263,28 +254,6 @@
         "resolved": "0.3.17",
         "contentHash": "FQgtCoF2HFwvzKWulAwBS5BGLlh8pgbrJtOp47jyBwh2CW16juVtacN1azOA2BqdrJXkXTNLNRMo7ZlHHiuAnA=="
       },
-      "Speckle.Sdk": {
-        "type": "Transitive",
-        "resolved": "3.1.0-dev.109",
-        "contentHash": "WXbMEyzdf2KVGC5gU5BSYHxBFFpAoDD7+qJ6L9XDNW01XoM+iB0jKmIxC3+qZwMZwdw0epLr5fXwIkVbCwyBPQ==",
-        "dependencies": {
-          "GraphQL.Client": "6.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.Data.Sqlite": "7.0.7",
-          "Polly": "7.2.3",
-          "Polly.Contrib.WaitAndRetry": "1.1.1",
-          "Polly.Extensions.Http": "3.0.0",
-          "Speckle.DoubleNumerics": "4.0.1",
-          "Speckle.Newtonsoft.Json": "13.0.2",
-          "Speckle.Sdk.Logging": "3.1.0-dev.109",
-          "System.Text.Json": "5.0.2"
-        }
-      },
-      "Speckle.Sdk.Logging": {
-        "type": "Transitive",
-        "resolved": "3.1.0-dev.109",
-        "contentHash": "4j+Bis84dCc0YoY5B5PCBq2TEMEgfTr6inbrImTmupYw1cw2k3nNcG/60h18ia0QdeF/J0Lig9gbDjK8hHXBgg=="
-      },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
         "resolved": "2.1.4",
@@ -382,6 +351,30 @@
         "type": "Transitive",
         "resolved": "4.5.4",
         "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
+      },
+      "speckle.objects": {
+        "type": "Project",
+        "dependencies": {
+          "Speckle.Sdk": "[1.0.0, )"
+        }
+      },
+      "speckle.sdk": {
+        "type": "Project",
+        "dependencies": {
+          "GraphQL.Client": "[6.0.0, )",
+          "Microsoft.CSharp": "[4.7.0, )",
+          "Microsoft.Data.Sqlite": "[7.0.7, )",
+          "Polly": "[7.2.3, )",
+          "Polly.Contrib.WaitAndRetry": "[1.1.1, )",
+          "Polly.Extensions.Http": "[3.0.0, )",
+          "Speckle.DoubleNumerics": "[4.0.1, )",
+          "Speckle.Newtonsoft.Json": "[13.0.2, )",
+          "Speckle.Sdk.Logging": "[1.0.0, )",
+          "System.Text.Json": "[5.0.2, )"
+        }
+      },
+      "speckle.sdk.logging": {
+        "type": "Project"
       },
       "GraphQL.Client": {
         "type": "CentralTransitive",

--- a/tests/Speckle.Sdk.Tests.Unit/Models/UtilitiesTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Models/UtilitiesTests.cs
@@ -35,7 +35,7 @@ public sealed class HashUtilityTests
   [Test, TestOf(nameof(Crypt.Md5))]
   public void Md5(
     [ValueSource(nameof(TestCases))] (string input, string _, string expected) testCase,
-    [Range(32, 32)] int length
+    [Range(0, 32)] int length
   )
   {
     var lower = Crypt.Md5(testCase.input, "x2", length);

--- a/tests/Speckle.Sdk.Tests.Unit/Models/UtilitiesTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Models/UtilitiesTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Collections;
+using NUnit.Framework;
 using Speckle.Sdk.Helpers;
 using Speckle.Sdk.Models;
 
@@ -7,26 +8,66 @@ namespace Speckle.Sdk.Tests.Unit.Models;
 [TestFixture(TestOf = typeof(Crypt))]
 public sealed class HashUtilityTests
 {
-  [Test]
-  [TestOf(nameof(Crypt.Md5))]
-  [TestCase("WnAbz1hCznVmDh1", "ad48ff1e60ea2369de178aaab2fa99af")]
-  [TestCase("wQKrSUzBB7FI1o6", "2424cff4a88055b149e5ff2aaf0b3131")]
-  public void Md5(string input, string expected)
+  public static IEnumerable<(string input, string sha256, string md5)> TestCases()
   {
-    var lower = Crypt.Md5(input, "x2");
-    var upper = Crypt.Md5(input, "X2");
-    Assert.That(lower, Is.EqualTo(expected.ToLower()));
-    Assert.That(upper, Is.EqualTo(expected.ToUpper()));
+    yield return (
+      "fxFB14cBcXvoENN",
+      "887db9349afa455f957a95f9dbacbb3c10697749cf4d4afc5c6398932a596fbc",
+      "d38572fdb20fe90c4871178df3f9570d"
+    );
+    yield return (
+      "tgWsOH8frdAwJT7",
+      "e486224ded0dcb1452d69d0d005a6dcbc52087f6e8c66e04803e1337a192abb4",
+      "a7eecf20d68f836f462963928cd0f1a1"
+    );
+    yield return (
+      "wQKrSUzBB7FI1o6",
+      "c8dc93bc5fcb299d8b39a66a52dd44705714859c2e8df044465088328c5e7d13",
+      "2424cff4a88055b149e5ff2aaf0b3131"
+    );
+    yield return (
+      "WnAbz1hCznVmDh1",
+      "037275ac033edfb9d4c5b3248cc71299685f04674914b7b68a7a9ff35a78aab1",
+      "ad48ff1e60ea2369de178aaab2fa99af"
+    );
   }
 
-  [TestCase("fxFB14cBcXvoENN", "887db9349afa455f957a95f9dbacbb3c10697749cf4d4afc5c6398932a596fbc")]
-  [TestCase("tgWsOH8frdAwJT7", "e486224ded0dcb1452d69d0d005a6dcbc52087f6e8c66e04803e1337a192abb4")]
-  [TestOf(nameof(Crypt.Sha256))]
-  public void Sha256(string input, string expected)
+  [Test, TestOf(nameof(Crypt.Md5))]
+  public void Md5(
+    [ValueSource(nameof(TestCases))] (string input, string _, string expected) testCase,
+    [Range(32, 32)] int length
+  )
   {
-    var lower = Crypt.Sha256(input, "x2");
-    var upper = Crypt.Sha256(input, "X2");
-    Assert.That(lower, Is.EqualTo(expected.ToLower()));
-    Assert.That(upper, Is.EqualTo(expected.ToUpper()));
+    var lower = Crypt.Md5(testCase.input, "x2", length);
+    var upper = Crypt.Md5(testCase.input, "X2", length);
+
+    Assert.That(lower, Is.EqualTo(new string(testCase.expected.ToLower()[..length])));
+    Assert.That(upper, Is.EqualTo(new string(testCase.expected.ToUpper()[..length])));
+  }
+
+  [Test, TestOf(nameof(Crypt.Sha256))]
+  public void Sha256(
+    [ValueSource(nameof(TestCases))] (string input, string expected, string _) testCase,
+    [Range(2, 64)] int length
+  )
+  {
+    var lower = Crypt.Sha256(testCase.input, "x2", length);
+    var upper = Crypt.Sha256(testCase.input, "X2", length);
+
+    Assert.That(lower, Is.EqualTo(new string(testCase.expected.ToLower()[..length])));
+    Assert.That(upper, Is.EqualTo(new string(testCase.expected.ToUpper()[..length])));
+  }
+
+  [Test, TestOf(nameof(Crypt.Sha256))]
+  public void Sha256_Span(
+    [ValueSource(nameof(TestCases))] (string input, string expected, string _) testCase,
+    [Range(2, 64, 2)] int length //Span version of the function must have multiple of 2
+  )
+  {
+    var lower64 = Crypt.Sha256(testCase.input.AsSpan(), "x2", length);
+    var upper64 = Crypt.Sha256(testCase.input.AsSpan(), "X2", length);
+
+    Assert.That(lower64, Is.EqualTo(new string(testCase.expected.ToLower()[..length])));
+    Assert.That(upper64, Is.EqualTo(new string(testCase.expected.ToUpper()[..length])));
   }
 }


### PR DESCRIPTION
Major changes:
- Added new overload of the sha256 hash function.
- Changed both sha256 hash functions to use a UTF16 encoding, rather than the existing UTF8

Both the sha256 overloads behave the same given the same payload to hash.
But due to the UTF8 -> 16 change, they will result in a different hash.

There is some extra minor gotchas with this new span based overload also. The `length` property now must be a multiple of 2 (because there are two bytes per char). This is ok for us because we only use this function with a `length = 32`.
