### PR TITLE
fix: Update HostAppVersion.cs for 2026

### DIFF
--- a/src/Speckle.Sdk/Host/HostAppVersion.cs
+++ b/src/Speckle.Sdk/Host/HostAppVersion.cs
@@ -13,6 +13,7 @@ public enum HostAppVersion
   v2023,
   v2024,
   v2025,
+  v2026,
   v21,
   v22,
   v25,


### PR DESCRIPTION
Adding v2026 for next autodesk releases support.

replaces https://github.com/specklesystems/speckle-sharp-sdk/pull/269