### PR TITLE
First pass increasing test coverage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -254,8 +254,7 @@ dotnet_diagnostic.ca1506.severity = warning # Avoid excessive class coupling
 dotnet_diagnostic.ca1507.severity = warning # Use nameof in place of string
 dotnet_diagnostic.ca1508.severity = warning # Avoid dead conditional code
 dotnet_diagnostic.ca1509.severity = warning # Invalid entry in code metrics configuration file
-dotnet_diagnostic.ca1861.severity = none # Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861)
-
+dotnet_diagnostic.ca1861.severity = suggestion # Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861)
 
 
 # Performance rules

--- a/Speckle.Sdk.sln.DotSettings
+++ b/Speckle.Sdk.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=QL/@EntryIndexedValue">QL</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=QL/@EntryIndexedValue">QL</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=XYZ/@EntryIndexedValue">XYZ</s:String></wpf:ResourceDictionary>

--- a/src/Speckle.Objects/Geometry/Vector.cs
+++ b/src/Speckle.Objects/Geometry/Vector.cs
@@ -86,15 +86,9 @@ public class Vector : Base, IHasBoundingBox, ITransformable<Vector>
   /// Returns the coordinates of this <see cref="Vector"/> as a list of numbers
   /// </summary>
   /// <returns>A list of coordinates {x, y, z} </returns>
-  public List<double> ToList()
-  {
-    return new List<double> { x, y, z };
-  }
+  public List<double> ToList() => [x, y, z];
 
-  public Point ToPoint()
-  {
-    return new Point(x, y, z, units, applicationId);
-  }
+  public Point ToPoint() => new(x, y, z, units, applicationId);
 
   /// <summary>
   /// Creates a new vector based on a list of coordinates and the unit they're drawn in.
@@ -176,11 +170,6 @@ public class Vector : Base, IHasBoundingBox, ITransformable<Vector>
     return new Vector(x, y, z, units: u.units);
   }
 
-  public static double Angle(Vector u, Vector v)
-  {
-    return Math.Acos(DotProduct(u, v) / (u.Length * v.Length));
-  }
-
   /// <summary>
   /// Compute and return a unit vector from this vector
   /// </summary>
@@ -204,23 +193,6 @@ public class Vector : Base, IHasBoundingBox, ITransformable<Vector>
     z *= -1;
     return this;
   }
-
-  /// <summary>
-  /// Returns a normalized copy of this vector.
-  /// </summary>
-  /// <returns>A copy of this vector unitized.</returns>
-  public Vector Unit()
-  {
-    return this / Length;
-  }
-
-  /// <summary>
-  /// Constructs a new <see cref="Vector"/> from a <see cref="Point"/>
-  /// </summary>
-  /// <param name="point">The point whose coordinates will be used</param>
-  /// <param name="applicationId">The unique application ID of the object.</param>
-  [Obsolete($"Use {nameof(Point.ToVector)}", true)]
-  public Vector(Point point, string? applicationId = null) { }
 
   /// <summary>
   /// Gets or sets the coordinates of the vector

--- a/src/Speckle.Sdk/Common/Units.cs
+++ b/src/Speckle.Sdk/Common/Units.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.Contracts;
+using Speckle.Sdk.Dependencies;
 
 namespace Speckle.Sdk.Common;
 
@@ -19,7 +20,7 @@ public static class Units
   /// <summary>US Survey foot, now not supported by Speckle, kept privately for backwards compatibility</summary>
   private const string USFeet = "us_ft";
 
-  internal static readonly List<string> SupportedUnits = new()
+  internal static readonly IReadOnlyCollection<string> SupportedUnits = new[]
   {
     Millimeters,
     Centimeters,
@@ -30,7 +31,7 @@ public static class Units
     Yards,
     Miles,
     None,
-  };
+  }.Freeze();
 
   /// <param name="unit"></param>
   /// <returns><see langword="true"/> if <paramref name="unit"/> is a recognised/supported unit string, otherwise <see langword="false"/></returns>

