### PR TITLE
Add exception handling for SerializeProcess with tests

### DIFF
--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
@@ -61,9 +61,7 @@ public abstract class ChannelSaver<T>
       await SendToServer((Batch<T>)batch, cancellationTokenSource.Token).ConfigureAwait(false);
       return batch;
     }
-#pragma warning disable CA1031
     catch (Exception)
-#pragma warning restore CA1031
     {
       cancellationTokenSource.Cancel(true);
       throw;
@@ -84,9 +82,7 @@ public abstract class ChannelSaver<T>
     {
       SaveToCache(item);
     }
-#pragma warning disable CA1031
     catch (Exception)
-#pragma warning restore CA1031
     {
       cancellationTokenSource.Cancel(true);
       throw;

--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
@@ -59,14 +59,15 @@ public abstract class ChannelSaver<T>
     try
     {
       await SendToServer((Batch<T>)batch, cancellationTokenSource.Token).ConfigureAwait(false);
+      return batch;
     }
 #pragma warning disable CA1031
     catch (Exception)
 #pragma warning restore CA1031
     {
       cancellationTokenSource.Cancel(true);
+      throw;
     }
-    return batch;
   }
 
   public abstract Task SendToServer(Batch<T> batch, CancellationToken cancellationToken);
@@ -88,6 +89,7 @@ public abstract class ChannelSaver<T>
 #pragma warning restore CA1031
     {
       cancellationTokenSource.Cancel(true);
+      throw;
     }
   }
 

--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
@@ -59,13 +59,14 @@ public abstract class ChannelSaver<T>
     try
     {
       await SendToServer((Batch<T>)batch, cancellationTokenSource.Token).ConfigureAwait(false);
-      return batch;
     }
+#pragma warning disable CA1031
     catch (Exception)
+#pragma warning restore CA1031
     {
       cancellationTokenSource.Cancel(true);
-      throw;
     }
+    return batch;
   }
 
   public abstract Task SendToServer(Batch<T> batch, CancellationToken cancellationToken);
@@ -82,10 +83,11 @@ public abstract class ChannelSaver<T>
     {
       SaveToCache(item);
     }
+#pragma warning disable CA1031
     catch (Exception)
+#pragma warning restore CA1031
     {
       cancellationTokenSource.Cancel(true);
-      throw;
     }
   }
 

--- a/src/Speckle.Sdk/Serialisation/V2/Send/PriorityScheduler.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/PriorityScheduler.cs
@@ -1,8 +1,13 @@
 using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
 
 namespace Speckle.Sdk.Serialisation.V2.Send;
 
-public sealed class PriorityScheduler(ThreadPriority priority, int maximumConcurrencyLevel) : TaskScheduler, IDisposable
+public sealed class PriorityScheduler(
+  ILogger<PriorityScheduler> logger,
+  ThreadPriority priority,
+  int maximumConcurrencyLevel
+) : TaskScheduler, IDisposable
 {
   private readonly CancellationTokenSource _cancellationTokenSource = new();
   private readonly BlockingCollection<Task> _tasks = new();
@@ -47,10 +52,10 @@ public sealed class PriorityScheduler(ThreadPriority priority, int maximumConcur
             }
           }
 #pragma warning disable CA1031
-          catch (Exception)
+          catch (Exception e)
 #pragma warning restore CA1031
           {
-            // ignored
+            logger.LogError(e, "{name} had an exception", Thread.CurrentThread.Name);
           }
         })
         {

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -99,7 +99,7 @@ public sealed class SerializeProcess(
       throw new OperationCanceledException();
     }
     //last chance to see if user cancelled
-    cancellationToken.ThrowIfCancellationRequested(); 
+    cancellationToken.ThrowIfCancellationRequested();
     return new(root.id.NotNull(), _objectReferences.Freeze());
   }
 

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -95,6 +95,7 @@ public sealed class SerializeProcess(
     await findTotalObjectsTask.ConfigureAwait(false);
     if (source.IsCancellationRequested)
     {
+      //this means we really want to stop but exceptions haven't bubbled up yet so don't let us continue if cancelled
       throw new OperationCanceledException();
     }
     return new(root.id.NotNull(), _objectReferences.Freeze());

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -253,7 +253,9 @@ public sealed class SerializeProcess(
         progress?.Report(new(ProgressEvent.UploadedObjects, _uploaded, null));
       }
     }
+#pragma warning disable CA1031
     catch (Exception e)
