### PR TITLE
fix (main) Don't drop items to write when sending fast

### DIFF
--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
@@ -76,7 +76,7 @@ public abstract class ChannelSaver<T>
     }
     //can switch to check then try pattern when back pressure is needed or exceptions are too much
     //the trees don't need to respond to back pressure
-    await _checkCacheChannel.Writer.WriteAsync(item, cancellationToken);
+    await _checkCacheChannel.Writer.WriteAsync(item, cancellationToken).ConfigureAwait(false);
   }
 
   private async Task<IMemoryOwner<T>> SendToServer(IMemoryOwner<T> batch)

--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
@@ -74,12 +74,9 @@ public abstract class ChannelSaver<T>
     {
       return; //don't save if we're already done through an error
     }
-    //better wait to handle writes instead of WriteAsync to create unlimited tasks
-    while (await _checkCacheChannel.Writer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false))
-    {
-      if (_checkCacheChannel.Writer.TryWrite(item))
-        return;
-    }
+    //can switch to check then try pattern when back pressure is needed or exceptions are too much
+    //the trees don't need to respond to back pressure
+    await _checkCacheChannel.Writer.WriteAsync(item, cancellationToken);
   }
 
   private async Task<IMemoryOwner<T>> SendToServer(IMemoryOwner<T> batch)

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaver.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaver.cs
@@ -12,7 +12,7 @@ public interface IObjectSaver : IDisposable
   Task Start(int? maxParallelism, int? httpBatchSize, int? cacheBatchSize, CancellationToken cancellationToken);
   void DoneTraversing();
   Task DoneSaving();
-  void SaveItem(BaseItem item);
+  Task SaveAsync(BaseItem item);
   long Uploaded { get; }
   long Cached { get; }
 }
@@ -81,10 +81,10 @@ public sealed class ObjectSaver(
     }
   }
 
-  public void SaveItem(BaseItem item)
+  public async Task SaveAsync(BaseItem item)
   {
     Interlocked.Increment(ref _objectsSerialized);
-    Save(item);
+     await SaveAsync(item, _cancellationTokenSource.Token).ConfigureAwait(false);
   }
 
   public override void SaveToCache(List<BaseItem> batch)

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaver.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaver.cs
@@ -13,8 +13,6 @@ public interface IObjectSaver : IDisposable
   void DoneTraversing();
   Task DoneSaving();
   Task SaveAsync(BaseItem item);
-  long Uploaded { get; }
-  long Cached { get; }
 }
 
 public sealed class ObjectSaver(
@@ -40,8 +38,6 @@ public sealed class ObjectSaver(
   private long _cached;
 
   private long _objectsSerialized;
-  public long Cached => _cached;
-  public long Uploaded => _uploaded;
 
   protected override async Task SendToServerInternal(Batch<BaseItem> batch)
   {

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaver.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaver.cs
@@ -80,7 +80,7 @@ public sealed class ObjectSaver(
   public async Task SaveAsync(BaseItem item)
   {
     Interlocked.Increment(ref _objectsSerialized);
-     await SaveAsync(item, _cancellationTokenSource.Token).ConfigureAwait(false);
+    await SaveAsync(item, _cancellationTokenSource.Token).ConfigureAwait(false);
   }
 
   public override void SaveToCache(List<BaseItem> batch)

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -258,7 +258,7 @@ public sealed class SerializeProcess(
             }
 
             Interlocked.Increment(ref _objectsSerialized);
-            objectSaver.SaveItem(item);
+            await objectSaver.SaveAsync(item).ConfigureAwait(false);
           }
 
           if (!currentClosures.ContainsKey(item.Id))


### PR DESCRIPTION
Reported as https://linear.app/speckle/issue/CNX-1670/sending-can-produce-commits-without-a-complete-model

Wait doesn't cause a wait...it just returns false
![image](https://github.com/user-attachments/assets/c43a5dfe-bd53-49ff-90a4-20e8f047d8da)
