### PR TITLE
Fix sending caching

### DIFF
--- a/src/Speckle.Sdk.Dependencies/Pools.cs
+++ b/src/Speckle.Sdk.Dependencies/Pools.cs
@@ -20,7 +20,6 @@ public static class Pools
 
   public static Pool<StringBuilder> StringBuilders { get; } =
     new(new StringBuilderPooledObjectPolicy() { MaximumRetainedCapacity = 100 * 1024 * 1024 });
-  
-  
+
   public static Pool<List<T>> CreateListPool<T>() => new(new DefaultPooledObjectPolicy<List<T>>());
 }

--- a/src/Speckle.Sdk.Dependencies/Pools.cs
+++ b/src/Speckle.Sdk.Dependencies/Pools.cs
@@ -20,4 +20,7 @@ public static class Pools
 
   public static Pool<StringBuilder> StringBuilders { get; } =
     new(new StringBuilderPooledObjectPolicy() { MaximumRetainedCapacity = 100 * 1024 * 1024 });
+  
+  
+  public static Pool<List<T>> CreateListPool<T>() => new(new DefaultPooledObjectPolicy<List<T>>());
 }

--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
@@ -20,17 +20,17 @@ public abstract class ChannelSaver
   private const int MAX_CACHE_WRITE_PARALLELISM = 1;
   private const int MAX_CACHE_BATCH = 200;
 
-  private readonly Channel<BaseItem> _checkCacheChannel = Channel.CreateBounded<BaseItem>(new BoundedChannelOptions(SEND_CAPACITY)
-  {
-    AllowSynchronousContinuations = true,
-    Capacity = SEND_CAPACITY,
-    SingleWriter = false,
-    SingleReader = false,
-    FullMode = BoundedChannelFullMode.Wait
-  }, x =>
-  {
-    Console.WriteLine($"Channel closed: {x}");
-  });
+  private readonly Channel<BaseItem> _checkCacheChannel = Channel.CreateBounded<BaseItem>(
+    new BoundedChannelOptions(SEND_CAPACITY)
+    {
+      AllowSynchronousContinuations = true,
+      Capacity = SEND_CAPACITY,
+      SingleWriter = false,
+      SingleReader = false,
+      FullMode = BoundedChannelFullMode.Wait,
+    },
+    _ => throw new NotImplementedException("Dropping items not supported.")
+  );
 
   public Task Start(CancellationToken cancellationToken = default)
   {

--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
@@ -8,6 +8,17 @@ namespace Speckle.Sdk.Dependencies.Serialization;
 public readonly record struct BaseItem(string Id, string Json, bool NeedsStorage)
 {
   public int Size { get; } = Encoding.UTF8.GetByteCount(Json);
+
+  public bool Equals(BaseItem? other)
+  {
+    if (other is null)
+    {
+      return false;
+    }
+    return string.Equals(Id, other.Value.Id, StringComparison.OrdinalIgnoreCase);
+  }
+
+  public override int GetHashCode() => Id.GetHashCode();
 }
 
 public abstract class ChannelSaver

--- a/src/Speckle.Sdk/Serialisation/SerializationResult.cs
+++ b/src/Speckle.Sdk/Serialisation/SerializationResult.cs
@@ -10,4 +10,15 @@ public readonly record struct Json(string Value)
 public readonly record struct Id(string Value)
 {
   public override string ToString() => Value;
+
+  public bool Equals(Id? other)
+  {
+    if (other is null)
+    {
+      return false;
+    }
+
+    return string.Equals(Value, other.Value.Value, StringComparison.OrdinalIgnoreCase);
+  }
+  public override int GetHashCode() => Value.GetHashCode();
 }

--- a/src/Speckle.Sdk/Serialisation/SerializationResult.cs
+++ b/src/Speckle.Sdk/Serialisation/SerializationResult.cs
@@ -20,5 +20,6 @@ public readonly record struct Id(string Value)
 
     return string.Equals(Value, other.Value.Value, StringComparison.OrdinalIgnoreCase);
   }