+#pragma warning restore CA1031
     {
       _logger.LogError(e, "Error sending objects to server");
       throw;
@@ -271,7 +273,9 @@ public sealed class SerializeProcess(
         progress?.Report(new(ProgressEvent.CachedToLocal, _cached, _objectsSerialized));
       }
     }
+#pragma warning disable CA1031
     catch (Exception e)
+#pragma warning restore CA1031
     {
       _logger.LogError(e, "Error sending objects to server");
       throw;

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -93,6 +93,10 @@ public sealed class SerializeProcess(
     await Done().ConfigureAwait(true);
     await channelTask.ConfigureAwait(false);
     await findTotalObjectsTask.ConfigureAwait(false);
+    if (source.IsCancellationRequested)
+    {
+      throw new OperationCanceledException();
+    }
     return new(root.id.NotNull(), _objectReferences.Freeze());
   }
 

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -44,7 +44,7 @@ public sealed class SerializeProcess(
   private readonly PriorityScheduler _belowNormal = new(
     loggerFactory.CreateLogger<PriorityScheduler>(),
     ThreadPriority.BelowNormal,
-    Environment.ProcessorCount *2
+    Environment.ProcessorCount * 2
   );
 
   private readonly SerializeProcessOptions _options = options ?? new(false, false, false, false);

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -98,6 +98,8 @@ public sealed class SerializeProcess(
       //this means we really want to stop but exceptions haven't bubbled up yet so don't let us continue if cancelled
       throw new OperationCanceledException();
     }
+    //last chance to see if user cancelled
+    cancellationToken.ThrowIfCancellationRequested(); 
     return new(root.id.NotNull(), _objectReferences.Freeze());
   }
 

--- a/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Speckle.Sdk.Serialisation.V2.Receive;
 using Speckle.Sdk.Serialisation.V2.Send;
 using Speckle.Sdk.SQLite;
@@ -28,7 +29,8 @@ public class SerializeProcessFactory(
   IObjectSerializerFactory objectSerializerFactory,
   IObjectDeserializerFactory objectDeserializerFactory,
   ISqLiteJsonCacheManagerFactory sqLiteJsonCacheManagerFactory,
-  IServerObjectManagerFactory serverObjectManagerFactory
+  IServerObjectManagerFactory serverObjectManagerFactory,
+  ILoggerFactory loggerFactory
 ) : ISerializeProcessFactory
 {
   public ISerializeProcess CreateSerializeProcess(
@@ -47,6 +49,7 @@ public class SerializeProcessFactory(
       serverObjectManager,
       baseChildFinder,
       objectSerializerFactory,
+      loggerFactory,
       options
     );
   }

--- a/tests/Speckle.Sdk.Serialization.Testing/Program.cs
+++ b/tests/Speckle.Sdk.Serialization.Testing/Program.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CA1506
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Speckle.Sdk;
 using Speckle.Sdk.Credentials;
 using Speckle.Sdk.Host;
@@ -45,7 +46,8 @@ var factory = new SerializeProcessFactory(
   new ObjectSerializerFactory(new BasePropertyGatherer()),
   new ObjectDeserializerFactory(),
   serviceProvider.GetRequiredService<ISqLiteJsonCacheManagerFactory>(),
-  serviceProvider.GetRequiredService<IServerObjectManagerFactory>()
+  serviceProvider.GetRequiredService<IServerObjectManagerFactory>(),
+  new NullLoggerFactory()
 );
 var process = factory.CreateDeserializeProcess(new Uri(url), streamId, token, progress, new(skipCacheReceive));
 var @base = await process.Deserialize(rootId, default).ConfigureAwait(false);

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -305,7 +305,7 @@ public class DummyServerObjectManager : IServerObjectManager
   public Task<Dictionary<string, bool>> HasObjects(
     IReadOnlyCollection<string> objectIds,
     CancellationToken cancellationToken
-  ) => throw new NotImplementedException();
+  ) => Task.FromResult(objectIds.ToDictionary(x => x, _ => false));
 
   public Task UploadObjects(
     IReadOnlyList<BaseItem> objects,

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Speckle.Newtonsoft.Json.Linq;
 using Speckle.Objects.Geometry;
 using Speckle.Sdk.Host;
@@ -37,6 +38,7 @@ public class DetachedTests
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
+      new NullLoggerFactory(),
       new SerializeProcessOptions(false, false, true, true)
     );
     await process2.Serialize(@base, default);
@@ -120,6 +122,7 @@ public class DetachedTests
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
+      new NullLoggerFactory(),
       new SerializeProcessOptions(false, false, true, true)
     );
     var results = await process2.Serialize(@base, default);
