### PR TITLE
fix(main) exception test correction and token usage

### DIFF
--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
@@ -28,9 +28,14 @@ public abstract class ChannelSaver<T>
     _ => throw new NotImplementedException("Dropping items not supported.")
   );
 
-  public Task Start(int? maxParallelism, int? httpBatchSize, int? cacheBatchSize, CancellationToken cancellationToken) =>
+  public Task Start(
+    int? maxParallelism,
+    int? httpBatchSize,
+    int? cacheBatchSize,
+    CancellationToken cancellationToken
+  ) =>
     _checkCacheChannel
-      .Reader.BatchByByteSize(httpBatchSize ??HTTP_SEND_CHUNK_SIZE)
+      .Reader.BatchByByteSize(httpBatchSize ?? HTTP_SEND_CHUNK_SIZE)
       .WithTimeout(HTTP_BATCH_TIMEOUT)
       .PipeAsync(
         maxParallelism ?? MAX_PARALLELISM_HTTP,

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaver.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaver.cs
@@ -9,7 +9,7 @@ namespace Speckle.Sdk.Serialisation.V2.Send;
 public interface IObjectSaver : IDisposable
 {
   Exception? Exception { get; set; }
-  Task Start(CancellationToken cancellationToken);
+  Task Start(int? maxParallelism, int? httpBatchSize, int? cacheBatchSize,   CancellationToken cancellationToken);
   void DoneTraversing();
   Task DoneSaving();
   void SaveItem(BaseItem item, CancellationToken cancellationToken);

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaver.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaver.cs
@@ -9,7 +9,7 @@ namespace Speckle.Sdk.Serialisation.V2.Send;
 public interface IObjectSaver : IDisposable
 {
   Exception? Exception { get; set; }
-  Task Start(int? maxParallelism, int? httpBatchSize, int? cacheBatchSize,   CancellationToken cancellationToken);
+  Task Start(int? maxParallelism, int? httpBatchSize, int? cacheBatchSize, CancellationToken cancellationToken);
   void DoneTraversing();
   Task DoneSaving();
   void SaveItem(BaseItem item, CancellationToken cancellationToken);

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -104,7 +104,12 @@ public sealed class SerializeProcess(
   {
     try
     {
-      var channelTask = objectSaver.Start(options?.MaxParallelism, options?.MaxHttpSendSize, options?.MaxCacheSize, _processSource.Token);
+      var channelTask = objectSaver.Start(
+        options?.MaxParallelism,
+        options?.MaxHttpSendSize,
+        options?.MaxCacheSize,
+        _processSource.Token
+      );
       var findTotalObjectsTask = Task.CompletedTask;
       if (!_options.SkipFindTotalObjects)
       {
@@ -227,20 +232,17 @@ public sealed class SerializeProcess(
         _currentClosurePool.Return(childClosure);
       }
 
-    
       if (childCts.Token.IsCancellationRequested)
       {
         return EMPTY_CLOSURES;
       }
-
 
       var items = baseSerializer.Serialise(obj, childClosures, _options.SkipCacheRead, childCts.Token);
-     
+
       if (childCts.Token.IsCancellationRequested)
       {
         return EMPTY_CLOSURES;
       }
-
 
       var currentClosures = _currentClosurePool.Get();
       try
@@ -251,12 +253,10 @@ public sealed class SerializeProcess(
         {
           if (item.NeedsStorage)
           {
-           
             if (childCts.Token.IsCancellationRequested)
             {
               return EMPTY_CLOSURES;
             }
-
 
             Interlocked.Increment(ref _objectsSerialized);
             objectSaver.SaveItem(item, childCts.Token);

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -14,7 +14,12 @@ public record SerializeProcessOptions(
   bool SkipCacheWrite = false,
   bool SkipServer = false,
   bool SkipFindTotalObjects = false
-);
+)
+{
+  public int? MaxHttpSendSize { get; set; }
+  public int? MaxCacheSize { get; set; }
+  public int? MaxParallelism { get; set; }
+}
 
 public readonly record struct SerializeProcessResults(
   string RootId,
@@ -99,7 +104,7 @@ public sealed class SerializeProcess(
   {
     try
     {
-      var channelTask = objectSaver.Start(_processSource.Token);
+      var channelTask = objectSaver.Start(options?.MaxParallelism, options?.MaxHttpSendSize, options?.MaxCacheSize, _processSource.Token);
       var findTotalObjectsTask = Task.CompletedTask;
       if (!_options.SkipFindTotalObjects)
       {

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Cache_ExceptionsAfter_10.verified.json
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Cache_ExceptionsAfter_10.verified.json
@@ -1,10 +1,10 @@
 ﻿{
   "Data": {},
   "InnerException": {
-    "$type": "NotImplementedException",
+    "$type": "Exception",
     "Data": {},
-    "Message": "The method or operation is not implemented.",
-    "Type": "NotImplementedException"
+    "Message": "Count exceeded",
+    "Type": "Exception"
   },
   "Message": "Error while sending",
   "Type": "SpeckleException"

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
@@ -66,7 +66,27 @@ public class ExceptionTests
   [Fact]
   public async Task Test_Exceptions_Cache_ExceptionsAfter_10()
   {
-    var testClass = new TestClass() { RegularProperty = "Hello" };
+    var @base = new SampleObjectBase2();
+    @base["dynamicProp"] = 123;
+    @base.applicationId = "1";
+    @base.detachedProp = new SamplePropBase2()
+    {
+      name = "detachedProp",
+      applicationId = "2",
+      line = new Polyline() { units = "test", value = [1.0, 2.0] },
+    };
+    @base.detachedProp2 = new SamplePropBase2()
+    {
+      name = "detachedProp2",
+      applicationId = "3",
+      line = new Polyline() { units = "test", value = [3.0, 2.0] },
+    };
+    @base.attachedProp = new SamplePropBase2()
+    {
+      name = "attachedProp",
+      applicationId = "4",
+      line = new Polyline() { units = "test", value = [3.0, 4.0] },
+    };
 
     await using var serializeProcess = _factory.CreateSerializeProcess(
       new ExceptionSendCacheManager(exceptionsAfter: 10),
@@ -74,9 +94,14 @@ public class ExceptionTests
       null,
       default,
       new SerializeProcessOptions(false, false, false, true)
+      {
+        MaxHttpSendSize = 1,
+        MaxCacheSize = 1,
+        MaxParallelism = 1
+      }
     );
 
-    var ex = await Assert.ThrowsAsync<SpeckleException>(async () => await serializeProcess.Serialize(testClass));
+    var ex = await Assert.ThrowsAsync<SpeckleException>(async () => await serializeProcess.Serialize(@base));
     await Verify(ex);
   }
 

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
@@ -97,7 +97,7 @@ public class ExceptionTests
       {
         MaxHttpSendSize = 1,
         MaxCacheSize = 1,
-        MaxParallelism = 1
+        MaxParallelism = 1,
       }
     );
 

--- a/tests/Speckle.Sdk.Serialization.Tests/Framework/ExceptionSendCacheManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/Framework/ExceptionSendCacheManager.cs
@@ -4,6 +4,7 @@ namespace Speckle.Sdk.Serialization.Tests.Framework;
 
 public class ExceptionSendCacheManager(bool? hasObject = null, int? exceptionsAfter = null) : ISqLiteJsonCacheManager
 {
+  private readonly object _lock = new();
   private int _count;
 
   public void Dispose() { }
@@ -24,18 +25,23 @@ public class ExceptionSendCacheManager(bool? hasObject = null, int? exceptionsAf
 
   private void CheckExceptions()
   {
-    if (exceptionsAfter is not null)
+    lock (_lock)
     {
-      if (exceptionsAfter.Value > _count)
+      if (exceptionsAfter is not null)
       {
-        _count++;
+        if (exceptionsAfter.Value > _count)
+        {
+          _count++;
+        }
+        else
+        {
+          throw new Exception("Count exceeded");
+        }
       }
       else
       {
-        throw new Exception("Count exceeded");
+        throw new NotImplementedException();
       }
     }
-
-    throw new NotImplementedException();
   }
 }


### PR DESCRIPTION
fixed an exception test to be correct counting by reducing parallelism just for that test
token source usage was made more explicit and correct when traversing the tree for sending