### PR TITLE
Breaking API changes for comments API

### DIFF
--- a/src/Speckle.Sdk/Api/GraphQL/Inputs/CommentInputs.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Inputs/CommentInputs.cs
@@ -1,6 +1,8 @@
 ﻿namespace Speckle.Sdk.Api.GraphQL.Inputs;
 
-public sealed record CreateCommentInput(
+internal sealed record CommentContentInput(IReadOnlyCollection<string>? blobIds, object? doc);
+
+internal sealed record CreateCommentInput(
   CommentContentInput content,
   string projectId,
   string resourceIdString,
@@ -8,8 +10,10 @@ public sealed record CreateCommentInput(
   object? viewerState
 );
 
-public sealed record EditCommentInput(CommentContentInput content, string commentId);
+internal sealed record EditCommentInput(CommentContentInput content, string commentId, string projectId);
 
-public sealed record CreateCommentReplyInput(CommentContentInput content, string threadId);
+internal sealed record CreateCommentReplyInput(CommentContentInput content, string threadId, string projectId);
 
-public sealed record CommentContentInput(IReadOnlyCollection<string>? blobIds, object? doc);
+public sealed record MarkCommentViewedInput(string commentId, string projectId);
+
+public sealed record ArchiveCommentInput(string commentId, string projectId, bool archived = true);

--- a/src/Speckle.Sdk/Api/GraphQL/Resources/ModelResource.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Resources/ModelResource.cs
@@ -249,7 +249,7 @@ public sealed class ModelResource
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
   /// <inheritdoc cref="ISpeckleGraphQLClient.ExecuteGraphQLRequest{T}"/>
-  public async Task<bool> Delete(DeleteModelInput input, CancellationToken cancellationToken = default)
+  public async Task Delete(DeleteModelInput input, CancellationToken cancellationToken = default)
   {
     //language=graphql
     const string QUERY = """
@@ -266,7 +266,11 @@ public sealed class ModelResource
       .ExecuteGraphQLRequest<RequiredResponse<RequiredResponse<bool>>>(request, cancellationToken)
       .ConfigureAwait(false);
 
-    return res.data.data;
+    if (!res.data.data)
+    {
+      //This should never happen, the server should never return `false` without providing a reason
+      throw new InvalidOperationException("GraphQL data did not indicate success, but no GraphQL error was provided");
+    }
   }
 
   /// <param name="input"></param>

--- a/src/Speckle.Sdk/Api/GraphQL/Resources/ProjectInviteResource.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Resources/ProjectInviteResource.cs
@@ -102,7 +102,7 @@ public sealed class ProjectInviteResource
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
   /// <inheritdoc cref="ISpeckleGraphQLClient.ExecuteGraphQLRequest{T}"/>
-  public async Task<bool> Use(ProjectInviteUseInput input, CancellationToken cancellationToken = default)
+  public async Task Use(ProjectInviteUseInput input, CancellationToken cancellationToken = default)
   {
     //language=graphql
     const string QUERY = """
@@ -119,7 +119,12 @@ public sealed class ProjectInviteResource
     var response = await _client
       .ExecuteGraphQLRequest<RequiredResponse<RequiredResponse<RequiredResponse<bool>>>>(request, cancellationToken)
       .ConfigureAwait(false);
-    return response.data.data.data;
+
+    if (!response.data.data.data)
+    {
+      //This should never happen, the server should never return `false` without providing a reason
+      throw new InvalidOperationException("GraphQL data did not indicate success, but no GraphQL error was provided");
+    }
   }
 
   /// <param name="projectId"></param>

--- a/src/Speckle.Sdk/Api/GraphQL/Resources/ProjectResource.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Resources/ProjectResource.cs
@@ -257,7 +257,7 @@ public sealed class ProjectResource
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
   /// <inheritdoc cref="ISpeckleGraphQLClient.ExecuteGraphQLRequest{T}"/>
-  public async Task<bool> Delete(string projectId, CancellationToken cancellationToken = default)
+  public async Task Delete(string projectId, CancellationToken cancellationToken = default)
   {
     //language=graphql
     const string QUERY = """
@@ -272,7 +272,12 @@ public sealed class ProjectResource
     var response = await _client
       .ExecuteGraphQLRequest<RequiredResponse<RequiredResponse<bool>>>(request, cancellationToken)
       .ConfigureAwait(false);
-    return response.data.data;
+
+    if (!response.data.data)
+    {
+      //This should never happen, the server should never return `false` without providing a reason
+      throw new InvalidOperationException("GraphQL data did not indicate success, but no GraphQL error was provided");
+    }
   }
 
   /// <param name="input"></param>

--- a/src/Speckle.Sdk/Api/GraphQL/Resources/VersionResource.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Resources/VersionResource.cs
@@ -214,7 +214,7 @@ public sealed class VersionResource
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
   /// <inheritdoc cref="ISpeckleGraphQLClient.ExecuteGraphQLRequest{T}"/>
-  public async Task<bool> Delete(DeleteVersionsInput input, CancellationToken cancellationToken = default)
+  public async Task Delete(DeleteVersionsInput input, CancellationToken cancellationToken = default)
   {
     //language=graphql
     const string QUERY = """
@@ -230,14 +230,18 @@ public sealed class VersionResource
       .ExecuteGraphQLRequest<RequiredResponse<RequiredResponse<bool>>>(request, cancellationToken)
       .ConfigureAwait(false);
 
-    return response.data.data;
+    if (!response.data.data)
+    {
+      //This should never happen, the server should never return `false` without providing a reason
+      throw new InvalidOperationException("GraphQL data did not indicate success, but no GraphQL error was provided");
+    }
   }
 
   /// <param name="input"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
   /// <inheritdoc cref="ISpeckleGraphQLClient.ExecuteGraphQLRequest{T}"/>
-  public async Task<bool> Received(MarkReceivedVersionInput input, CancellationToken cancellationToken = default)
+  public async Task Received(MarkReceivedVersionInput input, CancellationToken cancellationToken = default)
   {
     //language=graphql
     const string QUERY = """
@@ -253,7 +257,11 @@ public sealed class VersionResource
       .ExecuteGraphQLRequest<RequiredResponse<RequiredResponse<bool>>>(request, cancellationToken)
       .ConfigureAwait(false);
 
-    return response.data.data;
+    if (!response.data.data)
+    {
+      //This should never happen, the server should never return `false` without providing a reason
+      throw new InvalidOperationException("GraphQL data did not indicate success, but no GraphQL error was provided");
+    }
   }
 
   [Obsolete("modelId is no longer required, use the overload that doesn't specify a model id", true)]

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/CommentResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/CommentResourceTests.cs
@@ -26,6 +26,14 @@ public class CommentResourceTests
   }
 
   [Test]
+  public async Task Get()
+  {
+    var comment = await Sut.Get(_comment.id, _project.id);
+    Assert.That(comment.id, Is.EqualTo(_comment.id));
+    Assert.That(comment.authorId, Is.EqualTo(_testUser.Account.userInfo.id));
+  }
+
+  [Test]
   public async Task GetProjectComments()
   {
     var comments = await Sut.GetProjectComments(_project.id);
@@ -46,20 +54,22 @@ public class CommentResourceTests
   [Test]
   public async Task MarkViewed()
   {
-    var viewed = await Sut.MarkViewed(_comment.id);
-    Assert.That(viewed, Is.True);
-    viewed = await Sut.MarkViewed(_comment.id);
-    Assert.That(viewed, Is.True);
+    await Sut.MarkViewed(new(_comment.id, _project.id));
+    var res = await Sut.Get(_comment.id, _project.id);
+
+    Assert.That(res.viewedAt, Is.Not.Null);
   }
 
   [Test]
   public async Task Archive()
   {
-    var archived = await Sut.Archive(_comment.id);
-    Assert.That(archived, Is.True);
+    await Sut.Archive(new(_comment.id, _project.id, true));
+    var archived = await Sut.Get(_comment.id, _project.id);
+    Assert.That(archived.archived, Is.True);
 
-    archived = await Sut.Archive(_comment.id);
-    Assert.That(archived, Is.True);
+    await Sut.Archive(new(_comment.id, _project.id, false));
+    var unarchived = await Sut.Get(_comment.id, _project.id);
+    Assert.That(unarchived.archived, Is.False);
   }
 
   [Test]
@@ -67,7 +77,7 @@ public class CommentResourceTests
   {
     var blobs = await Fixtures.SendBlobData(_testUser.Account, _project.id);
     var blobIds = blobs.Select(b => b.id).ToList();
-    EditCommentInput input = new(new(blobIds, null), _comment.id);
+    EditCommentInput input = new(new(blobIds, null), _comment.id, _project.id);
 
     var editedComment = await Sut.Edit(input);
 
@@ -83,7 +93,7 @@ public class CommentResourceTests
   {
     var blobs = await Fixtures.SendBlobData(_testUser.Account, _project.id);
     var blobIds = blobs.Select(b => b.id).ToList();
-    CreateCommentReplyInput input = new(new(blobIds, null), _comment.id);
+    CreateCommentReplyInput input = new(new(blobIds, null), _comment.id, _project.id);
 
     var editedComment = await Sut.Reply(input);
 

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ModelResourceExceptionalTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ModelResourceExceptionalTests.cs
@@ -80,9 +80,8 @@ public class ModelResourceExceptionalTests
   {
     Model toDelete = await Sut.Create(new("Delete me", null, _project.id));
     DeleteModelInput input = new(toDelete.id, _project.id);
-    bool response = await Sut.Delete(input);
-    Assert.That(response, Is.True);
+    await Sut.Delete(input);
 
-    Assert.CatchAsync<SpeckleGraphQLException>(async () => _ = await Sut.Delete(input));
+    Assert.CatchAsync<SpeckleGraphQLException>(async () => await Sut.Delete(input));
   }
 }

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ModelResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ModelResourceTests.cs
@@ -91,7 +91,7 @@ public class ModelResourceTests
 
     await Sut.Delete(input);
 
-    Assert.CatchAsync<SpeckleGraphQLException>(async () => _ = await Sut.Get(_model.id, _project.id));
-    Assert.CatchAsync<SpeckleGraphQLException>(async () => _ = await Sut.Delete(input));
+    Assert.CatchAsync<SpeckleGraphQLException>(async () => await Sut.Get(_model.id, _project.id));
+    Assert.CatchAsync<SpeckleGraphQLException>(async () => await Sut.Delete(input));
   }
 }

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ModelResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ModelResourceTests.cs
@@ -89,8 +89,7 @@ public class ModelResourceTests
   {
     DeleteModelInput input = new(_model.id, _project.id);
 
-    bool response = await Sut.Delete(input);
-    Assert.That(response, Is.True);
+    await Sut.Delete(input);
 
     Assert.CatchAsync<SpeckleGraphQLException>(async () => _ = await Sut.Get(_model.id, _project.id));
     Assert.CatchAsync<SpeckleGraphQLException>(async () => _ = await Sut.Delete(input));

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectInviteResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectInviteResourceTests.cs
@@ -82,8 +82,7 @@ public class ProjectInviteResourceTests
   public async Task ProjectInviteUse_MemberAdded()
   {
     ProjectInviteUseInput input = new(true, _createdInvite.projectId, _createdInvite.token.NotNull());
-    var res = await _invitee.ProjectInvite.Use(input);
-    Assert.That(res, Is.True);
+    await _invitee.ProjectInvite.Use(input);
 
     var project = await _inviter.Project.GetWithTeam(_project.id);
     var teamMembers = project.team.Select(c => c.user.id);

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceExceptionalTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceExceptionalTests.cs
@@ -99,8 +99,7 @@ public class ProjectResourceExceptionalTests
   [Test]
   public async Task ProjectDelete_NonExistentProject()
   {
-    bool response = await Sut.Delete(_testProject.id);
-    Assert.That(response, Is.True);
+    await Sut.Delete(_testProject.id);
 
     Assert.ThrowsAsync<SpeckleGraphQLStreamNotFoundException>(async () => _ = await Sut.Get(_testProject.id)); //TODO: Exception types
   }

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
@@ -64,8 +64,7 @@ public class ProjectResourceTests
   public async Task ProjectDelete()
   {
     Project toDelete = await Sut.Create(new("Delete me", null, null));
-    bool response = await Sut.Delete(toDelete.id);
-    Assert.That(response, Is.True);
+    await Sut.Delete(toDelete.id);
 
     Assert.ThrowsAsync<SpeckleGraphQLStreamNotFoundException>(async () => _ = await Sut.Get(toDelete.id));
   }

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/VersionResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/VersionResourceTests.cs
@@ -52,9 +52,7 @@ public class VersionResourceTests
   public async Task VersionReceived()
   {
     MarkReceivedVersionInput input = new(_version.id, _project.id, "Integration test");
-    var result = await Sut.Received(input);
-
-    Assert.That(result, Is.True);
+    await Sut.Received(input);
   }
 
   [Test]
@@ -99,10 +97,9 @@ public class VersionResourceTests
   {
     DeleteVersionsInput input = new([_version.id], _project.id);
 
-    bool response = await Sut.Delete(input);
-    Assert.That(response, Is.True);
+    await Sut.Delete(input);
 
-    Assert.CatchAsync<SpeckleGraphQLException>(async () => _ = await Sut.Get(_version.id, _project.id));
-    Assert.CatchAsync<SpeckleGraphQLException>(async () => _ = await Sut.Delete(input));
+    Assert.CatchAsync<SpeckleGraphQLException>(async () => await Sut.Get(_version.id, _project.id));
+    Assert.CatchAsync<SpeckleGraphQLException>(async () => await Sut.Delete(input));
   }
 }


### PR DESCRIPTION
1. Updated comments API to respond to the workspace related breaking changes
2. Added comment get
3. Removed boolean return from several mutations (confirmed already with @fabis94, the server should be responding with an gql error, which we are throwing on anyway, so there's zero value in the way we were returning the bools)