@@ -188,6 +191,7 @@ public class DetachedTests
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
+      new NullLoggerFactory(),
       new SerializeProcessOptions(false, false, true, true)
     );
     var results = await process2.Serialize(@base, default);
@@ -221,6 +225,7 @@ public class DetachedTests
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
+      new NullLoggerFactory(),
       new SerializeProcessOptions(false, false, true, true)
     );
     var results = await process2.Serialize(@base, default);

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Cache.verified.json
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Cache.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "Type": "AggregateException",
+  "InnerException": {
+    "Data": {},
+    "Message": "The method or operation is not implemented.",
+    "StackTrace": "at Speckle.Sdk.Serialization.Tests.ExceptionSendCacheManager.SaveObjects(IEnumerable`1 items)\nat Speckle.Sdk.Serialisation.V2.Send.SerializeProcess.SaveToCache(List`1 batch)\nat Open.ChannelExtensions.<28d3e838-dde6-44a1-8f5e-d1c739a178d0>Extensions.<>c__DisplayClass98_0`1.<ReadAllConcurrently>b__0(T e)\nat Open.ChannelExtensions.<28d3e838-dde6-44a1-8f5e-d1c739a178d0>Extensions.<>c__DisplayClass92_0`1.<ReadAllConcurrentlyAsync>b__2(T item, Int64 _)\nat Open.ChannelExtensions.<28d3e838-dde6-44a1-8f5e-d1c739a178d0>Extensions.ReadUntilCancelledAsync[T](<5e816acc-9cf8-4b52-a8da-ceb5bd7eecc7>ChannelReader`1 reader, CancellationToken cancellationToken, Func`3 receiver, Boolean deferredExecution)\n--- End of stack trace from previous location ---",
+    "Type": "NotImplementedException"
+  },
+  "StackTrace": "at Speckle.Sdk.Dependencies.Serialization.ChannelSaver`1.DoneSaving()\nat Speckle.Sdk.Serialisation.V2.Send.SerializeProcess.Serialize(Base root, CancellationToken cancellationToken)\n--- End of stack trace from previous location ---\nat Xunit.Assert.RecordExceptionAsync(Func`1 testCode)"
+}

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Upload.verified.json
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Upload.verified.json
@@ -1,0 +1,30 @@
+﻿{
+  "Type": "AggregateException",
+  "InnerExceptions": [
+    {
+      "Data": {},
+      "Message": "The method or operation is not implemented.",
+      "StackTrace": "at Speckle.Sdk.Serialization.Tests.ExceptionServerObjectManager.HasObjects(IReadOnlyCollection`1 objectIds, CancellationToken cancellationToken)\nat Speckle.Sdk.Serialisation.V2.Send.SerializeProcess.SendToServer(Batch`1 batch, CancellationToken cancellationToken)\nat Speckle.Sdk.Dependencies.Serialization.ChannelSaver`1.SendToServer(IMemoryOwner`1 batch, CancellationToken cancellationToken)\n--- End of stack trace from previous location ---\n--- End of stack trace from previous location ---\nat Open.ChannelExtensions.<28d3e838-dde6-44a1-8f5e-d1c739a178d0>Extensions.ReadUntilCancelledAsync[T](<5e816acc-9cf8-4b52-a8da-ceb5bd7eecc7>ChannelReader`1 reader, CancellationToken cancellationToken, Func`3 receiver, Boolean deferredExecution)\n--- End of stack trace from previous location ---",
+      "Type": "NotImplementedException"
+    },
+    {
+      "Data": {},
+      "Message": "The method or operation is not implemented.",
+      "StackTrace": "at Speckle.Sdk.Serialization.Tests.ExceptionServerObjectManager.HasObjects(IReadOnlyCollection`1 objectIds, CancellationToken cancellationToken)\nat Speckle.Sdk.Serialisation.V2.Send.SerializeProcess.SendToServer(Batch`1 batch, CancellationToken cancellationToken)\nat Speckle.Sdk.Dependencies.Serialization.ChannelSaver`1.SendToServer(IMemoryOwner`1 batch, CancellationToken cancellationToken)\n--- End of stack trace from previous location ---\n--- End of stack trace from previous location ---\nat Open.ChannelExtensions.<28d3e838-dde6-44a1-8f5e-d1c739a178d0>Extensions.ReadUntilCancelledAsync[T](<5e816acc-9cf8-4b52-a8da-ceb5bd7eecc7>ChannelReader`1 reader, CancellationToken cancellationToken, Func`3 receiver, Boolean deferredExecution)\n--- End of stack trace from previous location ---",
+      "Type": "NotImplementedException"
+    },
+    {
+      "Data": {},
+      "Message": "The method or operation is not implemented.",
+      "StackTrace": "at Speckle.Sdk.Serialization.Tests.ExceptionServerObjectManager.HasObjects(IReadOnlyCollection`1 objectIds, CancellationToken cancellationToken)\nat Speckle.Sdk.Serialisation.V2.Send.SerializeProcess.SendToServer(Batch`1 batch, CancellationToken cancellationToken)\nat Speckle.Sdk.Dependencies.Serialization.ChannelSaver`1.SendToServer(IMemoryOwner`1 batch, CancellationToken cancellationToken)\n--- End of stack trace from previous location ---\n--- End of stack trace from previous location ---\nat Open.ChannelExtensions.<28d3e838-dde6-44a1-8f5e-d1c739a178d0>Extensions.ReadUntilCancelledAsync[T](<5e816acc-9cf8-4b52-a8da-ceb5bd7eecc7>ChannelReader`1 reader, CancellationToken cancellationToken, Func`3 receiver, Boolean deferredExecution)\n--- End of stack trace from previous location ---",
+      "Type": "NotImplementedException"
+    },
+    {
+      "Data": {},
+      "Message": "The method or operation is not implemented.",
+      "StackTrace": "at Speckle.Sdk.Serialization.Tests.ExceptionServerObjectManager.HasObjects(IReadOnlyCollection`1 objectIds, CancellationToken cancellationToken)\nat Speckle.Sdk.Serialisation.V2.Send.SerializeProcess.SendToServer(Batch`1 batch, CancellationToken cancellationToken)\nat Speckle.Sdk.Dependencies.Serialization.ChannelSaver`1.SendToServer(IMemoryOwner`1 batch, CancellationToken cancellationToken)\n--- End of stack trace from previous location ---\n--- End of stack trace from previous location ---\nat Open.ChannelExtensions.<28d3e838-dde6-44a1-8f5e-d1c739a178d0>Extensions.ReadUntilCancelledAsync[T](<5e816acc-9cf8-4b52-a8da-ceb5bd7eecc7>ChannelReader`1 reader, CancellationToken cancellationToken, Func`3 receiver, Boolean deferredExecution)\n--- End of stack trace from previous location ---",
+      "Type": "NotImplementedException"
+    }
+  ],
+  "StackTrace": "at Speckle.Sdk.Dependencies.Serialization.ChannelSaver`1.DoneSaving()\nat Speckle.Sdk.Serialisation.V2.Send.SerializeProcess.Serialize(Base root, CancellationToken cancellationToken)\n--- End of stack trace from previous location ---\nat Xunit.Assert.RecordExceptionAsync(Func`1 testCode)"
+}

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Speckle.Objects.Geometry;
+using Speckle.Sdk.Host;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Serialisation.V2;
+using Speckle.Sdk.Serialisation.V2.Send;
+using Speckle.Sdk.Transports;
+
+namespace Speckle.Sdk.Serialization.Tests;
+
+public class ExceptionTests
+{
+  public ExceptionTests()
+  {
+    TypeLoader.Reset();
+    TypeLoader.Initialize(typeof(Base).Assembly, typeof(DetachedTests).Assembly, typeof(Polyline).Assembly);
+  }
+
+  [Fact]
+  public async Task Test_Exceptions()
+  {
+    var testClass = new TestClass() { RegularProperty = "Hello" };
+
+    var objects = new Dictionary<string, string>();
+    using var process2 = new SerializeProcess(
+      null,
+      new DummySendCacheManager(objects),
+      new ExceptionServerObjectManager(),
+      new BaseChildFinder(new BasePropertyGatherer()),
+      new ObjectSerializerFactory(new BasePropertyGatherer()),
+      new NullLoggerFactory(),
+      new SerializeProcessOptions(false, false, false, true)
+    );
+
+    await Assert.ThrowsAsync<OperationCanceledException>(async () => await process2.Serialize(testClass, default));
+  }
+}
+
+public class ExceptionServerObjectManager : IServerObjectManager
+{
+  public IAsyncEnumerable<(string, string)> DownloadObjects(
+    IReadOnlyCollection<string> objectIds,
+    IProgress<ProgressArgs>? progress,
+    CancellationToken cancellationToken
+  ) => throw new NotImplementedException();
+
+  public Task<string?> DownloadSingleObject(
+    string objectId,
+    IProgress<ProgressArgs>? progress,
+    CancellationToken cancellationToken
+  ) => throw new NotImplementedException();
+
+  public Task<Dictionary<string, bool>> HasObjects(
+    IReadOnlyCollection<string> objectIds,
+    CancellationToken cancellationToken
+  ) => throw new NotImplementedException();
+
+  public Task UploadObjects(
+    IReadOnlyList<BaseItem> objects,
+    bool compressPayloads,
+    IProgress<ProgressArgs>? progress,
+    CancellationToken cancellationToken
+  ) => throw new NotImplementedException();
+}

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
@@ -33,7 +33,7 @@ public class ExceptionTests
       new SerializeProcessOptions(false, false, false, true)
     );
 
