### PR TITLE
Cancellation check for sending needs to not be wrapped

### DIFF
--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -89,11 +89,12 @@ public sealed class SerializeProcess(
 
   public void ThrowIfFailed()
   {
+    //always check for cancellation first
+    cancellationToken.ThrowIfCancellationRequested();
     if (Exception is not null)
     {
       throw new SpeckleException("Error while sending", Exception);
     }
-    cancellationToken.ThrowIfCancellationRequested();
   }
 
   private async Task WaitForSchedulerCompletion()


### PR DESCRIPTION
Send cancellation can result in a wrapped SpeckleException.  It shouldn't because the caller will handle the cancelled exception differently 

![image](https://github.com/user-attachments/assets/b68034e8-2f91-467b-8f6a-9e0da6cf89bc)
