### PR TITLE
bjorn/csi interface

### DIFF
--- a/src/Speckle.Objects/Data/CSiObject.cs
+++ b/src/Speckle.Objects/Data/CSiObject.cs
@@ -1,0 +1,17 @@
+using Speckle.Sdk.Models;
+
+namespace Speckle.Objects.Data;
+
+[SpeckleType("Objects.Data.CSiObject")]
+public class CSiObject : Base, ICSiObject
+{
+  public required string name { get; set; }
+  public required string type { get; set; }
+
+  [DetachProperty]
+  public required List<Base> displayValue { get; set; }
+
+  public required string units { get; set; }
+
+  IReadOnlyList<Base> IDataObject.displayValue => displayValue;
+}

--- a/src/Speckle.Objects/Interfaces.cs
+++ b/src/Speckle.Objects/Interfaces.cs
@@ -159,4 +159,9 @@ public interface ITeklaObject : IDataObject
   [DetachProperty]
   IReadOnlyList<ITeklaObject> elements { get; }
 }
+
+public interface ICSiObject : IDataObject
+{
+  string type { get; }
+}
 #endregion


### PR DESCRIPTION
- Related to [CNX-835](https://linear.app/speckle/issue/CNX-835/add-converter-projects-and-top-level-converter)
- `CSiObject` common for both ETABS and SAP 2000
- cPointObj, cFrameObj, cAreaObj, etc. are all independent objects
- They don't have a native parent-child hierarchy like Tekla or Revit. Relationships (like Points being part of a Frame) exist but these aren't parent-child relationships. No need for `elements`.