-    await Assert.ThrowsAsync<OperationCanceledException>(async () => await process2.Serialize(testClass, default));
+    await Assert.ThrowsAsync<AggregateException>(async () => await process2.Serialize(testClass, default));
   }
 
   [Fact]
@@ -51,7 +51,7 @@ public class ExceptionTests
       new SerializeProcessOptions(false, false, false, true)
     );
 
-    await Assert.ThrowsAsync<OperationCanceledException>(async () => await process2.Serialize(testClass, default));
+    await Assert.ThrowsAsync<AggregateException>(async () => await process2.Serialize(testClass, default));
   }
 }
 

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
@@ -33,7 +33,9 @@ public class ExceptionTests
       new SerializeProcessOptions(false, false, false, true)
     );
 
-    await Assert.ThrowsAsync<AggregateException>(async () => await process2.Serialize(testClass, default));
+    //4 exceptions are fine because we use 4 threads for saving cache
+    var ex = await Assert.ThrowsAsync<AggregateException>(async () => await process2.Serialize(testClass, default));
+    await Verify(ex);
   }
 
   [Fact]
@@ -51,7 +53,8 @@ public class ExceptionTests
       new SerializeProcessOptions(false, false, false, true)
     );
 
-    await Assert.ThrowsAsync<AggregateException>(async () => await process2.Serialize(testClass, default));
+    var ex = await Assert.ThrowsAsync<AggregateException>(async () => await process2.Serialize(testClass, default));
+    await Verify(ex);
   }
 }
 