--- a/tests/Speckle.Objects.Tests.Unit/Geometry/MeshTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Geometry/MeshTests.cs
@@ -6,22 +6,7 @@ namespace Speckle.Objects.Tests.Unit.Geometry;
 
 public class MeshTests
 {
-  private static readonly Mesh[] TestCaseSource = { CreateBlenderStylePolygon(), CreateRhinoStylePolygon() };
-
-  [Theory]
-  [MemberData(nameof(GetTestCaseSource))]
-  public void CanAlignVertices(Mesh inPolygon)
-  {
-    inPolygon.AlignVerticesWithTexCoordsByIndex();
-
-    inPolygon.VerticesCount.Should().Be(inPolygon.TextureCoordinatesCount);
-
-    var expectedPolygon = CreateRhinoStylePolygon();
-
-    inPolygon.vertices.Should().BeEquivalentTo(expectedPolygon.vertices);
-    inPolygon.faces.Should().BeEquivalentTo(expectedPolygon.faces);
-    inPolygon.textureCoordinates.Should().BeEquivalentTo(expectedPolygon.textureCoordinates);
-  }
+  private static readonly Mesh[] TestCaseSource = { CreateRhinoStylePolygon(), CreateEmpty() };
 
   public static IEnumerable<object[]> GetTestCaseSource() => TestCaseSource.Select(mesh => new object[] { mesh });
 
@@ -36,14 +21,51 @@ public class MeshTests
     };
   }
 
-  private static Mesh CreateBlenderStylePolygon()
+  private static Mesh CreateEmpty()
   {
     return new Mesh
     {
-      vertices = new List<double> { 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 0 },
-      faces = new List<int> { 3, 0, 1, 2, 3, 0, 2, 3 },
-      textureCoordinates = new List<double> { 0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0 },
+      vertices = [],
+      faces = [],
+      textureCoordinates = [],
       units = Units.Meters,
     };
+  }
+
+  [Theory]
+  [MemberData(nameof(GetTestCaseSource))]
+  public void GetTextureCoordinate_ReturnsCorrectUVValue(Mesh testCase)
+  {
+    for (int i = 0, j = 0; i < testCase.textureCoordinates.Count; i += 2, j++)
+    {
+      var (u, v) = testCase.GetTextureCoordinate(j);
+
+      u.Should().Be(testCase.textureCoordinates[i]);
+      v.Should().Be(testCase.textureCoordinates[i + 1]);
+    }
+
+    Assert.Throws<ArgumentOutOfRangeException>(() => testCase.GetTextureCoordinate(testCase.textureCoordinates.Count));
+  }
+
+  [Theory]
+  [MemberData(nameof(GetTestCaseSource))]
+  public void GetPoints_ReturnsVerticesAsPoints(Mesh testCase)
+  {
+    testCase.VerticesCount.Should().Be(testCase.vertices.Count / 3);
+
+    var getPoints = testCase.GetPoints();
+    var getPoint = Enumerable.Range(0, testCase.VerticesCount).Select(i => testCase.GetPoint(i));
+
+    //Test each point has correct units
+    getPoints.Select(x => x.units).Should().AllBe(testCase.units).And.HaveCount(testCase.VerticesCount);
+    getPoints.Select(x => x.units).Should().AllBe(testCase.units).And.HaveCount(testCase.VerticesCount);
+
+    //Convert back to flat list
+    var expected = testCase.vertices;
+    var getPointsList = getPoints.SelectMany(x => x.ToList());
+    var getPointList = getPoint.SelectMany(x => x.ToList());
+
+    getPointsList.Should().BeEquivalentTo(expected);
+    getPointList.Should().BeEquivalentTo(expected);
   }
 }

--- a/tests/Speckle.Objects.Tests.Unit/Geometry/PointTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Geometry/PointTests.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using Speckle.DoubleNumerics;
 using Speckle.Objects.Geometry;
+using Speckle.Objects.Other;
 using Speckle.Sdk.Common;
 
 namespace Speckle.Objects.Tests.Unit.Geometry;
@@ -63,5 +65,84 @@ public class PointTests
     Point p2 = new(x2, y2, z2, units2);
 
     (p1 == p2).Should().Be(expectedResult);
