### PR TITLE
Use priority scheduler like serialize process to constrain Task enqueuing

### DIFF
--- a/src/Speckle.Sdk/Serialisation/V2/PriorityScheduler.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/PriorityScheduler.cs
@@ -1,7 +1,7 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 
-namespace Speckle.Sdk.Serialisation.V2.Send;
+namespace Speckle.Sdk.Serialisation.V2;
 
 public sealed class PriorityScheduler(
   ILogger<PriorityScheduler> logger,

--- a/src/Speckle.Sdk/Serialisation/V2/Receive/DeserializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/DeserializeProcess.cs
@@ -46,7 +46,7 @@ public sealed class DeserializeProcess(
   public void Dispose()
   {
     objectLoader.Dispose();
-    _belowNormal.Dispose(); 
+    _belowNormal.Dispose();
   }
 
   /// <summary>

--- a/src/Speckle.Sdk/Serialisation/V2/Receive/DeserializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/DeserializeProcess.cs
@@ -1,8 +1,10 @@
 using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
 using Speckle.InterfaceGenerator;
 using Speckle.Sdk.Dependencies;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Serialisation.Utilities;
+using Speckle.Sdk.Serialisation.V2.Send;
 using Speckle.Sdk.Transports;
 
 namespace Speckle.Sdk.Serialisation.V2.Receive;
@@ -21,10 +23,17 @@ public sealed class DeserializeProcess(
   IProgress<ProgressArgs>? progress,
   IObjectLoader objectLoader,
   IBaseDeserializer baseDeserializer,
+  ILoggerFactory loggerFactory,
   CancellationToken cancellationToken,
   DeserializeProcessOptions? options = null
 ) : IDeserializeProcess
 {
+  private readonly PriorityScheduler _belowNormal = new(
+    loggerFactory.CreateLogger<PriorityScheduler>(),
+    ThreadPriority.BelowNormal,
+    Environment.ProcessorCount * 2,
+    cancellationToken
+  );
   private readonly DeserializeProcessOptions _options = options ?? new();
 
   private readonly ConcurrentDictionary<Id, (Json, IReadOnlyCollection<Id>)> _closures = new();
@@ -35,7 +44,11 @@ public sealed class DeserializeProcess(
   public long Total { get; private set; }
 
   [AutoInterfaceIgnore]
-  public void Dispose() => objectLoader.Dispose();
+  public void Dispose()
+  {
+    objectLoader.Dispose();
+    _belowNormal.Dispose(); 
+  }
 
   /// <summary>
   /// All meaningful ids in the upcoming version
@@ -94,7 +107,7 @@ public sealed class DeserializeProcess(
             () => Traverse(tmpId),
             cancellationToken,
             TaskCreationOptions.AttachedToParent | TaskCreationOptions.PreferFairness,
-            TaskScheduler.Default
+            _belowNormal
           )
           .Unwrap();
         tasks.Add(t);

--- a/src/Speckle.Sdk/Serialisation/V2/Receive/DeserializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/DeserializeProcess.cs
@@ -4,7 +4,6 @@ using Speckle.InterfaceGenerator;
 using Speckle.Sdk.Dependencies;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Serialisation.Utilities;
-using Speckle.Sdk.Serialisation.V2.Send;
 using Speckle.Sdk.Transports;
 
 namespace Speckle.Sdk.Serialisation.V2.Receive;

--- a/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
@@ -74,6 +74,7 @@ public class SerializeProcessFactory(
     //owned by process, refactor later
     var objectLoader = new ObjectLoader(sqLiteJsonCacheManager, serverObjectManager, progress);
 #pragma warning restore CA2000
-    return new DeserializeProcess(progress, objectLoader, baseDeserializer, cancellationToken, options);
+    return new DeserializeProcess(progress, objectLoader, baseDeserializer, 
+      loggerFactory,cancellationToken, options);
   }
 }

--- a/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
@@ -74,7 +74,6 @@ public class SerializeProcessFactory(
     //owned by process, refactor later
     var objectLoader = new ObjectLoader(sqLiteJsonCacheManager, serverObjectManager, progress);
 #pragma warning restore CA2000
-    return new DeserializeProcess(progress, objectLoader, baseDeserializer, 
-      loggerFactory,cancellationToken, options);
+    return new DeserializeProcess(progress, objectLoader, baseDeserializer, loggerFactory, cancellationToken, options);
   }
 }

--- a/tests/Speckle.Sdk.Serialization.Tests/CancellationTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/CancellationTests.cs
@@ -107,6 +107,7 @@ public class CancellationTests
       null,
       o,
       new BaseDeserializer(new ObjectDeserializerFactory()),
+      new NullLoggerFactory(),
       cancellationSource.Token,
       new(MaxParallelism: 1)
     );
@@ -137,6 +138,7 @@ public class CancellationTests
       null,
       o,
       new BaseDeserializer(new ObjectDeserializerFactory()),
+      new NullLoggerFactory(),
       cancellationSource.Token,
       new(MaxParallelism: 1)
     );
@@ -167,6 +169,7 @@ public class CancellationTests
       null,
       o,
       new CancellationBaseDeserializer(cancellationSource),
+      new NullLoggerFactory(),
       cancellationSource.Token,
       new(MaxParallelism: 1)
     );

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
@@ -72,6 +72,7 @@ public class ExceptionTests
       null,
       o,
       new BaseDeserializer(new ObjectDeserializerFactory()),
+      new NullLoggerFactory(),
       default,
       new(true, MaxParallelism: 1)
     );
@@ -100,6 +101,7 @@ public class ExceptionTests
       null,
       o,
       new BaseDeserializer(new ObjectDeserializerFactory()),
+      new NullLoggerFactory(),
       default,
       new(MaxParallelism: 1)
     );

--- a/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/SerializationTests.cs
@@ -119,6 +119,7 @@ public class SerializationTests
       null,
       new TestObjectLoader(closures),
       new BaseDeserializer(new ObjectDeserializerFactory()),
+      new NullLoggerFactory(),
       default
     );
     await process.Deserialize("3416d3fe01c9196115514c4a2f41617b");
@@ -218,6 +219,7 @@ public class SerializationTests
       null,
       o,
       new BaseDeserializer(new ObjectDeserializerFactory()),
+      new NullLoggerFactory(),
       default,
       new(true)
     );


### PR DESCRIPTION
Things like CEF get overwhelmed by the enqueuing of Tasks on the default scheduler.  Use the custom PriorityScheduler instead.