### PR TITLE
Closures are kept for children instead of global

### DIFF
--- a/src/Speckle.Sdk.Dependencies/Pools.cs
+++ b/src/Speckle.Sdk.Dependencies/Pools.cs
@@ -21,5 +21,30 @@ public static class Pools
   public static Pool<StringBuilder> StringBuilders { get; } =
     new(new StringBuilderPooledObjectPolicy() { MaximumRetainedCapacity = 100 * 1024 * 1024 });
 
-  public static Pool<List<T>> CreateListPool<T>() => new(new DefaultPooledObjectPolicy<List<T>>());
+  private sealed class ObjectDictionaryPolicy<TKey, TValue> : IPooledObjectPolicy<Dictionary<TKey, TValue>>
+  where TKey : notnull
+  {
+    public Dictionary<TKey, TValue> Create() => new(50);
+
+    public bool Return(Dictionary<TKey, TValue> obj)
+    {
+      obj.Clear();
+      return true;
+    }
+  } 
+  
+  private sealed class ObjectListPolicy<T> : IPooledObjectPolicy<List<T>>
+  {
+    public List<T> Create() => new(50);
+
+    public bool Return(List<T> obj)
+    {
+      obj.Clear();
+      return true;
+    }
+  } 
+  
+  public static Pool<List<T>> CreateListPool<T>() => new(new ObjectListPolicy<T>());
+  public static Pool<Dictionary<TKey, TValue>> CreateDictionaryPool<TKey, TValue>()  where TKey : notnull => new(new ObjectDictionaryPolicy<TKey, TValue>());
+ 
 }

--- a/src/Speckle.Sdk.Dependencies/Pools.cs
+++ b/src/Speckle.Sdk.Dependencies/Pools.cs
@@ -22,7 +22,7 @@ public static class Pools
     new(new StringBuilderPooledObjectPolicy() { MaximumRetainedCapacity = 100 * 1024 * 1024 });
 
   private sealed class ObjectDictionaryPolicy<TKey, TValue> : IPooledObjectPolicy<Dictionary<TKey, TValue>>
-  where TKey : notnull
+    where TKey : notnull
   {
     public Dictionary<TKey, TValue> Create() => new(50);
 
@@ -31,8 +31,8 @@ public static class Pools
       obj.Clear();
       return true;
     }
-  } 
-  
+  }
+
   private sealed class ObjectListPolicy<T> : IPooledObjectPolicy<List<T>>
   {
     public List<T> Create() => new(50);
@@ -42,9 +42,10 @@ public static class Pools
       obj.Clear();
       return true;
     }
-  } 
-  
+  }
+
   public static Pool<List<T>> CreateListPool<T>() => new(new ObjectListPolicy<T>());
-  public static Pool<Dictionary<TKey, TValue>> CreateDictionaryPool<TKey, TValue>()  where TKey : notnull => new(new ObjectDictionaryPolicy<TKey, TValue>());
- 
+
+  public static Pool<Dictionary<TKey, TValue>> CreateDictionaryPool<TKey, TValue>()
+    where TKey : notnull => new(new ObjectDictionaryPolicy<TKey, TValue>());
 }

--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelExtensions.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelExtensions.cs
@@ -1,18 +1,18 @@
 ﻿using System.Threading.Channels;
 using Open.ChannelExtensions;
