### PR TITLE
csi-host-app-versions

### DIFF
--- a/src/Speckle.Sdk/Host/HostAppVersion.cs
+++ b/src/Speckle.Sdk/Host/HostAppVersion.cs
@@ -13,6 +13,8 @@ public enum HostAppVersion
   v2023,
   v2024,
   v2025,
+  v21,
+  v22,
   v25,
   v26,
   v715,


### PR DESCRIPTION
## Description & Motivation
Will need the following for ETABS Next-Gen release:
- support for etabs v21 and v22
- sap 2000 is already covered with v25 and v26