### PR TITLE
Use WhenAll instead of WhenAny and avoid manual task exception processing

### DIFF
--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -193,8 +193,8 @@ public sealed class SerializeProcess(
       Dictionary<Id, NodeInfo>[] taskClosures = [];
       if (tasks.Count > 0)
       {
-          //grab when any Task is done and see if we're cancelling
-          taskClosures = await Task.WhenAll(tasks).ConfigureAwait(false);
+        //grab when any Task is done and see if we're cancelling
+        taskClosures = await Task.WhenAll(tasks).ConfigureAwait(false);
       }
 
       if (_processSource.Token.IsCancellationRequested)

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -198,21 +198,21 @@ public sealed class SerializeProcess(
       if (tasks.Count > 0)
       {
         //get child results
-         var childTask = Task.WhenAll(tasks);
-         await Task.WhenAny(childTask, Task.Delay(Timeout.InfiniteTimeSpan, _processSource.Token)).ConfigureAwait(false);
-         if (childTask.IsFaulted)	
-         {	
-           if (childTask.Exception is not null)	
-           {	
-             RecordException(childTask.Exception);	
-           }	
-           return EMPTY_CLOSURES;	
-         }
-         if (!childTask.IsCompleted)
-         {
-           return EMPTY_CLOSURES;	
-         }
-         taskClosures = childTask.Result;
+        var childTask = Task.WhenAll(tasks);
+        await Task.WhenAny(childTask, Task.Delay(Timeout.InfiniteTimeSpan, _processSource.Token)).ConfigureAwait(false);
+        if (childTask.IsFaulted)
+        {
+          if (childTask.Exception is not null)
+          {
+            RecordException(childTask.Exception);
+          }
+          return EMPTY_CLOSURES;
+        }
+        if (!childTask.IsCompleted)
+        {
+          return EMPTY_CLOSURES;
+        }
+        taskClosures = childTask.Result;
       }
       _taskResultPool.Return(tasks);
 

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -198,7 +198,21 @@ public sealed class SerializeProcess(
       if (tasks.Count > 0)
       {
         //get child results
-        taskClosures = await Task.WhenAll(tasks).ConfigureAwait(false);
+         var childTask = Task.WhenAll(tasks);
+         await Task.WhenAny(childTask, Task.Delay(Timeout.InfiniteTimeSpan, _processSource.Token)).ConfigureAwait(false);
+         if (childTask.IsFaulted)	
+         {	
+           if (childTask.Exception is not null)	
+           {	
+             RecordException(childTask.Exception);	
+           }	
+           return EMPTY_CLOSURES;	
+         }
+         if (!childTask.IsCompleted)
+         {
+           return EMPTY_CLOSURES;	
+         }
+         taskClosures = childTask.Result;
       }
       _taskResultPool.Return(tasks);
 

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -190,29 +190,11 @@ public sealed class SerializeProcess(
         return EMPTY_CLOSURES;
       }
 
-      List<Dictionary<Id, NodeInfo>> taskClosures = new();
+      Dictionary<Id, NodeInfo>[] taskClosures = [];
       if (tasks.Count > 0)
       {
-        var currentTasks = tasks.ToList();
-        do
-        {
           //grab when any Task is done and see if we're cancelling
-          var t = await Task.WhenAny(currentTasks).ConfigureAwait(false);
-          if (t.IsCanceled)
-          {
-            return EMPTY_CLOSURES;
-          }
-          if (t.IsFaulted)
-          {
-            if (t.Exception is not null)
-            {
-              RecordException(t.Exception);
-            }
-            return EMPTY_CLOSURES;
-          }
-          taskClosures.Add(t.Result);
-          currentTasks.Remove(t);
-        } while (currentTasks.Count > 0);
+          taskClosures = await Task.WhenAll(tasks).ConfigureAwait(false);
       }
 
       if (_processSource.Token.IsCancellationRequested)


### PR DESCRIPTION
Removing the arbitrary WhenAny in favor of WhenAny(WhenAll,Delay)

gets the cancellation we want and no significant allocations