### PR TITLE
fix: Change `SpecklePathProvider` from internal to public

### DIFF
--- a/src/Speckle.Sdk/Logging/SpecklePathProvider.cs
+++ b/src/Speckle.Sdk/Logging/SpecklePathProvider.cs
@@ -5,7 +5,7 @@ namespace Speckle.Sdk.Logging;
 /// <summary>
 /// Helper class dedicated for Speckle specific Path operations.
 /// </summary>
-internal static class SpecklePathProvider
+public static class SpecklePathProvider
 {
   private const string APPLICATION_NAME = "Speckle";
 


### PR DESCRIPTION
Re-expose SpecklePathProvider to enable access from connectors.