+  }
+
+  [Fact]
+  public void TestDistanceTo()
+  {
+    //Arrange
+    var p1 = new Point(1, 0, 0, units: Units.Meters);
+    var p2 = new Point(0, 0, 0, units: Units.Meters);
+
+    //Act
+    var result = p1.DistanceTo(p2);
+
+    //Assert
+    result.Should().Be(1);
+  }
+
+  private static IReadOnlyList<Matrix4x4> MatrixTestData =>
+    [
+      Matrix4x4.Identity,
+      Matrix4x4.CreateScale(1, 2, 3),
+      Matrix4x4.CreateTranslation(100, 10, 0),
+      Matrix4x4.CreateRotationZ(1),
+    ];
+
+  private static IReadOnlyList<Point> PointTestData =>
+    [
+      new(1, 2, 3, Units.Meters),
+      new(0.5, 100.5, 123.123, Units.Meters),
+      new(1, 2, 3, Units.Meters, applicationId: "Test me!"),
+      new(0, 0, 0, Units.Feet),
+    ];
+
+  public static IEnumerable<object> TransformTestCases =>
+    Enumerable.Range(0, PointTestData.Count).Select(i => new object[] { MatrixTestData[i], PointTestData[i] });
+
+  [Theory]
+  [MemberData(nameof(TransformTestCases))]
+  public void TransformPoint_SameUnits(Matrix4x4 matrix, Point point)
+  {
+    //Arrange
+    Transform t = new() { matrix = Matrix4x4.Transpose(matrix), units = point.units };
+
+    Vector3 expectedVector = Vector3.Transform(new(point.x, point.y, point.z), matrix);
+    var expectedResult = (expectedVector.X, expectedVector.Y, expectedVector.Z);
+
+    //Act
+    point.TransformTo(t, out Point transformedPoint);
+    var actualResult = (transformedPoint.x, transformedPoint.y, transformedPoint.z);
+
+    //Assert
+    actualResult.Should().Be(expectedResult);
+    transformedPoint.applicationId.Should().Be(point.applicationId);
+
+    transformedPoint.applicationId.Should().Be(point.applicationId);
+    transformedPoint.id.Should().Be(point.id);
+    transformedPoint.units.Should().Be(point.units);
+  }
+
+  [Fact(Skip = "Something clearly wrong with units!!!")]
+  public void TransformingPoint_ChangeOfUnits()
+  {
+    //Arrange
+    Point point = new(0, 0, 10, Units.Meters);
+    Transform t = new()
+    {
+      matrix = Matrix4x4.Transpose(Matrix4x4.CreateTranslation(1000, 0, 0)),
+      units = Units.Millimeters,
+    };
+    Vector3 expected = new(1, 0, 10);
+
+    //Act
+    point.TransformTo(t, out Point transformedPoint);
+
+    //Assert
+    (double x, double y, double z) = transformedPoint;
+    transformedPoint.units.Should().Be(point.units);
+    transformedPoint.applicationId.Should().Be(point.applicationId);
+
+    new Vector3(x, y, z).Should().Be(expected);
   }
 }

--- a/tests/Speckle.Objects.Tests.Unit/Geometry/PointTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Geometry/PointTests.cs
@@ -97,8 +97,17 @@ public class PointTests
       new(0, 0, 0, Units.Feet),
     ];
 
-  public static IEnumerable<object> TransformTestCases =>
-    Enumerable.Range(0, PointTestData.Count).Select(i => new object[] { MatrixTestData[i], PointTestData[i] });
+  public static TheoryData<Point> PointTestCases() => new(PointTestData);
+
+  public static TheoryData<Matrix4x4, Point> TransformTestCases()
+  {
+    TheoryData<Matrix4x4, Point> testCases = new();
+    for (int i = 0; i < PointTestData.Count; i++)
+    {
+      testCases.Add(MatrixTestData[i], PointTestData[i]);
+    }
+    return testCases;
+  }
 
   [Theory]
   [MemberData(nameof(TransformTestCases))]
