### PR TITLE
gql api changes

### DIFF
--- a/src/Speckle.Sdk/Api/GraphQL/Models/Comment.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Models/Comment.cs
@@ -1,4 +1,6 @@
-﻿namespace Speckle.Sdk.Api.GraphQL.Models;
+﻿using Speckle.Newtonsoft.Json;
+
+namespace Speckle.Sdk.Api.GraphQL.Models;
 
 public sealed class Comment
 {
@@ -17,4 +19,33 @@ public sealed class Comment
   public DateTime updatedAt { get; init; }
   public DateTime? viewedAt { get; init; }
   public List<ViewerResourceItem> viewerResources { get; init; }
+  public SerializedViewerState viewerState { get; init; }
+}
+
+/// <summary>
+/// See <c>SerializedViewerState</c> in <a href="https://github.com/specklesystems/speckle-server/blob/main/packages/shared/src/viewer/helpers/state.ts">/shared/src/viewer/helpers/state.ts</a>
+/// </summary>
+/// <remarks>
+/// Note, there are many FE/Viewer specific properties on this object that are not reflected here (hence the <see cref="MissingMemberHandling"/> override)
+/// We can add them as needed, keeping in mind flexiblity for breaking changes (these classes are intentionally not documented in our schema!)
+/// </remarks>
+[JsonObject(MissingMemberHandling = MissingMemberHandling.Ignore)]
+public sealed class SerializedViewerState
+{
+  public ViewerStateUI ui { get; init; }
+}
+
+[JsonObject(MissingMemberHandling = MissingMemberHandling.Ignore)]
+public sealed class ViewerStateUI
+{
+  public ViewerStateCamera camera { get; init; }
+}
+
+[JsonObject(MissingMemberHandling = MissingMemberHandling.Ignore)]
+public sealed class ViewerStateCamera
+{
+  public List<double> position { get; init; }
+  public List<double> target { get; init; }
+  public bool isOrthoProjection { get; init; }
+  public double zoom { get; init; }
 }

--- a/src/Speckle.Sdk/Api/GraphQL/Models/SubscriptionMessages.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Models/SubscriptionMessages.cs
@@ -77,7 +77,8 @@ public sealed class ProjectVersionsUpdatedMessage : EventArgs
   [JsonRequired]
   public ProjectVersionsUpdatedMessageType type { get; init; }
 
-  public string? modelId { get; init; }
+  [JsonRequired]
+  public string modelId { get; init; }
 
   public Version? version { get; init; }
 }

--- a/src/Speckle.Sdk/Api/GraphQL/Resources/CommentResource.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Resources/CommentResource.cs
@@ -150,6 +150,7 @@ public sealed class CommentResource
                 objectId
                 versionId
               }
+              viewerState
             }
           }
         }


### PR DESCRIPTION
1. Corrected nullability of `modelId` on project version updated subscriptions
2. Copied changes from https://github.com/specklesystems/speckle-sharp/pull/3662/files#diff-e7db83a33c9826dbf7838af285cbfb7d150bc5ab7c77bf046d518654ec32a362 r.e. comment resources


Note: 
 - Neither of these functions are used by DUI3, if integration tests pass, we should be good.