-using Speckle.Sdk.Dependencies.Serialization;
 
 namespace Speckle.Sdk.Serialisation.V2.Send;
 
 public static class ChannelExtensions
 {
-  public static BatchingChannelReader<BaseItem, List<BaseItem>> BatchBySize(
-    this ChannelReader<BaseItem> source,
+  public static BatchingChannelReader<T, List<T>> BatchBySize<T>(
+    this ChannelReader<T> source,
     int batchSize,
     bool singleReader = false,
     bool allowSynchronousContinuations = false
-  ) =>
-    new SizeBatchingChannelReader(
+  ) 
+    where T : IHasSize =>
+    new SizeBatchingChannelReader<T>(
       source ?? throw new ArgumentNullException(nameof(source)),
       batchSize,
       singleReader,

--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelExtensions.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelExtensions.cs
@@ -10,7 +10,7 @@ public static class ChannelExtensions
     int batchSize,
     bool singleReader = false,
     bool allowSynchronousContinuations = false
-  ) 
+  )
     where T : IHasSize =>
     new SizeBatchingChannelReader<T>(
       source ?? throw new ArgumentNullException(nameof(source)),

--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelLoader.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelLoader.cs
@@ -2,7 +2,7 @@
 
 namespace Speckle.Sdk.Dependencies.Serialization;
 
-public abstract class ChannelLoader
+public abstract class ChannelLoader<T>
 {
   private const int HTTP_GET_CHUNK_SIZE = 500;
   private const int MAX_PARALLELISM_HTTP = 4;
@@ -27,7 +27,7 @@ public abstract class ChannelLoader
 
   public abstract string? CheckCache(string id);
 
-  public abstract Task<List<BaseItem>> Download(List<string?> ids);
+  public abstract Task<List<T>> Download(List<string?> ids);
 
-  public abstract void SaveToCache(List<BaseItem> x);
+  public abstract void SaveToCache(List<T> x);
 }

--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
@@ -4,9 +4,8 @@ using Speckle.Sdk.Serialisation.V2.Send;
 
 namespace Speckle.Sdk.Dependencies.Serialization;
 
-
 public abstract class ChannelSaver<T>
-where T : IHasSize
+  where T : IHasSize
 {
   private const int SEND_CAPACITY = 50;
   private const int HTTP_SEND_CHUNK_SIZE = 25_000_000; //bytes
@@ -15,7 +14,7 @@ where T : IHasSize
   private const int HTTP_CAPACITY = 50;
   private const int MAX_CACHE_WRITE_PARALLELISM = 1;
   private const int MAX_CACHE_BATCH = 200;
-  
+
   private bool _enabled;
 
   private readonly Channel<T> _checkCacheChannel = Channel.CreateBounded<T>(
@@ -30,7 +29,11 @@ where T : IHasSize
     _ => throw new NotImplementedException("Dropping items not supported.")
   );
 
-  public Task<long> Start(bool enableServerSending = true, bool enableCacheSaving = true, CancellationToken cancellationToken = default)
+  public Task<long> Start(
+    bool enableServerSending = true,
+    bool enableCacheSaving = true,
+    CancellationToken cancellationToken = default
+  )
   {
     ValueTask<long> t = new(Task.FromResult(0L));
     if (enableServerSending)
@@ -48,10 +51,13 @@ where T : IHasSize
         );
       if (enableCacheSaving)
       {
-        t =new (tChannelReader.Join()
-          .Batch(MAX_CACHE_BATCH)
-          .WithTimeout(HTTP_BATCH_TIMEOUT)
-          .ReadAllConcurrently(MAX_CACHE_WRITE_PARALLELISM, SaveToCache, cancellationToken));
+        t = new(
+          tChannelReader
+            .Join()
+            .Batch(MAX_CACHE_BATCH)
+            .WithTimeout(HTTP_BATCH_TIMEOUT)
+            .ReadAllConcurrently(MAX_CACHE_WRITE_PARALLELISM, SaveToCache, cancellationToken)
+        );
       }
       else
       {

--- a/src/Speckle.Sdk.Dependencies/Serialization/SizeBatchingChannelReader.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/SizeBatchingChannelReader.cs
@@ -1,28 +1,32 @@
 using System.Threading.Channels;
 using Open.ChannelExtensions;
-using Speckle.Sdk.Dependencies.Serialization;
 
 namespace Speckle.Sdk.Serialisation.V2.Send;
 
-public class SizeBatchingChannelReader(
-  ChannelReader<BaseItem> source,
+public interface IHasSize
+{
+  int Size { get; }
+}
+public class SizeBatchingChannelReader<T>(
+  ChannelReader<T> source,
   int batchSize,
   bool singleReader,
   bool syncCont = false
-) : BatchingChannelReader<BaseItem, List<BaseItem>>(source, batchSize, singleReader, syncCont)
+) : BatchingChannelReader<T, List<T>>(source, batchSize, singleReader, syncCont)
+where T : IHasSize
 {
   private readonly int _batchSize = batchSize;
 
-  protected override List<BaseItem> CreateBatch(int capacity) => new();
+  protected override List<T> CreateBatch(int capacity) => new();
 
-  protected override void TrimBatch(List<BaseItem> batch) => batch.TrimExcess();
+  protected override void TrimBatch(List<T> batch) => batch.TrimExcess();
 
-  protected override void AddBatchItem(List<BaseItem> batch, BaseItem item) => batch.Add(item);
+  protected override void AddBatchItem(List<T> batch, T item) => batch.Add(item);
 
-  protected override int GetBatchSize(List<BaseItem> batch)
+  protected override int GetBatchSize(List<T> batch)
   {
     int size = 0;
-    foreach (BaseItem item in batch)
+    foreach (T item in batch)
     {
       size += item.Size;
     }

--- a/src/Speckle.Sdk.Dependencies/Serialization/SizeBatchingChannelReader.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/SizeBatchingChannelReader.cs
@@ -7,13 +7,14 @@ public interface IHasSize
 {
   int Size { get; }
 }
+
 public class SizeBatchingChannelReader<T>(
   ChannelReader<T> source,
   int batchSize,
   bool singleReader,
   bool syncCont = false
 ) : BatchingChannelReader<T, List<T>>(source, batchSize, singleReader, syncCont)
-where T : IHasSize
+  where T : IHasSize
 {
   private readonly int _batchSize = batchSize;
 

--- a/src/Speckle.Sdk/Serialisation/V2/DummySendServerObjectManager.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/DummySendServerObjectManager.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text;
-using Speckle.Sdk.Dependencies.Serialization;
+using Speckle.Sdk.Serialisation.V2.Send;
 using Speckle.Sdk.SQLite;
 using Speckle.Sdk.Transports;
 
@@ -49,7 +49,7 @@ public class DummySendServerObjectManager : IServerObjectManager
     long totalBytes = 0;
     foreach (var item in objects)
     {
-      totalBytes += Encoding.Default.GetByteCount(item.Json);
+      totalBytes += Encoding.Default.GetByteCount(item.Json.Value);
     }
 
     progress?.Report(new(ProgressEvent.UploadBytes, totalBytes, totalBytes));

--- a/src/Speckle.Sdk/Serialisation/V2/DummySendServerObjectManager.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/DummySendServerObjectManager.cs
@@ -23,7 +23,7 @@ public class DummySqLiteJsonCacheManager : ISqLiteJsonCacheManager
 public class DummySendServerObjectManager : IServerObjectManager
 {
   public IAsyncEnumerable<(string, string)> DownloadObjects(
-    IReadOnlyList<string> objectIds,
+    IReadOnlyCollection<string> objectIds,
     IProgress<ProgressArgs>? progress,
     CancellationToken cancellationToken
   ) => throw new NotImplementedException();
@@ -35,7 +35,7 @@ public class DummySendServerObjectManager : IServerObjectManager
   ) => throw new NotImplementedException();
 
   public Task<Dictionary<string, bool>> HasObjects(
-    IReadOnlyList<string> objectIds,
+    IReadOnlyCollection<string> objectIds,
     CancellationToken cancellationToken
   ) => throw new NotImplementedException();
 

--- a/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectLoader.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectLoader.cs
@@ -81,7 +81,7 @@ public sealed class ObjectLoader(
       var (id, json) in serverObjectManager.DownloadObjects(ids.Select(x => x.NotNull()).ToList(), progress, default)
     )
     {
-      toCache.Add(new(new (id), new (json), true, null));
+      toCache.Add(new(new(id), new(json), true, null));
     }
 
     if (toCache.Count != ids.Count)

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializer.cs
@@ -15,7 +15,8 @@ namespace Speckle.Sdk.Serialisation.V2.Send;
 
 public readonly record struct NodeInfo(Json Json, Closures? C)
 {
-  public Closures GetClosures() => C ?? ClosureParser.GetClosures( Json.Value ).ToDictionary(x => new Id(x.Item1), x => x.Item2 );
+  public Closures GetClosures() =>
+    C ?? ClosureParser.GetClosures(Json.Value).ToDictionary(x => new Id(x.Item1), x => x.Item2);
 }
 
 public partial interface IObjectSerializer : IDisposable;
@@ -40,10 +41,10 @@ public sealed class ObjectSerializer : IObjectSerializer
 
   private readonly List<(Id, Json, Closures)> _chunks;
   private readonly Pool<List<(Id, Json, Closures)>> _chunksPool;
-  
+
   private readonly List<List<DataChunk>> _chunks2 = new();
   private readonly Pool<List<DataChunk>> _chunks2Pool;
-  
+
   private readonly List<List<object?>> _chunks3 = new();
   private readonly Pool<List<object?>> _chunks3Pool;
 
@@ -55,7 +56,10 @@ public sealed class ObjectSerializer : IObjectSerializer
   public ObjectSerializer(
     IBasePropertyGatherer propertyGatherer,
     IReadOnlyDictionary<Id, NodeInfo> childCache,
-    Pool<List<(Id, Json, Closures)>> chunksPool, Pool<List<DataChunk>> chunks2Pool, Pool<List<object?>> chunks3Pool, bool trackDetachedChildren = false,
+    Pool<List<(Id, Json, Closures)>> chunksPool,
+    Pool<List<DataChunk>> chunks2Pool,
+    Pool<List<object?>> chunks3Pool,
+    bool trackDetachedChildren = false,
     CancellationToken cancellationToken = default
   )
   {
@@ -278,7 +282,7 @@ public sealed class ObjectSerializer : IObjectSerializer
       Id id;
       Json json;
       //avoid multiple serialization to get closures
-      if (baseObj.id != null && _childCache.TryGetValue(new (baseObj.id), out var info))
+      if (baseObj.id != null && _childCache.TryGetValue(new(baseObj.id), out var info))
       {
         id = new Id(baseObj.id);
         childClosures = info.GetClosures();
@@ -306,7 +310,7 @@ public sealed class ObjectSerializer : IObjectSerializer
           applicationId = baseObj.applicationId,
           closure = childClosures.ToDictionary(x => x.Key.Value, x => x.Value),
         };
-      }     
+      }
       _chunks.Add(new(id, json, []));
       return new(id, json2);
     }
@@ -379,14 +383,15 @@ public sealed class ObjectSerializer : IObjectSerializer
     _chunks3.Add(chunk);
     return chunk;
   }
+
   private void SerializeOrChunkProperty(object? baseValue, JsonWriter jsonWriter, PropertyAttributeInfo detachInfo)
   {
     if (baseValue is IEnumerable chunkableCollection && detachInfo.IsChunkable)
     {
       List<DataChunk> chunks = _chunks2Pool.Get();
       _chunks2.Add(chunks);
-      
-      DataChunk crtChunk = new() { data =GetChunk() };
+
+      DataChunk crtChunk = new() { data = GetChunk() };
 
       foreach (object element in chunkableCollection)
       {

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializerFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializerFactory.cs
@@ -11,6 +11,7 @@ public class ObjectSerializerFactory(IBasePropertyGatherer propertyGatherer) : I
   private readonly Pool<List<(Id, Json, Closures)>> _chunkPool = Pools.CreateListPool<(Id, Json, Closures)>();
   private readonly Pool<List<DataChunk>> _chunk2Pool = Pools.CreateListPool<DataChunk>();
   private readonly Pool<List<object?>> _chunk3Pool = Pools.CreateListPool<object?>();
+
   public IObjectSerializer Create(IReadOnlyDictionary<Id, NodeInfo> baseCache, CancellationToken cancellationToken) =>
     new ObjectSerializer(propertyGatherer, baseCache, _chunkPool, _chunk2Pool, _chunk3Pool, true, cancellationToken);
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializerFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializerFactory.cs
@@ -1,11 +1,10 @@
 using Speckle.InterfaceGenerator;
-using Speckle.Sdk.Models;
 
 namespace Speckle.Sdk.Serialisation.V2.Send;
 
 [GenerateAutoInterface]
 public class ObjectSerializerFactory(IBasePropertyGatherer propertyGatherer) : IObjectSerializerFactory
 {
-  public IObjectSerializer Create(IDictionary<Base, CacheInfo> baseCache, CancellationToken cancellationToken) =>
+  public IObjectSerializer Create(IReadOnlyDictionary<Id, NodeInfo> baseCache, CancellationToken cancellationToken) =>
     new ObjectSerializer(propertyGatherer, baseCache, true, cancellationToken);
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializerFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSerializerFactory.cs
@@ -1,10 +1,16 @@
 using Speckle.InterfaceGenerator;
+using Speckle.Sdk.Dependencies;
+using Speckle.Sdk.Models;
+using Closures = System.Collections.Generic.Dictionary<Speckle.Sdk.Serialisation.Id, int>;
 
 namespace Speckle.Sdk.Serialisation.V2.Send;
 
 [GenerateAutoInterface]
 public class ObjectSerializerFactory(IBasePropertyGatherer propertyGatherer) : IObjectSerializerFactory
 {
+  private readonly Pool<List<(Id, Json, Closures)>> _chunkPool = Pools.CreateListPool<(Id, Json, Closures)>();
+  private readonly Pool<List<DataChunk>> _chunk2Pool = Pools.CreateListPool<DataChunk>();
+  private readonly Pool<List<object?>> _chunk3Pool = Pools.CreateListPool<object?>();
   public IObjectSerializer Create(IReadOnlyDictionary<Id, NodeInfo> baseCache, CancellationToken cancellationToken) =>
-    new ObjectSerializer(propertyGatherer, baseCache, true, cancellationToken);
+    new ObjectSerializer(propertyGatherer, baseCache, _chunkPool, _chunk2Pool, _chunk3Pool, true, cancellationToken);
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -169,7 +169,7 @@ public class SerializeProcess(
       }
     }
 
-    var serializer2 = objectSerializerFactory.Create(childInfo, cancellationToken);
+    using var serializer2 = objectSerializerFactory.Create(childInfo, cancellationToken);
     var items = _pool.Get();
     try
     {

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -25,7 +25,6 @@ public readonly record struct SerializeProcessResults(
   IReadOnlyDictionary<Id, ObjectReference> ConvertedReferences
 );
 
-
 public readonly record struct BaseItem(Id Id, Json Json, bool NeedsStorage, Closures? Closures) : IHasSize
 {
   public int Size { get; } = Encoding.UTF8.GetByteCount(Json.Value);
@@ -57,7 +56,6 @@ public class SerializeProcess(
   private readonly ConcurrentDictionary<Id, ObjectReference> _objectReferences = new();
   private readonly Pool<List<(Id, Json, Closures)>> _pool = Pools.CreateListPool<(Id, Json, Closures)>();
   private readonly Pool<Dictionary<Id, NodeInfo>> _childClosurePool = Pools.CreateDictionaryPool<Id, NodeInfo>();
-
 
   private long _objectCount;
   private long _objectsFound;
@@ -130,7 +128,7 @@ public class SerializeProcess(
     }
 
     var items = Serialise(obj, childClosures, cancellationToken);
-    
+
     var currentClosures = new Dictionary<Id, NodeInfo>();
     Interlocked.Increment(ref _objectCount);
     progress?.Report(new(ProgressEvent.FromCacheOrSerialized, _objectCount, _objectsFound));
@@ -157,14 +155,18 @@ public class SerializeProcess(
   }
 
   //leave this sync
-  private IEnumerable<BaseItem> Serialise(Base obj, IReadOnlyDictionary<Id, NodeInfo> childInfo, CancellationToken cancellationToken)
+  private IEnumerable<BaseItem> Serialise(
+    Base obj,
+    IReadOnlyDictionary<Id, NodeInfo> childInfo,
+    CancellationToken cancellationToken
+  )
   {
     if (!_options.SkipCacheRead && obj.id != null)
     {
       var cachedJson = sqLiteJsonCacheManager.GetObject(obj.id);
       if (cachedJson != null)
       {
-        yield return new BaseItem(new (obj.id.NotNull()), new (cachedJson), false, null);
+        yield return new BaseItem(new(obj.id.NotNull()), new(cachedJson), false, null);
         yield break;
       }
     }
@@ -200,7 +202,7 @@ public class SerializeProcess(
       var cachedJson = sqLiteJsonCacheManager.GetObject(id.Value);
       if (cachedJson != null)
       {
-        return new BaseItem(id, new (cachedJson), false, null);
+        return new BaseItem(id, new(cachedJson), false, null);
       }
     }
     return new BaseItem(id, json, true, closures);

--- a/src/Speckle.Sdk/Serialisation/V2/ServerObjectManager.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/ServerObjectManager.cs
@@ -42,7 +42,7 @@ public class ServerObjectManager : IServerObjectManager
   }
 
   public async IAsyncEnumerable<(string, string)> DownloadObjects(
-    IReadOnlyList<string> objectIds,
+    IReadOnlyCollection<string> objectIds,
     IProgress<ProgressArgs>? progress,
     [EnumeratorCancellation] CancellationToken cancellationToken
   )
@@ -139,7 +139,7 @@ public class ServerObjectManager : IServerObjectManager
   }
 
   public async Task<Dictionary<string, bool>> HasObjects(
-    IReadOnlyList<string> objectIds,
+    IReadOnlyCollection<string> objectIds,
     CancellationToken cancellationToken
   )
   {

--- a/src/Speckle.Sdk/Serialisation/V2/ServerObjectManager.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/ServerObjectManager.cs
@@ -5,9 +5,9 @@ using System.Text;
 using Speckle.InterfaceGenerator;
 using Speckle.Newtonsoft.Json;
 using Speckle.Sdk.Common;
-using Speckle.Sdk.Dependencies.Serialization;
 using Speckle.Sdk.Helpers;
 using Speckle.Sdk.Logging;
+using Speckle.Sdk.Serialisation.V2.Send;
 using Speckle.Sdk.Transports;
 using Speckle.Sdk.Transports.ServerUtils;
 

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -336,7 +336,7 @@ public class SamplePropBase2 : Base
 public class DummyServerObjectManager : IServerObjectManager
 {
   public IAsyncEnumerable<(string, string)> DownloadObjects(
-    IReadOnlyList<string> objectIds,
+    IReadOnlyCollection<string> objectIds,
     IProgress<ProgressArgs>? progress,
     CancellationToken cancellationToken
   ) => throw new NotImplementedException();
@@ -348,7 +348,7 @@ public class DummyServerObjectManager : IServerObjectManager
   ) => throw new NotImplementedException();
 
   public Task<Dictionary<string, bool>> HasObjects(
-    IReadOnlyList<string> objectIds,
+    IReadOnlyCollection<string> objectIds,
     CancellationToken cancellationToken
   ) => throw new NotImplementedException();
 
@@ -362,7 +362,7 @@ public class DummyServerObjectManager : IServerObjectManager
     long totalBytes = 0;
     foreach (var item in objects)
     {
-      totalBytes += Encoding.Default.GetByteCount(item.Json);
+      totalBytes += Encoding.Default.GetByteCount(item.Json.Value);
     }
 
     progress?.Report(new(ProgressEvent.UploadBytes, totalBytes, totalBytes));

--- a/tests/Speckle.Sdk.Serialization.Tests/DummyReceiveServerObjectManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DummyReceiveServerObjectManager.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using Speckle.Sdk.Dependencies.Serialization;
 using Speckle.Sdk.Serialisation.V2;
+using Speckle.Sdk.Serialisation.V2.Send;
 using Speckle.Sdk.Transports;
 
 namespace Speckle.Sdk.Serialization.Tests;
@@ -9,7 +10,7 @@ namespace Speckle.Sdk.Serialization.Tests;
 public class DummyReceiveServerObjectManager(Dictionary<string, string> objects) : IServerObjectManager
 {
   public async IAsyncEnumerable<(string, string)> DownloadObjects(
-    IReadOnlyList<string> objectIds,
+    IReadOnlyCollection<string> objectIds,
     IProgress<ProgressArgs>? progress,
     [EnumeratorCancellation] CancellationToken cancellationToken
   )
@@ -32,7 +33,7 @@ public class DummyReceiveServerObjectManager(Dictionary<string, string> objects)
   }
 
   public Task<Dictionary<string, bool>> HasObjects(
-    IReadOnlyList<string> objectIds,
+    IReadOnlyCollection<string> objectIds,
     CancellationToken cancellationToken
   ) => throw new NotImplementedException();
 
@@ -46,7 +47,7 @@ public class DummyReceiveServerObjectManager(Dictionary<string, string> objects)
     long totalBytes = 0;
     foreach (var item in objects)
     {
-      totalBytes += Encoding.Default.GetByteCount(item.Json);
+      totalBytes += Encoding.Default.GetByteCount(item.Json.Value);
     }
 
     progress?.Report(new(ProgressEvent.UploadBytes, totalBytes, totalBytes));

--- a/tests/Speckle.Sdk.Serialization.Tests/DummySendServerObjectManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DummySendServerObjectManager.cs
@@ -4,6 +4,7 @@ using Speckle.Newtonsoft.Json.Linq;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Dependencies.Serialization;
 using Speckle.Sdk.Serialisation.V2;
+using Speckle.Sdk.Serialisation.V2.Send;
 using Speckle.Sdk.Transports;
 
 namespace Speckle.Sdk.Serialization.Tests;
@@ -11,7 +12,7 @@ namespace Speckle.Sdk.Serialization.Tests;
 public class DummySendServerObjectManager(ConcurrentDictionary<string, string> savedObjects) : IServerObjectManager
 {
   public IAsyncEnumerable<(string, string)> DownloadObjects(
-    IReadOnlyList<string> objectIds,
+    IReadOnlyCollection<string> objectIds,
     IProgress<ProgressArgs>? progress,
     CancellationToken cancellationToken
   ) => throw new NotImplementedException();
@@ -22,7 +23,7 @@ public class DummySendServerObjectManager(ConcurrentDictionary<string, string> s
     CancellationToken cancellationToken
   ) => throw new NotImplementedException();
 
-  public Task<Dictionary<string, bool>> HasObjects(IReadOnlyList<string> objectIds, CancellationToken cancellationToken)
+  public Task<Dictionary<string, bool>> HasObjects(IReadOnlyCollection<string> objectIds, CancellationToken cancellationToken)
   {
     return Task.FromResult(objectIds.Distinct().ToDictionary(x => x, savedObjects.ContainsKey));
   }
@@ -36,7 +37,7 @@ public class DummySendServerObjectManager(ConcurrentDictionary<string, string> s
   {
     foreach (var obj in objects)
     {
-      savedObjects.TryAdd(obj.Id, obj.Json);
+      savedObjects.TryAdd(obj.Id.Value, obj.Json.Value);
     }
     return Task.CompletedTask;
   }

--- a/tests/Speckle.Sdk.Serialization.Tests/DummySendServerObjectManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DummySendServerObjectManager.cs
@@ -23,7 +23,10 @@ public class DummySendServerObjectManager(ConcurrentDictionary<string, string> s
     CancellationToken cancellationToken
   ) => throw new NotImplementedException();
 
-  public Task<Dictionary<string, bool>> HasObjects(IReadOnlyCollection<string> objectIds, CancellationToken cancellationToken)
+  public Task<Dictionary<string, bool>> HasObjects(
+    IReadOnlyCollection<string> objectIds,
+    CancellationToken cancellationToken
+  )
   {
     return Task.FromResult(objectIds.Distinct().ToDictionary(x => x, savedObjects.ContainsKey));
   }

--- a/tests/Speckle.Sdk.Serialization.Tests/ExternalIdTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExternalIdTests.cs
@@ -26,7 +26,7 @@ public class ExternalIdTests
   public void ExternalIdTest_Detached(string lineId, string valueId)
   {
     var p = new Polyline() { units = "cm", value = [1, 2] };
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Base, CacheInfo>(), true);
+    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Id, NodeInfo>(), true);
     var list = serializer.Serialize(p).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -53,7 +53,7 @@ public class ExternalIdTests
       knots = [],
       weights = [],
     };
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Base, CacheInfo>(), true);
+    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Id, NodeInfo>(), true);
     var list = serializer.Serialize(curve).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -81,7 +81,7 @@ public class ExternalIdTests
       weights = [],
     };
     var polycurve = new Polycurve() { segments = [curve], units = "cm" };
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Base, CacheInfo>(), true);
+    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Id, NodeInfo>(), true);
     var list = serializer.Serialize(polycurve).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -111,7 +111,7 @@ public class ExternalIdTests
     var polycurve = new Polycurve() { segments = [curve], units = "cm" };
     var @base = new Base();
     @base.SetDetachedProp("profile", polycurve);
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Base, CacheInfo>(), true);
+    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Id, NodeInfo>(), true);
     var list = serializer.Serialize(@base).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];

--- a/tests/Speckle.Sdk.Serialization.Tests/ExternalIdTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExternalIdTests.cs
@@ -26,7 +26,10 @@ public class ExternalIdTests
   public void ExternalIdTest_Detached(string lineId, string valueId)
   {
     var p = new Polyline() { units = "cm", value = [1, 2] };
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Id, NodeInfo>(), true);
+    using var serializer = new ObjectSerializerFactory(new BasePropertyGatherer()).Create(
+      new Dictionary<Id, NodeInfo>(),
+      default
+    );
     var list = serializer.Serialize(p).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -53,7 +56,10 @@ public class ExternalIdTests
       knots = [],
       weights = [],
     };
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Id, NodeInfo>(), true);
+    using var serializer = new ObjectSerializerFactory(new BasePropertyGatherer()).Create(
+      new Dictionary<Id, NodeInfo>(),
+      default
+    );
     var list = serializer.Serialize(curve).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -81,7 +87,10 @@ public class ExternalIdTests
       weights = [],
     };
     var polycurve = new Polycurve() { segments = [curve], units = "cm" };
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Id, NodeInfo>(), true);
+    using var serializer = new ObjectSerializerFactory(new BasePropertyGatherer()).Create(
+      new Dictionary<Id, NodeInfo>(),
+      default
+    );
     var list = serializer.Serialize(polycurve).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];
@@ -111,7 +120,10 @@ public class ExternalIdTests
     var polycurve = new Polycurve() { segments = [curve], units = "cm" };
     var @base = new Base();
     @base.SetDetachedProp("profile", polycurve);
-    var serializer = new ObjectSerializer(new BasePropertyGatherer(), new Dictionary<Id, NodeInfo>(), true);
+    using var serializer = new ObjectSerializerFactory(new BasePropertyGatherer()).Create(
+      new Dictionary<Id, NodeInfo>(),
+      default
+    );
     var list = serializer.Serialize(@base).ToDictionary(x => x.Item1, x => x.Item2);
     list.ContainsKey(new Id(lineId)).ShouldBeTrue();
     var json = list[new Id(lineId)];


### PR DESCRIPTION
- closures are kept only for parents
- no more global collection
- now can pool closures as well as lists for data chunks