### PR TITLE
Fix externals refs again

### DIFF
--- a/src/Speckle.Sdk/Serialisation/V2/Receive/DeserializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/DeserializeProcess.cs
@@ -118,22 +118,22 @@ public sealed class DeserializeProcess(
     {
       return;
     }
-    (string json, _) = GetClosures(id);
-    var @base = Deserialise(id, json);
+    (string json, IReadOnlyList<string> closures) = GetClosures(id);
+    var @base = Deserialise(id, json, closures);
     _baseCache.TryAdd(id, @base);
     //remove from JSON cache because we've finally made the Base
     _closures.TryRemove(id, out _);
     _activeTasks.TryRemove(id, out _);
   }
 
-  private Base Deserialise(string id, string json)
+  private Base Deserialise(string id, string json, IReadOnlyList<string> closures)
   {
     if (_baseCache.TryGetValue(id, out var baseObject))
     {
       return baseObject;
     }
 
-    var deserializer = objectDeserializerFactory.Create(_baseCache);
+    var deserializer = objectDeserializerFactory.Create(id, closures, _baseCache);
     return deserializer.Deserialize(json);
   }
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectDeserializer.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectDeserializer.cs
@@ -104,7 +104,7 @@ public sealed class ObjectDeserializer(
       {
         throw new InvalidOperationException($"current Id: {currentId} has missing closure: {objId}");
       }
-      
+
       if (references.TryGetValue(objId, out Base? closure))
       {
         return closure;

--- a/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectDeserializerFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectDeserializerFactory.cs
@@ -6,6 +6,10 @@ namespace Speckle.Sdk.Serialisation.V2.Receive;
 [GenerateAutoInterface]
 public class ObjectDeserializerFactory : IObjectDeserializerFactory
 {
-  public IObjectDeserializer Create(string currentId, IReadOnlyList<string> currentClosures, IReadOnlyDictionary<string, Base> references, DeserializeOptions? options = null) =>
-    new ObjectDeserializer(currentId, currentClosures, references, SpeckleObjectSerializerPool.Instance, options);
+  public IObjectDeserializer Create(
+    string currentId,
+    IReadOnlyList<string> currentClosures,
+    IReadOnlyDictionary<string, Base> references,
+    DeserializeOptions? options = null
+  ) => new ObjectDeserializer(currentId, currentClosures, references, SpeckleObjectSerializerPool.Instance, options);
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectDeserializerFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectDeserializerFactory.cs
@@ -6,6 +6,6 @@ namespace Speckle.Sdk.Serialisation.V2.Receive;
 [GenerateAutoInterface]
 public class ObjectDeserializerFactory : IObjectDeserializerFactory
 {
-  public IObjectDeserializer Create(IReadOnlyDictionary<string, Base> references, DeserializeOptions? options = null) =>
-    new ObjectDeserializer(references, SpeckleObjectSerializerPool.Instance, options);
+  public IObjectDeserializer Create(string currentId, IReadOnlyList<string> currentClosures, IReadOnlyDictionary<string, Base> references, DeserializeOptions? options = null) =>
+    new ObjectDeserializer(currentId, currentClosures, references, SpeckleObjectSerializerPool.Instance, options);
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
@@ -221,7 +221,7 @@ public class ObjectSerializer : IObjectSerializer
     }
     else
     {
-      childClosures = isRoot ? _currentClosures : new();
+      childClosures = isRoot || inheritedDetachInfo.IsDetachable ? _currentClosures : [];
       var sb = Pools.StringBuilders.Get();
       using var writer = new StringWriter(sb);
       using var jsonWriter = SpeckleObjectSerializerPool.Instance.GetJsonTextWriter(writer);

--- a/tests/Speckle.Sdk.Serialization.Tests/ExternalIdTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExternalIdTests.cs
@@ -21,13 +21,17 @@ public class ExternalIdTests
     TypeLoader.Reset();
     TypeLoader.Initialize(typeof(Base).Assembly, typeof(Polyline).Assembly);
   }
+
   [Test]
   [TestCase("cfaf7ae0dfc5a7cf3343bb6db46ed238", "8d27f5c7fac36d985d89bb6d6d8acddc")]
   public void ExternalIdTest_Detached(string lineId, string valueId)
   {
     var p = new Polyline() { units = "cm", value = [1, 2] };
-    var serializer =
-      new ObjectSerializer(new BasePropertyGatherer(), new ConcurrentDictionary<Base, CacheInfo>(), true);
+    var serializer = new ObjectSerializer(
+      new BasePropertyGatherer(),
+      new ConcurrentDictionary<Base, CacheInfo>(),
+      true
+    );
     var list = serializer.Serialize(p).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -36,13 +40,15 @@ public class ExternalIdTests
     var closures = (JObject)jObject["__closure"].NotNull();
     closures.ContainsKey(valueId).ShouldBeTrue();
   }
+
   [Test]
   [TestCase("cfaf7ae0dfc5a7cf3343bb6db46ed238", "8d27f5c7fac36d985d89bb6d6d8acddc")]
   public void ExternalIdTest_Detached_Nested(string lineId, string valueId)
   {
     var curve = new Curve()
     {
-      closed = false, displayValue = new Polyline() { units = "cm", value = [1, 2] },
+      closed = false,
+      displayValue = new Polyline() { units = "cm", value = [1, 2] },
       domain = new Interval() { start = 0, end = 1 },
       units = "cm",
       degree = 1,
@@ -50,10 +56,13 @@ public class ExternalIdTests
       rational = false,
       points = [],
       knots = [],
-      weights = []
+      weights = [],
     };
-    var serializer =
-      new ObjectSerializer(new BasePropertyGatherer(), new ConcurrentDictionary<Base, CacheInfo>(), true);
+    var serializer = new ObjectSerializer(
+      new BasePropertyGatherer(),
+      new ConcurrentDictionary<Base, CacheInfo>(),
+      true
+    );
     var list = serializer.Serialize(curve).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -69,7 +78,8 @@ public class ExternalIdTests
   {
     var curve = new Curve()
     {
-      closed = false, displayValue = new Polyline() { units = "cm", value = [1, 2] },
+      closed = false,
+      displayValue = new Polyline() { units = "cm", value = [1, 2] },
       domain = new Interval() { start = 0, end = 1 },
       units = "cm",
       degree = 1,
@@ -77,11 +87,14 @@ public class ExternalIdTests
       rational = false,
       points = [],
       knots = [],
-      weights = []
+      weights = [],
     };
-    var polycurve = new Polycurve() { segments = [curve], units = "cm"};
-    var serializer =
-      new ObjectSerializer(new BasePropertyGatherer(), new ConcurrentDictionary<Base, CacheInfo>(), true);
+    var polycurve = new Polycurve() { segments = [curve], units = "cm" };
+    var serializer = new ObjectSerializer(
+      new BasePropertyGatherer(),
+      new ConcurrentDictionary<Base, CacheInfo>(),
+      true
+    );
     var list = serializer.Serialize(polycurve).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -90,14 +103,15 @@ public class ExternalIdTests
     var closures = (JObject)jObject["__closure"].NotNull();
     closures.ContainsKey(valueId).ShouldBeTrue();
   }
-  
+
   [Test]
   [TestCase("cfaf7ae0dfc5a7cf3343bb6db46ed238", "8d27f5c7fac36d985d89bb6d6d8acddc")]
   public void ExternalIdTest_Detached_Nested_More_Too(string lineId, string valueId)
   {
     var curve = new Curve()
     {
-      closed = false, displayValue = new Polyline() { units = "cm", value = [1, 2] },
+      closed = false,
+      displayValue = new Polyline() { units = "cm", value = [1, 2] },
       domain = new Interval() { start = 0, end = 1 },
       units = "cm",
       degree = 1,
@@ -105,12 +119,16 @@ public class ExternalIdTests
       rational = false,
       points = [],
       knots = [],
-      weights = []
+      weights = [],
     };
-    var polycurve = new Polycurve() { segments = [curve], units = "cm"};
+    var polycurve = new Polycurve() { segments = [curve], units = "cm" };
     var @base = new Base();
     @base.SetDetachedProp("profile", polycurve);
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new ConcurrentDictionary<Base, CacheInfo>(), true);
+    var serializer = new ObjectSerializer(
+      new BasePropertyGatherer(),
+      new ConcurrentDictionary<Base, CacheInfo>(),
+      true
+    );
     var list = serializer.Serialize(@base).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -118,6 +136,5 @@ public class ExternalIdTests
     jObject.ContainsKey("__closure").ShouldBeTrue();
     var closures = (JObject)jObject["__closure"].NotNull();
     closures.ContainsKey(valueId).ShouldBeTrue();
-    
   }
 }

--- a/tests/Speckle.Sdk.Serialization.Tests/ExternalIdTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExternalIdTests.cs
@@ -1,0 +1,123 @@
+﻿using System.Collections.Concurrent;
+using NUnit.Framework;
+using Shouldly;
+using Speckle.Newtonsoft.Json.Linq;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Primitive;
+using Speckle.Sdk.Common;
+using Speckle.Sdk.Host;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Models.Extensions;
+using Speckle.Sdk.Serialisation;
+using Speckle.Sdk.Serialisation.V2.Send;
+
+namespace Speckle.Sdk.Serialization.Tests;
+
+public class ExternalIdTests
+{
+  [SetUp]
+  public void Setup()
+  {
+    TypeLoader.Reset();
+    TypeLoader.Initialize(typeof(Base).Assembly, typeof(Polyline).Assembly);
+  }
+  [Test]
+  [TestCase("cfaf7ae0dfc5a7cf3343bb6db46ed238", "8d27f5c7fac36d985d89bb6d6d8acddc")]
+  public void ExternalIdTest_Detached(string lineId, string valueId)
+  {
+    var p = new Polyline() { units = "cm", value = [1, 2] };
+    var serializer =
+      new ObjectSerializer(new BasePropertyGatherer(), new ConcurrentDictionary<Base, CacheInfo>(), true);
+    var list = serializer.Serialize(p).ToDictionary(x => x.Item1, x => x.Item2);
+    list.ContainsKey(new Id(lineId)).ShouldBeTrue();
+    var json = list[new Id(lineId)];
+    var jObject = JObject.Parse(json.Value);
+    jObject.ContainsKey("__closure").ShouldBeTrue();
+    var closures = (JObject)jObject["__closure"].NotNull();
+    closures.ContainsKey(valueId).ShouldBeTrue();
+  }
+  [Test]
+  [TestCase("cfaf7ae0dfc5a7cf3343bb6db46ed238", "8d27f5c7fac36d985d89bb6d6d8acddc")]
+  public void ExternalIdTest_Detached_Nested(string lineId, string valueId)
+  {
+    var curve = new Curve()
+    {
+      closed = false, displayValue = new Polyline() { units = "cm", value = [1, 2] },
+      domain = new Interval() { start = 0, end = 1 },
+      units = "cm",
+      degree = 1,
+      periodic = false,
+      rational = false,
+      points = [],
+      knots = [],
+      weights = []
+    };
+    var serializer =
+      new ObjectSerializer(new BasePropertyGatherer(), new ConcurrentDictionary<Base, CacheInfo>(), true);
+    var list = serializer.Serialize(curve).ToDictionary(x => x.Item1, x => x.Item2);
+    list.ContainsKey(new Id(lineId)).ShouldBeTrue();
+    var json = list[new Id(lineId)];
+    var jObject = JObject.Parse(json.Value);
+    jObject.ContainsKey("__closure").ShouldBeTrue();
+    var closures = (JObject)jObject["__closure"].NotNull();
+    closures.ContainsKey(valueId).ShouldBeTrue();
+  }
+
+  [Test]
+  [TestCase("cfaf7ae0dfc5a7cf3343bb6db46ed238", "8d27f5c7fac36d985d89bb6d6d8acddc")]
+  public void ExternalIdTest_Detached_Nested_More(string lineId, string valueId)
+  {
+    var curve = new Curve()
+    {
+      closed = false, displayValue = new Polyline() { units = "cm", value = [1, 2] },
+      domain = new Interval() { start = 0, end = 1 },
+      units = "cm",
+      degree = 1,
+      periodic = false,
+      rational = false,
+      points = [],
+      knots = [],
+      weights = []
+    };
+    var polycurve = new Polycurve() { segments = [curve], units = "cm"};
+    var serializer =
+      new ObjectSerializer(new BasePropertyGatherer(), new ConcurrentDictionary<Base, CacheInfo>(), true);
+    var list = serializer.Serialize(polycurve).ToDictionary(x => x.Item1, x => x.Item2);
+    list.ContainsKey(new Id(lineId)).ShouldBeTrue();
+    var json = list[new Id(lineId)];
+    var jObject = JObject.Parse(json.Value);
+    jObject.ContainsKey("__closure").ShouldBeTrue();
+    var closures = (JObject)jObject["__closure"].NotNull();
+    closures.ContainsKey(valueId).ShouldBeTrue();
+  }
+  
+  [Test]
+  [TestCase("cfaf7ae0dfc5a7cf3343bb6db46ed238", "8d27f5c7fac36d985d89bb6d6d8acddc")]
+  public void ExternalIdTest_Detached_Nested_More_Too(string lineId, string valueId)
+  {
+    var curve = new Curve()
+    {
+      closed = false, displayValue = new Polyline() { units = "cm", value = [1, 2] },
+      domain = new Interval() { start = 0, end = 1 },
+      units = "cm",
+      degree = 1,
+      periodic = false,
+      rational = false,
+      points = [],
+      knots = [],
+      weights = []
+    };
+    var polycurve = new Polycurve() { segments = [curve], units = "cm"};
+    var @base = new Base();
+    @base.SetDetachedProp("profile", polycurve);
+    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new ConcurrentDictionary<Base, CacheInfo>(), true);
+    var list = serializer.Serialize(@base).ToDictionary(x => x.Item1, x => x.Item2);
+    list.ContainsKey(new Id(lineId)).ShouldBeTrue();
+    var json = list[new Id(lineId)];
+    var jObject = JObject.Parse(json.Value);
+    jObject.ContainsKey("__closure").ShouldBeTrue();
+    var closures = (JObject)jObject["__closure"].NotNull();
+    closures.ContainsKey(valueId).ShouldBeTrue();
+    
+  }
+}


### PR DESCRIPTION
Adds a new check when writing nested detached objects to see if closure table should be written

Also adds a check for when deserializing that the current closures have a child object

Related to https://linear.app/speckle/issue/CNX-821/failed-to-deserialize