--- a/tests/Speckle.Sdk.Serialization.Tests/ExplicitInterfaceTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExplicitInterfaceTests.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.Sdk.Host;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Speckle.Sdk.Host;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Serialisation.V2.Send;
 
@@ -24,6 +25,7 @@ public class ExplicitInterfaceTests
       new DummyServerObjectManager(),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
+      new NullLoggerFactory(),
       new SerializeProcessOptions(false, false, true, true)
     );
 

--- a/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.IO.Compression;
 using System.Reflection;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Speckle.Newtonsoft.Json;
 using Speckle.Newtonsoft.Json.Linq;
 using Speckle.Objects.Data;
@@ -265,6 +266,7 @@ public class SerializationTests
       new DummySendServerObjectManager(newIdToJson),
       new BaseChildFinder(new BasePropertyGatherer()),
       new ObjectSerializerFactory(new BasePropertyGatherer()),
+      new NullLoggerFactory(),
       new SerializeProcessOptions(true, true, false, true)
     );
     var (rootId2, _) = await serializeProcess.Serialize(root, default);

--- a/tests/Speckle.Sdk.Serialization.Tests/Speckle.Sdk.Serialization.Tests.csproj
+++ b/tests/Speckle.Sdk.Serialization.Tests/Speckle.Sdk.Serialization.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="altcover" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+    <PackageReference Include="xunit.assert" />
     <PackageReference Include="xunit.runner.visualstudio"/>
   </ItemGroup>
 

--- a/tests/Speckle.Sdk.Serialization.Tests/packages.lock.json
+++ b/tests/Speckle.Sdk.Serialization.Tests/packages.lock.json
@@ -55,6 +55,12 @@
         "resolved": "0.9.6",
         "contentHash": "HKH7tYrYYlCK1ct483hgxERAdVdMtl7gUKW9ijWXxA1UsYR4Z+TrRHYmzZ9qmpu1NnTycSrp005NYM78GDKV1w=="
       },
+      "xunit.assert": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
       "xunit.runner.visualstudio": {
         "type": "Direct",
         "requested": "[3.0.1, )",


### PR DESCRIPTION
When exceptions happened, UnobservedTaskException would be called and/or threads would freeze.

Now exceptions are handled and the process is stopped via CancellationTokenSource.  The better what would be via faulted Tasks but they don't work.  Currently, there is no difference between manual cancellation and exceptions.

Exceptions are logged with the logger.