@@ -144,5 +153,44 @@ public class PointTests
     transformedPoint.applicationId.Should().Be(point.applicationId);
 
     new Vector3(x, y, z).Should().Be(expected);
+  }
+
+  [Theory]
+  [MemberData(nameof(PointTestCases))]
+  public void ToVector(Point testCase)
+  {
+    var expectedXYZ = (testCase.x, testCase.y, testCase.z);
+    var expectedUnits = testCase.units;
+    var expectedApplicationId = testCase.applicationId;
+
+    var asVector = testCase.ToVector();
+    var resultXYZ = (asVector.x, asVector.y, asVector.z);
+
+    resultXYZ.Should().Be(expectedXYZ);
+    asVector.units.Should().Be(expectedUnits);
+    asVector.applicationId.Should().Be(expectedApplicationId);
+  }
+
+  [Theory]
+  [MemberData(nameof(PointTestCases))]
+  public void Deconstruct_Double_Double_Double_String(Point testCase)
+  {
+    (double x, double y, double z, string? units) = testCase;
+
+    x.Should().Be(testCase.x);
+    y.Should().Be(testCase.y);
+    z.Should().Be(testCase.z);
+    units.Should().Be(testCase.units);
+  }
+
+  [Theory]
+  [MemberData(nameof(PointTestCases))]
+  public void Deconstruct_Double_Double_Double(Point testCase)
+  {
+    (double x, double y, double z) = testCase;
+
+    x.Should().Be(testCase.x);
+    y.Should().Be(testCase.y);
+    z.Should().Be(testCase.z);
   }
 }

