### PR TITLE
add a task.yield for a cached model to let progress happen

### DIFF
--- a/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectLoader.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectLoader.cs
@@ -43,6 +43,9 @@ public sealed class ObjectLoader(
       {
         //assume everything exists as the root is there.
         var allChildren = ClosureParser.GetChildrenIds(rootJson).ToList();
+        //this probably yields away from the Main thread to let host apps update progress
+        //in any case, this fixes a Revit only issue for this situation
+        await Task.Yield();
         return (rootJson, allChildren);
       }
     }


### PR DESCRIPTION
adding this seems to fix a Revit only issue of updating deserialization progress when the model is cached locally