### PR TITLE
Fix DataObject inheritance

### DIFF
--- a/src/Speckle.Objects/Data/ArcgisObject.cs
+++ b/src/Speckle.Objects/Data/ArcgisObject.cs
@@ -6,15 +6,9 @@ namespace Speckle.Objects.Data;
 /// Represents a ArcGIS.Core.CoreObjectsBase object in ArcGIS
 /// </summary>
 [SpeckleType("Objects.Data.ArcgisObject")]
-public class ArcgisObject : Base, IGisObject
+public class ArcgisObject : DataObject, IGisObject
 {
-  public required string name { get; set; }
   public required string type { get; set; }
-
-  [DetachProperty]
-  public required List<Base> displayValue { get; set; }
-
-  public required Dictionary<string, object?> properties { get; set; }
 
   public required string units { get; set; }
 

--- a/src/Speckle.Objects/Data/Civil3dObject.cs
+++ b/src/Speckle.Objects/Data/Civil3dObject.cs
@@ -6,9 +6,8 @@ namespace Speckle.Objects.Data;
 /// Represents an Autodesk.Civil.DatabaseServices.Entity object in Civil3d
 /// </summary>
 [SpeckleType("Objects.Data.Civil3dObject")]
-public class Civil3dObject : Base, ICivilObject
+public class Civil3dObject : DataObject, ICivilObject
 {
-  public required string name { get; set; }
   public required string type { get; set; }
 
   /// <summary>
@@ -22,14 +21,7 @@ public class Civil3dObject : Base, ICivilObject
   [DetachProperty]
   public required List<Base> elements { get; set; }
 
-  [DetachProperty]
-  public required List<Base> displayValue { get; set; }
-
-  public required Dictionary<string, object?> properties { get; set; }
-
   public required string units { get; set; }
 
   IReadOnlyList<Base> ICivilObject.elements => elements;
-
-  IReadOnlyList<Base> IDisplayValue<IReadOnlyList<Base>>.displayValue => displayValue;
 }

--- a/src/Speckle.Objects/Data/EtabsObject.cs
+++ b/src/Speckle.Objects/Data/EtabsObject.cs
@@ -6,9 +6,8 @@ namespace Speckle.Objects.Data;
 /// Represents a wrapper object in ETABS
 /// </summary>
 [SpeckleType("Objects.Data.EtabsObject")]
-public class EtabsObject : Base, ICsiObject
+public class EtabsObject : DataObject, ICsiObject
 {
-  public required string name { get; set; }
   public required string type { get; set; }
 
   /// <summary>
@@ -16,11 +15,6 @@ public class EtabsObject : Base, ICsiObject
   /// </summary>
   [DetachProperty]
   public required List<EtabsObject> elements { get; set; }
-
-  [DetachProperty]
-  public required List<Base> displayValue { get; set; }
-
-  public required Dictionary<string, object?> properties { get; set; }
 
   public required string units { get; set; }
 

--- a/src/Speckle.Objects/Data/NavisworksObject.cs
+++ b/src/Speckle.Objects/Data/NavisworksObject.cs
@@ -6,15 +6,8 @@ namespace Speckle.Objects.Data;
 /// Represents a "first selectable ancestor" Navisworks.ModelItem object in Navisworks
 /// </summary>
 [SpeckleType("Objects.Data.NavisworksObject")]
-public class NavisworksObject : Base, INavisworksObject
+public class NavisworksObject : DataObject, INavisworksObject
 {
-  public required string name { get; set; }
-
-  [DetachProperty]
-  public required List<Base> displayValue { get; set; }
-
-  public required Dictionary<string, object?> properties { get; set; }
-
   public required string units { get; set; }
 
   IReadOnlyList<Base> IDisplayValue<IReadOnlyList<Base>>.displayValue => displayValue;

--- a/src/Speckle.Objects/Data/RevitObject.cs
+++ b/src/Speckle.Objects/Data/RevitObject.cs
@@ -1,4 +1,3 @@
-using Speckle.Objects.Geometry;
 using Speckle.Sdk.Models;
 
 namespace Speckle.Objects.Data;
@@ -7,9 +6,8 @@ namespace Speckle.Objects.Data;
 /// Represents an Autodesk.Revit.DB.Element object in Revit
 /// </summary>
 [SpeckleType("Objects.Data.RevitObject")]
-public class RevitObject : Base, IRevitObject
+public class RevitObject : DataObject, IRevitObject
 {
-  public required string name { get; set; }
   public required string type { get; set; }
   public required string family { get; set; }
   public required string category { get; set; }
@@ -25,14 +23,7 @@ public class RevitObject : Base, IRevitObject
   [DetachProperty]
   public required List<RevitObject> elements { get; set; }
 
-  [DetachProperty]
-  public required List<Mesh> displayValue { get; set; }
-
-  public required Dictionary<string, object?> properties { get; set; }
-
   public required string units { get; set; }
 
   IReadOnlyList<IRevitObject> IRevitObject.elements => elements;
-
-  IReadOnlyList<Base> IDisplayValue<IReadOnlyList<Base>>.displayValue => displayValue;
 }

--- a/src/Speckle.Objects/Data/TeklaObject.cs
+++ b/src/Speckle.Objects/Data/TeklaObject.cs
@@ -6,9 +6,8 @@ namespace Speckle.Objects.Data;
 /// Represents an Tekla.Structures.Model.ModelObject object in Tekla Structures
 /// </summary>
 [SpeckleType("Objects.Data.TeklaObject")]
-public class TeklaObject : Base, ITeklaObject
+public class TeklaObject : DataObject, ITeklaObject
 {
-  public required string name { get; set; }
   public required string type { get; set; }
 
   /// <summary>
@@ -16,11 +15,6 @@ public class TeklaObject : Base, ITeklaObject
   /// </summary>
   [DetachProperty]
   public required List<TeklaObject> elements { get; set; }
-
-  [DetachProperty]
-  public required List<Base> displayValue { get; set; }
-
-  public required Dictionary<string, object?> properties { get; set; }
 
   public required string units { get; set; }
 

--- a/src/Speckle.Objects/Interfaces.cs
+++ b/src/Speckle.Objects/Interfaces.cs
@@ -126,7 +126,7 @@ public interface IProperties : ISpeckleObject
   Dictionary<string, object?> properties { get; }
 }
 
-public interface IDataObject : ISpeckleObject, IProperties, IDisplayValue<IReadOnlyList<Base>>
+public interface IDataObject : IProperties, IDisplayValue<IReadOnlyList<Base>>
 {
   /// <summary>
   /// The name of the object, primarily used to decorate the object for consumption in frontend and other apps


### PR DESCRIPTION
All objects should inherit from DataObject too because IDataObject is inherited.  Converters currently use classes instead of interfaces for resolution

Why do we have interfaces too?