### PR TITLE
NET 8 can source gen Regex optimisations

### DIFF
--- a/src/Speckle.Sdk/Helpers/Constants.cs
+++ b/src/Speckle.Sdk/Helpers/Constants.cs
@@ -1,5 +1,3 @@
-using System.Text.RegularExpressions;
-
 namespace Speckle.Sdk.Helpers;
 
 public static class Constants
@@ -7,6 +5,4 @@ public static class Constants
   public const double EPS = 1e-5;
   public const double SMALL_EPS = 1e-8;
   public const double EPS_SQUARED = EPS * EPS;
-
-  public static readonly Regex ChunkPropertyNameRegex = new(@"^@\((\d*)\)"); //TODO: Experiment with compiled flag
 }

--- a/src/Speckle.Sdk/Helpers/PropNameValidator.cs
+++ b/src/Speckle.Sdk/Helpers/PropNameValidator.cs
@@ -1,0 +1,41 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Speckle.Sdk.Helpers;
+
+public static
+#if NET7_0_OR_GREATER
+partial
+#endif
+class PropNameValidator
+{
+  private const string CHUNK_PROPERTY_NAME_REGEX_STRING = @"^@\((\d*)\)";
+
+#if NET7_0_OR_GREATER
+  [GeneratedRegex(CHUNK_PROPERTY_NAME_REGEX_STRING)]
+  private static partial Regex ChunkRegex();
+
+  private static readonly Regex ChunkPropertyNameRegex = ChunkRegex();
+#else
+  private static readonly Regex ChunkPropertyNameRegex = new(CHUNK_PROPERTY_NAME_REGEX_STRING);
+#endif
+
+  public static bool IsChunkable(string propName, out int chunkSize)
+  {
+    if (ChunkPropertyNameRegex.IsMatch(propName))
+    {
+      var match = ChunkPropertyNameRegex.Match(propName);
+      var isChunkable = int.TryParse(match.Groups[^1].Value, out chunkSize);
+      return isChunkable;
+    }
+
+    chunkSize = -1;
+    return false;
+  }
+
+  public static bool IsDetached(string propName) =>
+#if NET5_0_OR_GREATER
+    propName.StartsWith('@');
+#else
+    propName.StartsWith("@");
+#endif
+}

--- a/src/Speckle.Sdk/Helpers/PropNameValidator.cs
+++ b/src/Speckle.Sdk/Helpers/PropNameValidator.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Diagnostics.Contracts;
+using System.Text.RegularExpressions;
 
 namespace Speckle.Sdk.Helpers;
 
@@ -32,6 +33,7 @@ class PropNameValidator
     return false;
   }
 
+  [Pure]
   public static bool IsDetached(string propName) =>
 #if NET5_0_OR_GREATER
     propName.StartsWith('@');

--- a/src/Speckle.Sdk/Models/Extras.cs
+++ b/src/Speckle.Sdk/Models/Extras.cs
@@ -16,5 +16,5 @@ public sealed class ObjectReference : Base
 {
   public required string referencedId { get; init; }
 
-  public Dictionary<string, int> closure { get; set; }
+  public Dictionary<string, int>? closure { get; set; }
 }


### PR DESCRIPTION
NET8 allows for compile time optimisations for Regex via source gen
I've moved the chunk regex into a `PropertyNameValidator` static class (naming is hard)
the regex is private implementation, exposed publicly through a simple `IsChunkable` function

While I was at it, I did something similar for detaching.