### PR TITLE
feat(objects): adds level property to RevitObject

### DIFF
--- a/src/Speckle.Objects/Data/RevitObject.cs
+++ b/src/Speckle.Objects/Data/RevitObject.cs
@@ -13,6 +13,11 @@ public class RevitObject : DataObject, IRevitObject
   public required string category { get; set; }
 
   /// <summary>
+  /// The level constraint of the object. For objects constrained by multiple levels, this represents the base constraint.
+  /// </summary>
+  public required string level { get; set; }
+
+  /// <summary>
   /// A Curve or Point object representing the location of a Revit element.
   /// </summary>
   public required Base? location { get; set; }


### PR DESCRIPTION
Since level is a frequently accessed property, this will be adding it to the `RevitObject` class as a required field.
Revit converter now needs to be updated to populate the required property.