--- a/tests/Speckle.Objects.Tests.Unit/Geometry/VectorTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Geometry/VectorTests.cs
@@ -8,15 +8,16 @@ public class VectorTests
 {
   private const float FLOAT_TOLERANCE = 1e-6f;
 
-  public static IReadOnlyList<object[]> TestCases() =>
-    [
-      [0d, 0d, 0d, "m"],
-      [1d, 2d, 3d, "ft"],
-      [0d, 0d, -1d, "km"],
-      [100d, 0d, -200d, "in"],
-      [123.123d, 456.456d, 5789.789d, "cm"],
-      [-123.123d, -456.456d, -5789.789d, "mm"],
-    ];
+  public static TheoryData<double, double, double, string> TestCases() =>
+    new()
+    {
+      { 0d, 0d, 0d, "m" },
+      { 1d, 2d, 3d, "ft" },
+      { 0d, 0d, -1d, "km" },
+      { 100d, 0d, -200d, "in" },
+      { 123.123d, 456.456d, 5789.789d, "cm" },
+      { -123.123d, -456.456d, -5789.789d, "mm" },
+    };
 
   [Theory]
   [MemberData(nameof(TestCases))]

--- a/tests/Speckle.Objects.Tests.Unit/Geometry/VectorTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Geometry/VectorTests.cs
@@ -1,0 +1,232 @@
+﻿using FluentAssertions;
+using Speckle.DoubleNumerics;
+using Speckle.Objects.Geometry;
+
+namespace Speckle.Objects.Tests.Unit.Geometry;
+
+public class VectorTests
+{
+  private const float FLOAT_TOLERANCE = 1e-6f;
+
+  public static IReadOnlyList<object[]> TestCases() =>
+    [
+      [0d, 0d, 0d, "m"],
+      [1d, 2d, 3d, "ft"],
+      [0d, 0d, -1d, "km"],
+      [100d, 0d, -200d, "in"],
+      [123.123d, 456.456d, 5789.789d, "cm"],
+      [-123.123d, -456.456d, -5789.789d, "mm"],
+    ];
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  public void Constructors_AreTheSame(double x, double y, double z, string units)
+  {
+    const string appId = "asdfasdfasdf";
+    var pctor = new Vector(x, y, z, units, applicationId: appId);
+
+    pctor.x.Should().Be(x);
+    pctor.y.Should().Be(y);
+    pctor.z.Should().Be(z);
+    pctor.units.Should().Be(units);
+    pctor.applicationId.Should().Be(appId);
+
+    var init = new Vector
+    {
+      x = x,
+      y = y,
+      z = z,
+      units = units,
+      applicationId = appId,
+    };
+
+    Assert.Equal(pctor.x, init.x);
+    Assert.Equal(pctor.y, init.y);
+    Assert.Equal(pctor.z, init.z);
+    Assert.Equal(pctor.units, init.units);
+    Assert.Equal(pctor.applicationId, init.applicationId);
+  }
+
+  [Theory]
+  [InlineData(1d, 0d, 0d, 1d)]
+  [InlineData(0d, 2d, 0d, 2d)]
+  [InlineData(0d, 0d, -3d, 3d)]
+  [InlineData(1d, 1d, 0d, 1.4142135623730951d)]
+  public void LengthCalculated(double x, double y, double z, double expected)
+  {
+    var testCase = new Vector(x, y, z, "");
+    var actual = testCase.Length;
+    actual.Should().Be(expected);
+  }
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  public void EncodingToAndFromList(double x, double y, double z, string units)
+  {
+    var testCase = new Vector(x, y, z, units);
+
+    var encoded = testCase.ToList();
+    encoded.Should().BeEquivalentTo([x, y, z]);
+
+    const string NEW_UNIT = "something different...";
+    var decoded = Vector.FromList(encoded, NEW_UNIT);
+
+    decoded.x.Should().Be(x);
+    decoded.y.Should().Be(y);
+    decoded.z.Should().Be(z);
+    decoded.units.Should().Be(NEW_UNIT);
+  }
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  public void ToPoint(double x, double y, double z, string units)
+  {
+    var testCase = new Vector(x, y, z, units, "asdfasdf");
+
+    var asPoint = testCase.ToPoint();
+
+    asPoint.x.Should().Be(x);
+    asPoint.y.Should().Be(y);
+    asPoint.z.Should().Be(z);
+    asPoint.units.Should().Be(units);
+    asPoint.applicationId.Should().Be("asdfasdf");
+  }
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  public void Normalize(double x, double y, double z, string units)
+  {
+    var sut = new Vector(x, y, z, units);
+    var originalLength = sut.Length;
+    sut.Normalize();
+
+    if (!(originalLength > 0))
+    {
+      sut.Length.Should().Be(double.NaN);
+      return;
+    }
+
+    sut.Length.Should().BeApproximately(1, FLOAT_TOLERANCE);
+
+    var rescaled = sut * originalLength;
+
+    rescaled.x.Should().BeApproximately(x, FLOAT_TOLERANCE);
+    rescaled.y.Should().BeApproximately(y, FLOAT_TOLERANCE);
+    rescaled.z.Should().BeApproximately(z, FLOAT_TOLERANCE);
+    rescaled.units.Should().Be(units);
+  }
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  public void Negate(double x, double y, double z, string units)
+  {
+    var sut = new Vector(x, y, z, units);
+    var originalLength = sut.Length;
+    sut.Negate();
+
+    sut.Length.Should().Be(originalLength);
+    var rescaled = sut.Negate();
+
+    rescaled.x.Should().BeApproximately(x, FLOAT_TOLERANCE);
+    rescaled.y.Should().BeApproximately(y, FLOAT_TOLERANCE);
+    rescaled.z.Should().BeApproximately(z, FLOAT_TOLERANCE);
+    rescaled.units.Should().Be(units);
+  }
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  public void TestAddition(double x, double y, double z, string units)
+  {
+    var operand1 = new Vector(x, y, z, units);
+    var operand2 = new Vector(x, y, z, units);
+
+    var result = operand1 + operand2;
+    double[] expected = [x + x, y + y, z + z];
+
+    result.ToList().Should().BeEquivalentTo(expected);
+    result.units.Should().BeEquivalentTo(units);
+  }
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  public void TestSubtraction(double x, double y, double z, string units)
+  {
+    var operand1 = new Vector(x, y, z, units);
+    var operand2 = new Vector(x, y, z, units);
+
+    var result = operand1 - operand2;
+    double[] expected = [x - x, y - y, z - z];
+
+    result.ToList().Should().BeEquivalentTo(expected);
+    result.units.Should().BeEquivalentTo(units);
+  }
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  public void TestDivision(double x, double y, double z, string units)
+  {
+    var operand1 = new Vector(x, y, z, units);
+    const int OPERAND2 = 2;
+
+    var result = operand1 / OPERAND2;
+    double[] expected = [x / OPERAND2, y / OPERAND2, z / OPERAND2];
+
+    result.ToList().Should().BeEquivalentTo(expected);
+    result.units.Should().BeEquivalentTo(units);
+  }
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  public void TestMultiplication(double x, double y, double z, string units)
+  {
+    var operand1 = new Vector(x, y, z, units);
+    const int OPERAND2 = 2;
+
+    var result = operand1 * OPERAND2;
+    double[] expected = [x * OPERAND2, y * OPERAND2, z * OPERAND2];
+
+    result.ToList().Should().BeEquivalentTo(expected);
+    result.units.Should().BeEquivalentTo(units);
+  }
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  public void TestDotProduct(double x, double y, double z, string units)
+  {
+    var operand1 = new Vector(x, y, z, units);
+    var operand2 = new Vector(x, y, z, units);
+
+    var result = Vector.DotProduct(operand1, operand2);
+    double expected = Vector3.Dot(new Vector3(x, y, z), new Vector3(x, y, z));
+
+    result.Should().BeApproximately(expected, FLOAT_TOLERANCE);
+  }
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  public void TestCrossProduct(double x, double y, double z, string units)
+  {
+    var operand1 = new Vector(x, y, z, units);
+    var operand2 = new Vector(x, y, z, units);
+
+    var result = Vector.CrossProduct(operand1, operand2);
+    var expected = Vector3.Cross(new Vector3(x, y, z), new Vector3(x, y, z));
+
+    result.x.Should().BeApproximately(expected.X, FLOAT_TOLERANCE);
+    result.y.Should().BeApproximately(expected.Y, FLOAT_TOLERANCE);
+    result.z.Should().BeApproximately(expected.Z, FLOAT_TOLERANCE);
+  }
+
+  [Theory]
+  [MemberData(nameof(TestCases))]
+  [Obsolete("Tests Obsolete legacy behaviour to maintain backwards json compatibility with ~2.13? data")]
+  public void TestLegacyValueProp(double x, double y, double z, string _)
+  {
+    var vector = Activator.CreateInstance<Vector>();
+    vector.value = [x, y, z];
+
+    vector.x.Should().Be(x);
+    vector.y.Should().Be(y);
+    vector.z.Should().Be(z);
+  }
+}

--- a/tests/Speckle.Sdk.Tests.Unit/Common/UnitsTest.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Common/UnitsTest.cs
@@ -8,11 +8,9 @@ public class UnitsTest
 {
   private const double EPS = 0.00022;
 
-  public static List<string> OfficiallySupportedUnits => Units.SupportedUnits;
-
-  public static List<string> NotSupportedUnits => ["feeters", "liters", "us_ft"];
-
-  public static List<string?> ConversionSupport => Units.SupportedUnits.Concat([null]).ToList();
+  public static IReadOnlyCollection<string> OfficiallySupportedUnits => Units.SupportedUnits;
+  public static IReadOnlyCollection<string> NotSupportedUnits => ["feeters", "liters", "us_ft"];
+  public static IReadOnlyCollection<string?> ConversionSupport => [.. Units.SupportedUnits, null];
 
   [Theory]
   [MemberData(nameof(ConversionSupportGenerator))]


### PR DESCRIPTION
Added some tests for `Point`, `Vector`, and `Mesh`
I'm skiping the `TransformTo` functions for now, since they contain some bugs/undefined behaviour r.e. units
I'm also skipping the `ToList` and `FromList` functions, since they are unused (originally for Brep encoding), Perhaps we should strip these out?

There's a couple changes here other than tests & docs
1. Removed the hacky `AlignVerticesWithTexCoordsByIndex` functions from `Mesh`
2. Removed the unused `Angle` and `Unit` function from `Vector`