### PR TITLE
Add headers to outgoing http requests for Open Telemetry

### DIFF
--- a/src/Speckle.Sdk/Helpers/SpeckleHttpClientHandler.cs
+++ b/src/Speckle.Sdk/Helpers/SpeckleHttpClientHandler.cs
@@ -39,7 +39,7 @@ public sealed class SpeckleHttpClientHandler : DelegatingHandler
       context.Add("retryCount", 0);
 
       request.Headers.Add("x-request-id", context.CorrelationId.ToString());
-      activity?.InjectHeaders((k,v) => request.Headers.TryAddWithoutValidation(k,v));
+      activity?.InjectHeaders((k, v) => request.Headers.TryAddWithoutValidation(k, v));
 
       var policyResult = await _resiliencePolicy
         .ExecuteAndCaptureAsync(

--- a/src/Speckle.Sdk/Helpers/SpeckleHttpClientHandler.cs
+++ b/src/Speckle.Sdk/Helpers/SpeckleHttpClientHandler.cs
@@ -39,6 +39,7 @@ public sealed class SpeckleHttpClientHandler : DelegatingHandler
       context.Add("retryCount", 0);
 
       request.Headers.Add("x-request-id", context.CorrelationId.ToString());
+      activity?.InjectHeaders((k,v) => request.Headers.TryAddWithoutValidation(k,v));
 
       var policyResult = await _resiliencePolicy
         .ExecuteAndCaptureAsync(

--- a/src/Speckle.Sdk/Logging/ISdkActivity.cs
+++ b/src/Speckle.Sdk/Logging/ISdkActivity.cs
@@ -6,6 +6,8 @@ public interface ISdkActivity : IDisposable
   void RecordException(Exception e);
   string TraceId { get; }
   void SetStatus(SdkActivityStatusCode code);
+  
+  void InjectHeaders(Action<string, string> header);
 }
 
 public enum SdkActivityStatusCode

--- a/src/Speckle.Sdk/Logging/ISdkActivity.cs
+++ b/src/Speckle.Sdk/Logging/ISdkActivity.cs
@@ -6,7 +6,7 @@ public interface ISdkActivity : IDisposable
   void RecordException(Exception e);
   string TraceId { get; }
   void SetStatus(SdkActivityStatusCode code);
-  
+
   void InjectHeaders(Action<string, string> header);
 }
 


### PR DESCRIPTION
Fixes an issue where custom http handlers don't propagate otel as well as it might not work on legacy framework

https://github.com/dotnet/runtime/issues/31261

https://stackoverflow.com/questions/74519328/opentelemetry-net-httpclient-not-propagating-traceid