+
   public override int GetHashCode() => Value.GetHashCode();
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
@@ -20,6 +20,7 @@ public class ObjectSerializer : IObjectSerializer
 {
   private HashSet<object> _parentObjects = new();
   private readonly Dictionary<Id, int> _currentClosures = new();
+  private readonly IDictionary<Base, CacheInfo> _baseCache;
 
   private readonly bool _trackDetachedChildren;
   private readonly IBasePropertyGatherer _propertyGatherer;
@@ -40,11 +41,13 @@ public class ObjectSerializer : IObjectSerializer
   /// <param name="cancellationToken"></param>
   public ObjectSerializer(
     IBasePropertyGatherer propertyGatherer,
+    IDictionary<Base, CacheInfo> baseCache,
     bool trackDetachedChildren = false,
     CancellationToken cancellationToken = default
   )
   {
     _propertyGatherer = propertyGatherer;
+    _baseCache = baseCache;
     _cancellationToken = cancellationToken;
     _trackDetachedChildren = trackDetachedChildren;
   }
@@ -66,6 +69,7 @@ public class ObjectSerializer : IObjectSerializer
       {
         throw new SpeckleSerializeException($"Failed to extract (pre-serialize) properties from the {baseObj}", ex);
       }
+      _baseCache[baseObj] = new(item.Item2, _currentClosures);
       yield return (item.Item1, item.Item2);
       foreach (var chunk in _chunks)
       {
@@ -227,14 +231,26 @@ public class ObjectSerializer : IObjectSerializer
     {
       return null;
     }
-
-    var childClosures = isRoot || inheritedDetachInfo.IsDetachable ? _currentClosures : [];
-    var sb = Pools.StringBuilders.Get();
-    using var writer = new StringWriter(sb);
-    using var jsonWriter = SpeckleObjectSerializerPool.Instance.GetJsonTextWriter(writer);
-    var id = SerializeBaseObject(baseObj, jsonWriter, childClosures);
-    var json = new Json(writer.ToString());
-    Pools.StringBuilders.Return(sb);
+    Closures childClosures;
+    Id id;
+    Json json;
+    if (_baseCache.TryGetValue(baseObj, out var info))
+    {
+      id = new Id(baseObj.id.NotNull());
+      childClosures = info.Closures;
+      json = info.Json;
+      MergeClosures(_currentClosures, childClosures);
+    }
+    else
+    {
+      childClosures = isRoot || inheritedDetachInfo.IsDetachable ? _currentClosures : [];
+      var sb = Pools.StringBuilders.Get();
+      using var writer = new StringWriter(sb);
+      using var jsonWriter = SpeckleObjectSerializerPool.Instance.GetJsonTextWriter(writer);
+      id = SerializeBaseObject(baseObj, jsonWriter, childClosures);
+      json = new Json(writer.ToString());
+      Pools.StringBuilders.Return(sb);
+    }
 
     _parentObjects.Remove(baseObj);
 

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
@@ -20,6 +20,7 @@ public class ObjectSerializer : IObjectSerializer
 {
   private HashSet<object> _parentObjects = new();
   private readonly Dictionary<Id, int> _currentClosures = new();
+
   private readonly IDictionary<Base, CacheInfo> _baseCache;
 
   private readonly bool _trackDetachedChildren;
@@ -234,6 +235,7 @@ public class ObjectSerializer : IObjectSerializer
     Closures childClosures;
     Id id;
     Json json;
+    //avoid multiple serialization to get closures
     if (_baseCache.TryGetValue(baseObj, out var info))
     {
       id = new Id(baseObj.id.NotNull());

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializerFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializerFactory.cs
@@ -1,10 +1,11 @@
 using Speckle.InterfaceGenerator;
+using Speckle.Sdk.Models;
 
 namespace Speckle.Sdk.Serialisation.V2.Send;
 
 [GenerateAutoInterface]
 public class ObjectSerializerFactory(IBasePropertyGatherer propertyGatherer) : IObjectSerializerFactory
 {
-  public IObjectSerializer Create(CancellationToken cancellationToken) =>
-    new ObjectSerializer(propertyGatherer, true, cancellationToken);
+  public IObjectSerializer Create(IDictionary<Base, CacheInfo> baseCache, CancellationToken cancellationToken) =>
+    new ObjectSerializer(propertyGatherer, baseCache, true, cancellationToken);
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -28,8 +28,6 @@ public class SerializeProcess(
 {
   private readonly SerializeProcessOptions _options = options ?? new(false, false, false);
   private readonly IDictionary<Base, CacheInfo> _baseCache = new ConcurrentDictionary<Base, CacheInfo>();
-  private readonly ConcurrentDictionary<Id, Json> _idsProcessed = new();
-
   private readonly ConcurrentDictionary<Id, ObjectReference> _objectReferences = new();
   private readonly Pool<List<(Id, Json)>> _pool = Pools.CreateListPool<(Id, Json)>();
 
@@ -107,11 +105,6 @@ public class SerializeProcess(
   //leave this sync
   private IEnumerable<BaseItem> Serialise(Base obj, CancellationToken cancellationToken)
   {
-    Id? id = obj.id != null ? new Id(obj.id) : null;
-    if (id != null && _idsProcessed.ContainsKey(id.Value))
-    {
-      yield break;
-    }
     if (!_options.SkipCacheRead && obj.id != null)
     {
       var cachedJson = sqLiteJsonCacheManager.GetObject(obj.id);
@@ -122,8 +115,6 @@ public class SerializeProcess(
       }
     }
 
-    if (id is null || !_idsProcessed.TryGetValue(id.Value, out var json))
-    {
       var serializer2 = objectSerializerFactory.Create(_baseCache, cancellationToken);
       var items = _pool.Get();
       try
@@ -134,33 +125,17 @@ public class SerializeProcess(
           _objectReferences.TryAdd(kvp.Key, kvp.Value);
         }
 
-        var (_, j) = items.First();
-        json = j;
-        var newId = new Id(obj.id.NotNull());    
-        _idsProcessed.TryAdd(newId, json);
-        yield return CheckCache(newId, json);
-        if (id is not null && id != newId)
-        {
-          //in case the ids changes which is due to id hash algorithm changing
-          _idsProcessed.TryAdd(id.Value, json);
-        }
+        var (id, json) = items.First(); 
+        yield return CheckCache(id, json);
         foreach (var (cid, cJson) in items.Skip(1))
         {
-          if (_idsProcessed.TryAdd(cid, json))
-          {
             yield return CheckCache(cid, cJson);
-          }
         }
       }
       finally
       {
         _pool.Return(items);
       }
-    }  
-    else
-    {
-      yield return new BaseItem(id.NotNull().Value, json.Value, true);
-    }
   }
 
   private BaseItem CheckCache(Id id, Json json)
@@ -182,7 +157,7 @@ public class SerializeProcess(
     {
       await serverObjectManager.UploadObjects(batch, true, progress, cancellationToken).ConfigureAwait(false);
       Interlocked.Exchange(ref _uploaded, _uploaded + batch.Count);
-      progress?.Report(new(ProgressEvent.UploadedObjects, _uploaded, _idsProcessed.Count));
+      progress?.Report(new(ProgressEvent.UploadedObjects, _uploaded, null));
     }
     return batch;
   }
@@ -193,7 +168,7 @@ public class SerializeProcess(
     {
       sqLiteJsonCacheManager.SaveObjects(batch.Select(x => (x.Id, x.Json)));
       Interlocked.Exchange(ref _cached, _cached + batch.Count);
-      progress?.Report(new(ProgressEvent.CachedToLocal, _cached, _idsProcessed.Count));
+      progress?.Report(new(ProgressEvent.CachedToLocal, _cached, null));
     }
   }
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -32,6 +32,8 @@ public class SerializeProcess(
 ) : ChannelSaver, ISerializeProcess
 {
   private readonly SerializeProcessOptions _options = options ?? new(false, false, false, false);
+
+  //cache bases and closure info to avoid reserialization
   private readonly IDictionary<Base, CacheInfo> _baseCache = new ConcurrentDictionary<Base, CacheInfo>();
   private readonly ConcurrentDictionary<Id, ObjectReference> _objectReferences = new();
   private readonly Pool<List<(Id, Json)>> _pool = Pools.CreateListPool<(Id, Json)>();

--- a/tests/Speckle.Sdk.Serialization.Testing/Program.cs
+++ b/tests/Speckle.Sdk.Serialization.Testing/Program.cs
@@ -61,7 +61,7 @@ var process2 = factory.CreateSerializeProcess(
   streamId,
   token,
   progress,
-  new SerializeProcessOptions(skipCacheSendCheck, skipCacheSendSave, true)
+  new SerializeProcessOptions(skipCacheSendCheck, skipCacheSendSave, true, true)
 );
 await process2.Serialize(@base, default).ConfigureAwait(false);
 Console.WriteLine("Detach");

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -74,7 +74,7 @@ public class DetachedTests
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
-      new SerializeProcessOptions(false, false, true)
+      new SerializeProcessOptions(false, false, true, true)
     );
     await process2.Serialize(@base, default).ConfigureAwait(false);
 
@@ -266,7 +266,7 @@ public class DetachedTests
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
-      new SerializeProcessOptions(false, false, true)
+      new SerializeProcessOptions(false, false, true, true)
     );
     var results = await process2.Serialize(@base, default).ConfigureAwait(false);
 

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -386,7 +386,7 @@ public class DummySendCacheManager(Dictionary<string, string> objects) : ISqLite
   {
     foreach (var (id, json) in items)
     {
-      objects.Add(id, json);
+      objects[id] = json;
     }
   }
 }

--- a/tests/Speckle.Sdk.Serialization.Tests/DummySendServerObjectManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DummySendServerObjectManager.cs
@@ -36,15 +36,7 @@ public class DummySendServerObjectManager(ConcurrentDictionary<string, string> s
   {
     foreach (var obj in objects)
     {
-      obj.Id.ShouldBe(JObject.Parse(obj.Json)["id"].NotNull().Value<string>());
-      if (savedObjects.TryGetValue(obj.Id, out var j))
-      {
-        j.ShouldBe(obj.Json);
-      }
-      else
-      {
-        savedObjects.TryAdd(obj.Id, obj.Json);
-      }
+      savedObjects.TryAdd(obj.Id, obj.Json);
     }
     return Task.CompletedTask;
   }

--- a/tests/Speckle.Sdk.Serialization.Tests/DummySendServerObjectManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DummySendServerObjectManager.cs
@@ -24,7 +24,7 @@ public class DummySendServerObjectManager(ConcurrentDictionary<string, string> s
 
   public Task<Dictionary<string, bool>> HasObjects(IReadOnlyList<string> objectIds, CancellationToken cancellationToken)
   {
-    return Task.FromResult(objectIds.ToDictionary(x => x, x => false));
+    return Task.FromResult(objectIds.Distinct().ToDictionary(x => x, savedObjects.ContainsKey));
   }
 
   public Task UploadObjects(

--- a/tests/Speckle.Sdk.Serialization.Tests/ExplicitInterfaceTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExplicitInterfaceTests.cs
@@ -27,7 +27,7 @@ public class ExplicitInterfaceTests
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
-      new SerializeProcessOptions(false, false, true)
+      new SerializeProcessOptions(false, false, true, true)
     );
     await process2.Serialize(testClass, default).ConfigureAwait(false);
     objects.Count.ShouldBe(1);

--- a/tests/Speckle.Sdk.Serialization.Tests/ExternalIdTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExternalIdTests.cs
@@ -26,7 +26,7 @@ public class ExternalIdTests
   public void ExternalIdTest_Detached(string lineId, string valueId)
   {
     var p = new Polyline() { units = "cm", value = [1, 2] };
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), true);
+    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Base, CacheInfo>(), true);
     var list = serializer.Serialize(p).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -53,7 +53,7 @@ public class ExternalIdTests
       knots = [],
       weights = [],
     };
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), true);
+    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Base, CacheInfo>(), true);
     var list = serializer.Serialize(curve).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -81,7 +81,7 @@ public class ExternalIdTests
       weights = [],
     };
     var polycurve = new Polycurve() { segments = [curve], units = "cm" };
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), true);
+    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Base, CacheInfo>(), true);
     var list = serializer.Serialize(polycurve).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -111,7 +111,7 @@ public class ExternalIdTests
     var polycurve = new Polycurve() { segments = [curve], units = "cm" };
     var @base = new Base();
     @base.SetDetachedProp("profile", polycurve);
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), true);
+    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Base, CacheInfo>(), true);
     var list = serializer.Serialize(@base).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];

--- a/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
@@ -263,7 +263,7 @@ public class SerializationTests
       new DummySendServerObjectManager(newIdToJson),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
-      new SerializeProcessOptions(true, true, false)
+      new SerializeProcessOptions(true, true, false, true)
     );
     var (rootId2, _) = await serializeProcess.Serialize(root, default);
 


### PR DESCRIPTION
https://linear.app/speckle/issue/CXPLA-143/sdk-slow-on-caching-and-general-sending

Caches:
- Removed the JSON tracking duplicates cache which seemed to cause slowness via contention on the shared ConcurrentDictionary
- Added back the JSON/Closure cache which sped up serialization

Channels:
- Using bounded channels instead of unbounded seems to have two benefits:
- Allows Readers of the channel to have priority to drain it
- Setting the capacity means a faster list instead of growing and cause a perf hit

Other:
- using a pool for lists when getting items from the serializer
- Using another thread to get total number of items as early as possible
- ConcurrentBag really stinks for Contains