### PR TITLE
Better options for serializer

### DIFF
--- a/src/Speckle.Sdk/Serialisation/V2/DummySendServerObjectManager.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/DummySendServerObjectManager.cs
@@ -1,11 +1,26 @@
 ﻿using System.Text;
 using Speckle.Sdk.Dependencies.Serialization;
-using Speckle.Sdk.Serialisation.V2;
+using Speckle.Sdk.SQLite;
 using Speckle.Sdk.Transports;
 
-namespace Speckle.Sdk.Serialization.Testing;
+namespace Speckle.Sdk.Serialisation.V2;
 
-public class DummyServerObjectManager : IServerObjectManager
+public class DummySqLiteJsonCacheManager : ISqLiteJsonCacheManager
+{
+  public IEnumerable<string> GetAllObjects() => throw new NotImplementedException();
+
+  public void DeleteObject(string id) => throw new NotImplementedException();
+
+  public string? GetObject(string id) => throw new NotImplementedException();
+
+  public void SaveObject(string id, string json) => throw new NotImplementedException();
+
+  public void SaveObjects(IEnumerable<(string id, string json)> items) => throw new NotImplementedException();
+
+  public bool HasObject(string objectId) => throw new NotImplementedException();
+}
+
+public class DummySendServerObjectManager : IServerObjectManager
 {
   public IAsyncEnumerable<(string, string)> DownloadObjects(
     IReadOnlyList<string> objectIds,

--- a/src/Speckle.Sdk/Serialisation/V2/Receive/DeserializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/DeserializeProcess.cs
@@ -29,10 +29,7 @@ public sealed class DeserializeProcess(
   public IReadOnlyDictionary<string, Base> BaseCache => _baseCache;
   public long Total { get; private set; }
 
-  public async Task<Base> Deserialize(
-    string rootId,
-    CancellationToken cancellationToken
-  )
+  public async Task<Base> Deserialize(string rootId, CancellationToken cancellationToken)
   {
     var (rootJson, childrenIds) = await objectLoader
       .GetAndCache(rootId, _options, cancellationToken)

--- a/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectDeserializer.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectDeserializer.cs
@@ -13,7 +13,7 @@ public sealed class ObjectDeserializer(
   IReadOnlyList<string> currentClosures,
   IReadOnlyDictionary<string, Base> references,
   SpeckleObjectSerializerPool pool,
-  DeserializeOptions? options = null
+  DeserializeProcessOptions? options = null
 ) : IObjectDeserializer
 {
   /// <param name="objectJson">The JSON string of the object to be deserialized <see cref="Base"/></param>

--- a/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectDeserializerFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectDeserializerFactory.cs
@@ -10,6 +10,6 @@ public class ObjectDeserializerFactory : IObjectDeserializerFactory
     string currentId,
     IReadOnlyList<string> currentClosures,
     IReadOnlyDictionary<string, Base> references,
-    DeserializeOptions? options = null
+    DeserializeProcessOptions? options = null
   ) => new ObjectDeserializer(currentId, currentClosures, references, SpeckleObjectSerializerPool.Instance, options);
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectLoader.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectLoader.cs
@@ -17,11 +17,11 @@ public sealed class ObjectLoader(
   private int? _allChildrenCount;
   private long _checkCache;
   private long _cached;
-  private DeserializeOptions _options = new(false);
+  private DeserializeProcessOptions _options = new(false);
 
   public async Task<(string, IReadOnlyList<string>)> GetAndCache(
     string rootId,
-    DeserializeOptions options,
+    DeserializeProcessOptions options,
     CancellationToken cancellationToken
   )
   {

--- a/src/Speckle.Sdk/Serialisation/V2/Send/EmptyDictionary.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/EmptyDictionary.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Speckle.Sdk.Serialisation.V2.Send;
+
+public class EmptyDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+{
+  public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => throw new NotImplementedException();
+
+  IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+  public void Add(KeyValuePair<TKey, TValue> item) { }
+
+  public void Clear() => throw new NotImplementedException();
+
+  public bool Contains(KeyValuePair<TKey, TValue> item) => false;
+
+  public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) => throw new NotImplementedException();
+
+  public bool Remove(KeyValuePair<TKey, TValue> item) => false;
+
+  public int Count => 0;
+  public bool IsReadOnly => false;
+
+  public void Add(TKey key, TValue value) { }
+
+  public bool ContainsKey(TKey key) => false;
+
+  public bool Remove(TKey key) => false;
+
+  public bool TryGetValue(TKey key, [UnscopedRef] out TValue value)
+  {
+    value = default!;
+    return false;
+  }
+
+  public TValue this[TKey key]
+  {
+#pragma warning disable CA1065
+    get => throw new NotImplementedException();
+#pragma warning restore CA1065
+    set { }
+  }
+
+  public ICollection<TKey> Keys { get; }
+  public ICollection<TValue> Values { get; }
+}

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Drawing;
 using System.Globalization;
 using Speckle.DoubleNumerics;
@@ -21,7 +20,7 @@ public class ObjectSerializer : IObjectSerializer
 {
   private HashSet<object> _parentObjects = new();
   private readonly Closures _currentClosures = new();
-  private readonly ConcurrentDictionary<Base, CacheInfo> _baseCache;
+  private readonly IDictionary<Base, CacheInfo> _baseCache;
 
   private readonly bool _trackDetachedChildren;
   private readonly IBasePropertyGatherer _propertyGatherer;
@@ -42,7 +41,7 @@ public class ObjectSerializer : IObjectSerializer
   /// <param name="cancellationToken"></param>
   public ObjectSerializer(
     IBasePropertyGatherer propertyGatherer,
-    ConcurrentDictionary<Base, CacheInfo> baseCache,
+    IDictionary<Base, CacheInfo> baseCache,
     bool trackDetachedChildren = false,
     CancellationToken cancellationToken = default
   )
@@ -70,7 +69,7 @@ public class ObjectSerializer : IObjectSerializer
       {
         throw new SpeckleSerializeException($"Failed to extract (pre-serialize) properties from the {baseObj}", ex);
       }
-      _baseCache.TryAdd(baseObj, new(item.Item2, _currentClosures));
+      _baseCache[baseObj] = new(item.Item2, _currentClosures);
       yield return (item.Item1, item.Item2);
       foreach (var chunk in _chunks)
       {

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
@@ -64,7 +64,7 @@ public class ObjectSerializer : IObjectSerializer
       (Id, Json) item;
       try
       {
-         item = SerializeBase(baseObj, true).NotNull();
+        item = SerializeBase(baseObj, true).NotNull();
       }
       catch (Exception ex) when (!ex.IsFatal() && ex is not OperationCanceledException)
       {

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
@@ -61,15 +61,20 @@ public class ObjectSerializer : IObjectSerializer
   {
     try
     {
+      (Id, Json) item;
       try
       {
-        var item = SerializeBase(baseObj, true).NotNull();
-        _baseCache.TryAdd(baseObj, new(item.Item2, _currentClosures));
-        return [new(item.Item1, item.Item2), .. _chunks];
+         item = SerializeBase(baseObj, true).NotNull();
       }
       catch (Exception ex) when (!ex.IsFatal() && ex is not OperationCanceledException)
       {
         throw new SpeckleSerializeException($"Failed to extract (pre-serialize) properties from the {baseObj}", ex);
+      }
+      _baseCache.TryAdd(baseObj, new(item.Item2, _currentClosures));
+      yield return (item.Item1, item.Item2);
+      foreach (var chunk in _chunks)
+      {
+        yield return chunk;
       }
     }
     finally

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
@@ -95,6 +95,25 @@ public class ObjectSerializer : IObjectSerializer
       return;
     }
 
+    switch (obj)
+    {
+      case double d:
+        writer.WriteValue(d);
+        return;
+      case string d:
+        writer.WriteValue(d);
+        return;
+      case bool d:
+        writer.WriteValue(d);
+        return;
+      case int d:
+        writer.WriteValue(d);
+        return;
+      case long d:
+        writer.WriteValue(d);
+        return;
+    }
+
     if (obj.GetType().IsPrimitive || obj is string)
     {
       writer.WriteValue(obj);

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializerFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializerFactory.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Speckle.InterfaceGenerator;
 using Speckle.Sdk.Models;
 
@@ -7,8 +6,6 @@ namespace Speckle.Sdk.Serialisation.V2.Send;
 [GenerateAutoInterface]
 public class ObjectSerializerFactory(IBasePropertyGatherer propertyGatherer) : IObjectSerializerFactory
 {
-  public IObjectSerializer Create(
-    ConcurrentDictionary<Base, CacheInfo> baseCache,
-    CancellationToken cancellationToken
-  ) => new ObjectSerializer(propertyGatherer, baseCache, true, cancellationToken);
+  public IObjectSerializer Create(IDictionary<Base, CacheInfo> baseCache, CancellationToken cancellationToken) =>
+    new ObjectSerializer(propertyGatherer, baseCache, true, cancellationToken);
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -21,7 +21,8 @@ public class SerializeProcess(
   ISqLiteJsonCacheManager sqLiteJsonCacheManager,
   IServerObjectManager serverObjectManager,
   IBaseChildFinder baseChildFinder,
-  IObjectSerializerFactory objectSerializerFactory
+  IObjectSerializerFactory objectSerializerFactory,
+  SerializeProcessOptions? options = null
 ) : ChannelSaver, ISerializeProcess
 {
   private readonly ConcurrentDictionary<Id, Json> _jsonCache = new();
@@ -34,15 +35,13 @@ public class SerializeProcess(
   private long _cached;
   private long _serialized;
 
-  private SerializeProcessOptions _options = new(false, false, false);
+  private readonly SerializeProcessOptions _options = options ?? new(false, false, false);
 
   public async Task<SerializeProcessResults> Serialize(
     Base root,
-    CancellationToken cancellationToken,
-    SerializeProcessOptions? options = null
+    CancellationToken cancellationToken
   )
   {
-    _options = options ?? _options;
     var channelTask = Start(cancellationToken);
     await Traverse(root, true, cancellationToken).ConfigureAwait(false);
     await channelTask.ConfigureAwait(false);

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -37,10 +37,7 @@ public class SerializeProcess(
 
   private readonly SerializeProcessOptions _options = options ?? new(false, false, false);
 
-  public async Task<SerializeProcessResults> Serialize(
-    Base root,
-    CancellationToken cancellationToken
-  )
+  public async Task<SerializeProcessResults> Serialize(Base root, CancellationToken cancellationToken)
   {
     var channelTask = Start(cancellationToken);
     await Traverse(root, true, cancellationToken).ConfigureAwait(false);

--- a/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
@@ -13,13 +13,20 @@ public interface ISerializeProcessFactory
     Uri url,
     string streamId,
     string? authorizationToken,
-    IProgress<ProgressArgs>? progress
+    IProgress<ProgressArgs>? progress,
+    SerializeProcessOptions? options = null
   );
   IDeserializeProcess CreateDeserializeProcess(
     Uri url,
     string streamId,
     string? authorizationToken,
-    IProgress<ProgressArgs>? progress
+    IProgress<ProgressArgs>? progress,
+    DeserializeProcessOptions? options = null
+  );
+
+  public ISerializeProcess CreateSerializeProcess(
+    SerializeProcessOptions? options = null,
+    IProgress<ProgressArgs>? progress = null
   );
 }
 
@@ -36,7 +43,8 @@ public class SerializeProcessFactory(
     Uri url,
     string streamId,
     string? authorizationToken,
-    IProgress<ProgressArgs>? progress
+    IProgress<ProgressArgs>? progress,
+    SerializeProcessOptions? options = null
   )
   {
     var sqLiteJsonCacheManager = sqLiteJsonCacheManagerFactory.CreateFromStream(streamId);
@@ -46,7 +54,25 @@ public class SerializeProcessFactory(
       sqLiteJsonCacheManager,
       serverObjectManager,
       baseChildFinder,
-      objectSerializerFactory
+      objectSerializerFactory,
+      options
+    );
+  }
+  
+  public ISerializeProcess CreateSerializeProcess(
+    SerializeProcessOptions? options = null,
+    IProgress<ProgressArgs>? progress = null
+  )
+  {
+    var sqLiteJsonCacheManager = new DummySqLiteJsonCacheManager();
+    var serverObjectManager = new DummySendServerObjectManager();
+    return new SerializeProcess(
+      progress,
+      sqLiteJsonCacheManager,
+      serverObjectManager,
+      baseChildFinder,
+      objectSerializerFactory,
+      options
     );
   }
 
@@ -54,13 +80,14 @@ public class SerializeProcessFactory(
     Uri url,
     string streamId,
     string? authorizationToken,
-    IProgress<ProgressArgs>? progress
+    IProgress<ProgressArgs>? progress,
+    DeserializeProcessOptions? options = null
   )
   {
     var sqLiteJsonCacheManager = sqLiteJsonCacheManagerFactory.CreateFromStream(streamId);
     var serverObjectManager = new ServerObjectManager(speckleHttp, activityFactory, url, streamId, authorizationToken);
 
     var objectLoader = new ObjectLoader(sqLiteJsonCacheManager, serverObjectManager, progress);
-    return new DeserializeProcess(progress, objectLoader, objectDeserializerFactory);
+    return new DeserializeProcess(progress, objectLoader, objectDeserializerFactory, options);
   }
 }

--- a/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
@@ -58,7 +58,7 @@ public class SerializeProcessFactory(
       options
     );
   }
-  
+
   public ISerializeProcess CreateSerializeProcess(
     SerializeProcessOptions? options = null,
     IProgress<ProgressArgs>? progress = null

--- a/tests/Speckle.Sdk.Serialization.Testing/Program.cs
+++ b/tests/Speckle.Sdk.Serialization.Testing/Program.cs
@@ -56,10 +56,14 @@ Console.WriteLine("Deserialized");
 Console.ReadLine();
 Console.WriteLine("Executing");
 
-var process2 = factory.CreateSerializeProcess(new Uri(url), streamId, token, progress, new SerializeProcessOptions(skipCacheSendCheck, skipCacheSendSave, true));
-await process2
-  .Serialize(@base, default)
-  .ConfigureAwait(false);
+var process2 = factory.CreateSerializeProcess(
+  new Uri(url),
+  streamId,
+  token,
+  progress,
+  new SerializeProcessOptions(skipCacheSendCheck, skipCacheSendSave, true)
+);
+await process2.Serialize(@base, default).ConfigureAwait(false);
 Console.WriteLine("Detach");
 Console.ReadLine();
 #pragma warning restore CA1506

--- a/tests/Speckle.Sdk.Serialization.Testing/Program.cs
+++ b/tests/Speckle.Sdk.Serialization.Testing/Program.cs
@@ -61,7 +61,7 @@ var process2 = factory.CreateSerializeProcess(
   streamId,
   token,
   progress,
-  new SerializeProcessOptions(skipCacheSendCheck, skipCacheSendSave, true)
+  new SerializeProcessOptions(skipCacheSendCheck, skipCacheSendSave, true, true)
 );
 await process2.Serialize(@base, default).ConfigureAwait(false);
 Console.WriteLine("Detach");

--- a/tests/Speckle.Sdk.Serialization.Testing/Program.cs
+++ b/tests/Speckle.Sdk.Serialization.Testing/Program.cs
@@ -50,15 +50,15 @@ var factory = new SerializeProcessFactory(
   new ObjectDeserializerFactory(),
   serviceProvider.GetRequiredService<ISqLiteJsonCacheManagerFactory>()
 );
-var process = factory.CreateDeserializeProcess(new Uri(url), streamId, token, progress);
-var @base = await process.Deserialize(rootId, default, new(skipCacheReceive)).ConfigureAwait(false);
+var process = factory.CreateDeserializeProcess(new Uri(url), streamId, token, progress, new(skipCacheReceive));
+var @base = await process.Deserialize(rootId, default).ConfigureAwait(false);
 Console.WriteLine("Deserialized");
 Console.ReadLine();
 Console.WriteLine("Executing");
 
-var process2 = factory.CreateSerializeProcess(new Uri(url), streamId, token, progress);
+var process2 = factory.CreateSerializeProcess(new Uri(url), streamId, token, progress, new SerializeProcessOptions(skipCacheSendCheck, skipCacheSendSave, true));
 await process2
-  .Serialize(@base, default, new SerializeProcessOptions(skipCacheSendCheck, skipCacheSendSave, true))
+  .Serialize(@base, default)
   .ConfigureAwait(false);
 Console.WriteLine("Detach");
 Console.ReadLine();

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -73,9 +73,9 @@ public class DetachedTests
       new DummySendCacheManager(objects),
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
-      new ObjectSerializerFactory(new BasePropertyGatherer())
+      new ObjectSerializerFactory(new BasePropertyGatherer()), new SerializeProcessOptions(false, false, true)
     );
-    await process2.Serialize(@base, default, new SerializeProcessOptions(false, false, true)).ConfigureAwait(false);
+    await process2.Serialize(@base, default).ConfigureAwait(false);
 
     objects.Count.ShouldBe(2);
     objects.ContainsKey("9ff8efb13c62fa80f3d1c4519376ba13").ShouldBeTrue();
@@ -264,10 +264,10 @@ public class DetachedTests
       new DummySendCacheManager(objects),
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
-      new ObjectSerializerFactory(new BasePropertyGatherer())
+      new ObjectSerializerFactory(new BasePropertyGatherer()), new SerializeProcessOptions(false, false, true)
     );
     var results = await process2
-      .Serialize(@base, default, new SerializeProcessOptions(false, false, true))
+      .Serialize(@base, default)
       .ConfigureAwait(false);
 
     objects.Count.ShouldBe(9);

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -26,7 +26,9 @@ public class DetachedTests
   }
 
   [Test(Description = "Checks that all typed properties (including obsolete ones) are returned")]
-  public async Task CanSerialize_New_Detached()
+  [TestCase(true)]
+  [TestCase(false)]
+  public async Task CanSerialize_New_Detached(bool cacheBases)
   {
     var expectedJson = """
       {
@@ -74,7 +76,7 @@ public class DetachedTests
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
-      new SerializeProcessOptions(false, false, true)
+      new SerializeProcessOptions(false, false, true, cacheBases)
     );
     await process2.Serialize(@base, default).ConfigureAwait(false);
 
@@ -191,7 +193,9 @@ public class DetachedTests
   }
 
   [Test(Description = "Checks that all typed properties (including obsolete ones) are returned")]
-  public async Task CanSerialize_New_Detached2()
+  [TestCase(true)]
+  [TestCase(false)]
+  public async Task CanSerialize_New_Detached2(bool cacheBases)
   {
     var root = """
          
@@ -266,7 +270,7 @@ public class DetachedTests
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
-      new SerializeProcessOptions(false, false, true)
+      new SerializeProcessOptions(false, false, true, cacheBases)
     );
     var results = await process2.Serialize(@base, default).ConfigureAwait(false);
 

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -73,7 +73,8 @@ public class DetachedTests
       new DummySendCacheManager(objects),
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
-      new ObjectSerializerFactory(new BasePropertyGatherer()), new SerializeProcessOptions(false, false, true)
+      new ObjectSerializerFactory(new BasePropertyGatherer()),
+      new SerializeProcessOptions(false, false, true)
     );
     await process2.Serialize(@base, default).ConfigureAwait(false);
 
@@ -264,11 +265,10 @@ public class DetachedTests
       new DummySendCacheManager(objects),
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
-      new ObjectSerializerFactory(new BasePropertyGatherer()), new SerializeProcessOptions(false, false, true)
+      new ObjectSerializerFactory(new BasePropertyGatherer()),
+      new SerializeProcessOptions(false, false, true)
     );
-    var results = await process2
-      .Serialize(@base, default)
-      .ConfigureAwait(false);
+    var results = await process2.Serialize(@base, default).ConfigureAwait(false);
 
     objects.Count.ShouldBe(9);
     var x = JObject.Parse(objects["fd4efeb8a036838c53ad1cf9e82b8992"]);

--- a/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
@@ -251,7 +251,7 @@ public class SerializationTests
       new DummyReceiveServerObjectManager(closure),
       null
     );
-    var process = new DeserializeProcess(null, o, new ObjectDeserializerFactory(), new (true));
+    var process = new DeserializeProcess(null, o, new ObjectDeserializerFactory(), new(true));
     var root = await process.Deserialize(rootId, default);
     process.BaseCache.Count.ShouldBe(oldCount);
     process.Total.ShouldBe(oldCount);
@@ -262,7 +262,8 @@ public class SerializationTests
       new DummySqLiteSendManager(),
       new DummySendServerObjectManager(newIdToJson),
       new BaseChildFinder(new BasePropertyGatherer()),
-      new ObjectSerializerFactory(new BasePropertyGatherer()), new SerializeProcessOptions(true, true, false)
+      new ObjectSerializerFactory(new BasePropertyGatherer()),
+      new SerializeProcessOptions(true, true, false)
     );
     var (rootId2, _) = await serializeProcess.Serialize(root, default);
 

--- a/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
@@ -24,7 +24,7 @@ public class SerializationTests
   {
     public Task<(string, IReadOnlyList<string>)> GetAndCache(
       string rootId,
-      DeserializeOptions? options,
+      DeserializeProcessOptions? options,
       CancellationToken cancellationToken
     )
     {
@@ -88,7 +88,7 @@ public class SerializationTests
   {
     public Task<(string, IReadOnlyList<string>)> GetAndCache(
       string rootId,
-      DeserializeOptions? options,
+      DeserializeProcessOptions? options,
       CancellationToken cancellationToken
     )
     {
@@ -251,8 +251,8 @@ public class SerializationTests
       new DummyReceiveServerObjectManager(closure),
       null
     );
-    var process = new DeserializeProcess(null, o, new ObjectDeserializerFactory());
-    var root = await process.Deserialize(rootId, default, new DeserializeOptions(true));
+    var process = new DeserializeProcess(null, o, new ObjectDeserializerFactory(), new (true));
+    var root = await process.Deserialize(rootId, default);
     process.BaseCache.Count.ShouldBe(oldCount);
     process.Total.ShouldBe(oldCount);
 
@@ -262,9 +262,9 @@ public class SerializationTests
       new DummySqLiteSendManager(),
       new DummySendServerObjectManager(newIdToJson),
       new BaseChildFinder(new BasePropertyGatherer()),
-      new ObjectSerializerFactory(new BasePropertyGatherer())
+      new ObjectSerializerFactory(new BasePropertyGatherer()), new SerializeProcessOptions(true, true, false)
     );
-    var (rootId2, _) = await serializeProcess.Serialize(root, default, new SerializeProcessOptions(true, true, false));
+    var (rootId2, _) = await serializeProcess.Serialize(root, default);
 
     rootId2.ShouldBe(root.id);
     newIdToJson.Count.ShouldBe(newCount);

--- a/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
@@ -263,7 +263,7 @@ public class SerializationTests
       new DummySendServerObjectManager(newIdToJson),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
-      new SerializeProcessOptions(true, true, false)
+      new SerializeProcessOptions(true, true, false, true)
     );
     var (rootId2, _) = await serializeProcess.Serialize(root, default);
 

--- a/tests/Speckle.Sdk.Tests.Performance/Benchmarks/GeneralDeserializerTest.cs
+++ b/tests/Speckle.Sdk.Tests.Performance/Benchmarks/GeneralDeserializerTest.cs
@@ -57,8 +57,8 @@ public class GeneralDeserializer : IDisposable
       null
     );
     var o = new ObjectLoader(sqlite, serverObjects, null);
-    var process = new DeserializeProcess(null, o, new ObjectDeserializerFactory());
-    return await process.Deserialize(rootId, default, new(skipCache)).ConfigureAwait(false);
+    var process = new DeserializeProcess(null, o, new ObjectDeserializerFactory(), new(skipCache));
+    return await process.Deserialize(rootId, default).ConfigureAwait(false);
   }
 
   /*


### PR DESCRIPTION
small change to use reduce a list allocation
also adds option to cache by Base.   Could be unnecessary for IFCs