### PR TITLE
NET core target to return IReadonlySet for freeze

### DIFF
--- a/src/Speckle.Sdk.Dependencies/Collections.cs
+++ b/src/Speckle.Sdk.Dependencies/Collections.cs
@@ -4,7 +4,14 @@ namespace Speckle.Sdk.Dependencies;
 
 public static class Collections
 {
-  public static IReadOnlyCollection<T> Freeze<T>(this IEnumerable<T> source) => source.ToFrozenSet();
+#if NET5_0_OR_GREATER
+  public static IReadOnlySet<T> Freeze<T>(this IEnumerable<T> source)
+#else
+  public static IReadOnlyCollection<T> Freeze<T>(this IEnumerable<T> source)
+#endif
+  {
+    return source.ToFrozenSet();
+  }
 
   public static IReadOnlyDictionary<TKey, TValue> Freeze<TKey, TValue>(
     this IEnumerable<KeyValuePair<TKey, TValue>> source


### PR DESCRIPTION
Net 5 introduced the `IReadOnlySet<T>` interface which inherits `IReadOnlyCollection<T>`. 
Since we now have NET8 only consumers (IFC importer), it would be nice to use this new interface