### PR TITLE
Deprecated public visibility

### DIFF
--- a/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
@@ -2,7 +2,9 @@
 
 public enum ProjectVisibility
 {
-  Private,
-  Public,
-  Unlisted,
+  Private = 0,
+
+  [Obsolete("Use Unlisted instead", true)]
+  Public = 1,
+  Unlisted = 2,
 }

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
@@ -29,7 +29,7 @@ public class ProjectResourceTests
 
   [Theory]
   [InlineData("Very private project", "My secret project", ProjectVisibility.Private)]
-  [InlineData("Very public project", null, ProjectVisibility.Public)]
+  [InlineData("Very unlisted project", null, ProjectVisibility.Unlisted)]
   public async Task ProjectCreate_Should_CreateProjectSuccessfully(
     string name,
     string? description,

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
@@ -70,7 +70,7 @@ public class ProjectResourceTests
     // Arrange
     const string NEW_NAME = "MY new name";
     const string NEW_DESCRIPTION = "MY new desc";
-    const ProjectVisibility NEW_VISIBILITY = ProjectVisibility.Public;
+    const ProjectVisibility NEW_VISIBILITY = ProjectVisibility.Unlisted;
 
     // Act
     var newProject = await Sut.Update(

--- a/tests/Speckle.Sdk.Tests.Performance/Benchmarks/GeneralSendTest.cs
+++ b/tests/Speckle.Sdk.Tests.Performance/Benchmarks/GeneralSendTest.cs
@@ -57,7 +57,7 @@ public class GeneralSendTest
     client = TestDataHelper.ServiceProvider.GetRequiredService<IClientFactory>().Create(acc);
 
     _project = await client.Project.Create(
-      new($"General Send Test run {Guid.NewGuid()}", null, ProjectVisibility.Public)
+      new($"General Send Test run {Guid.NewGuid()}", null, ProjectVisibility.Unlisted)
     );
     _remote = TestDataHelper.ServiceProvider.GetRequiredService<IServerTransportFactory>().Create(acc, _project.id);
   }


### PR DESCRIPTION
Public visibility is being deprecated. And mutations like `ProjectMutations.Update` will no longer handle public visibility (sets to unlisted)

https://discord.com/channels/726756379083145269/1347576486282002512/1347582593805189133