### PR TITLE
Use CancellationSource to properly dispose of threads in PriorityScheduler

### DIFF
--- a/src/Speckle.Sdk/Serialisation/V2/Send/PriorityScheduler.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/PriorityScheduler.cs
@@ -3,7 +3,7 @@
 namespace Speckle.Sdk.Serialisation.V2.Send;
 
 public sealed class PriorityScheduler(ThreadPriority priority, int maximumConcurrencyLevel) : TaskScheduler, IDisposable
-{ 
+{
   private readonly CancellationTokenSource _cancellationTokenSource = new();
   private readonly BlockingCollection<Task> _tasks = new();
   private Thread[]? _threads;
@@ -15,7 +15,6 @@ public sealed class PriorityScheduler(ThreadPriority priority, int maximumConcur
     _tasks.Dispose();
     _cancellationTokenSource.Dispose();
   }
- 
 
   public override int MaximumConcurrencyLevel => maximumConcurrencyLevel;
 


### PR DESCRIPTION
references https://stackoverflow.com/questions/9106419/how-to-cancel-getconsumingenumerable-on-blockingcollection