### PR TITLE
Use a sqlite manager per stream that's kept around forever

### DIFF
--- a/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
+++ b/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
@@ -15,11 +15,16 @@ public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
 
   public SqLiteJsonCacheManager(string path, int concurrency)
   {
+    Path = path;
+    Concurrency = concurrency;
     //disable pooling as we pool ourselves
     var builder = new SqliteConnectionStringBuilder { Pooling = false, DataSource = path };
     _pool = new CacheDbCommandPool(builder.ToString(), concurrency);
     Initialize();
   }
+  
+  public string Path { get; }
+  public int Concurrency { get; }
 
   [AutoInterfaceIgnore]
   public void Dispose() => _pool.Dispose();

--- a/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
+++ b/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
@@ -9,7 +9,7 @@ public partial interface ISqLiteJsonCacheManager : IDisposable;
 [GenerateAutoInterface]
 public sealed class SqLiteJsonCacheManager(ISqliteJsonCachePool pool, bool dispose) : ISqLiteJsonCacheManager
 {
-  
+  public ISqliteJsonCachePool Pool => pool;
   public IReadOnlyCollection<(string Id, string Json)> GetAllObjects() =>
     pool.Use(
       CacheOperation.GetAll,

--- a/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
+++ b/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
@@ -5,11 +5,14 @@ using Speckle.Sdk.Common;
 using Speckle.Sdk.Dependencies;
 
 namespace Speckle.Sdk.SQLite;
+
 public partial interface ISqLiteJsonCacheManager : IDisposable;
+
 [GenerateAutoInterface]
 public sealed class SqLiteJsonCacheManager(ISqliteJsonCachePool pool, bool dispose) : ISqLiteJsonCacheManager
 {
   public ISqliteJsonCachePool Pool => pool;
+
   public IReadOnlyCollection<(string Id, string Json)> GetAllObjects() =>
     pool.Use(
       CacheOperation.GetAll,

--- a/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
+++ b/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
@@ -5,93 +5,13 @@ using Speckle.Sdk.Common;
 using Speckle.Sdk.Dependencies;
 
 namespace Speckle.Sdk.SQLite;
-
 public partial interface ISqLiteJsonCacheManager : IDisposable;
-
 [GenerateAutoInterface]
-public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
+public sealed class SqLiteJsonCacheManager(ISqliteJsonCachePool pool, bool dispose) : ISqLiteJsonCacheManager
 {
-  private readonly CacheDbCommandPool _pool;
-
-  public SqLiteJsonCacheManager(string path, int concurrency)
-  {
-    Path = path;
-    Concurrency = concurrency;
-    //disable pooling as we pool ourselves
-    var builder = new SqliteConnectionStringBuilder { Pooling = false, DataSource = path };
-    _pool = new CacheDbCommandPool(builder.ToString(), concurrency);
-    Initialize();
-  }
   
-  public string Path { get; }
-  public int Concurrency { get; }
-
-  [AutoInterfaceIgnore]
-  public void Dispose() => _pool.Dispose();
-
-  private void Initialize()
-  {
-    // NOTE: used for creating partioned object tables.
-    //string[] HexChars = new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f" };
-    //var cart = new List<string>();
-    //foreach (var str in HexChars)
-    //  foreach (var str2 in HexChars)
-    //    cart.Add(str + str2);
-
-    _pool.Use(c =>
-    {
-      const string COMMAND_TEXT =
-        @"
-            CREATE TABLE IF NOT EXISTS objects(
-              hash TEXT PRIMARY KEY,
-              content TEXT
-            ) WITHOUT ROWID;
-          ";
-      using (var command = new SqliteCommand(COMMAND_TEXT, c))
-      {
-        command.ExecuteNonQuery();
-      }
-
-      // Insert Optimisations
-
-      //Note / Hack: This setting has the potential to corrupt the db.
-      //cmd = new SqliteCommand("PRAGMA synchronous=OFF;", Connection);
-      //cmd.ExecuteNonQuery();
-
-      using (SqliteCommand cmd1 = new("PRAGMA count_changes=OFF;", c))
-      {
-        cmd1.ExecuteNonQuery();
-      }
-
-      using (SqliteCommand cmd2 = new("PRAGMA temp_store=MEMORY;", c))
-      {
-        cmd2.ExecuteNonQuery();
-      }
-
-      using (SqliteCommand cmd3 = new("PRAGMA mmap_size = 30000000000;", c))
-      {
-        cmd3.ExecuteNonQuery();
-      }
-
-      using (SqliteCommand cmd4 = new("PRAGMA page_size = 32768;", c))
-      {
-        cmd4.ExecuteNonQuery();
-      }
-
-      using (SqliteCommand cmd5 = new("PRAGMA journal_mode='wal';", c))
-      {
-        cmd5.ExecuteNonQuery();
-      }
-      //do this to wait 5 seconds to avoid db lock exceptions, this is 0 by default
-      using (SqliteCommand cmd6 = new("PRAGMA busy_timeout=5000;", c))
-      {
-        cmd6.ExecuteNonQuery();
-      }
-    });
-  }
-
   public IReadOnlyCollection<(string Id, string Json)> GetAllObjects() =>
-    _pool.Use(
+    pool.Use(
       CacheOperation.GetAll,
       command =>
       {
@@ -106,7 +26,7 @@ public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
     );
 
   public void DeleteObject(string id) =>
-    _pool.Use(
+    pool.Use(
       CacheOperation.Delete,
       command =>
       {
@@ -116,7 +36,7 @@ public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
     );
 
   public string? GetObject(string id) =>
-    _pool.Use(
+    pool.Use(
       CacheOperation.Get,
       command =>
       {
@@ -130,7 +50,7 @@ public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
   {
     id.NotNullOrWhiteSpace();
     json.NotNullOrWhiteSpace();
-    _pool.Use(
+    pool.Use(
       CacheOperation.InsertOrIgnore,
       command =>
       {
@@ -143,7 +63,7 @@ public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
 
   //This does an insert or replaces if already exists
   public void UpdateObject(string id, string json) =>
-    _pool.Use(
+    pool.Use(
       CacheOperation.InsertOrReplace,
       command =>
       {
@@ -154,7 +74,7 @@ public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
     );
 
   public void SaveObjects(IEnumerable<(string id, string json)> items) =>
-    _pool.Use(
+    pool.Use(
       CacheOperation.BulkInsertOrIgnore,
       cmd =>
       {
@@ -200,7 +120,7 @@ public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
   }
 
   public bool HasObject(string objectId) =>
-    _pool.Use(
+    pool.Use(
       CacheOperation.Has,
       command =>
       {
@@ -210,4 +130,13 @@ public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
         return rowFound;
       }
     );
+
+  [AutoInterfaceIgnore]
+  public void Dispose()
+  {
+    if (dispose)
+    {
+      pool.Dispose();
+    }
+  }
 }

--- a/src/Speckle.Sdk/SQLite/SqLiteJsonCacheManagerFactory.cs
+++ b/src/Speckle.Sdk/SQLite/SqLiteJsonCacheManagerFactory.cs
@@ -9,7 +9,7 @@ namespace Speckle.Sdk.SQLite;
 public class SqLiteJsonCacheManagerFactory : ISqLiteJsonCacheManagerFactory
 {
   public const int INITIAL_CONCURRENCY = 4;
-  
+
   private readonly ConcurrentDictionary<string, ISqLiteJsonCacheManager> _cachedManagers = new();
 
   private ISqLiteJsonCacheManager Create(string path, int concurrency) => new SqLiteJsonCacheManager(path, concurrency);

--- a/src/Speckle.Sdk/SQLite/SqLiteJsonCacheManagerFactory.cs
+++ b/src/Speckle.Sdk/SQLite/SqLiteJsonCacheManagerFactory.cs
@@ -28,12 +28,13 @@ public sealed class SqLiteJsonCacheManagerFactory : ISqLiteJsonCacheManagerFacto
   private ISqliteJsonCachePool Create(string path, int concurrency) => new SqliteJsonCachePool(path, concurrency);
 
   public ISqLiteJsonCacheManager CreateForUser(string scope) =>
-    new SqLiteJsonCacheManager( 
+    new SqLiteJsonCacheManager(
 #pragma warning disable CA2000
       //this is fine because we told SqLiteJsonCacheManager to dispose this
       Create(Path.Combine(SpecklePathProvider.UserApplicationDataPath(), "Speckle", $"{scope}.db"), 1),
 #pragma warning restore CA2000
-      true);
+      true
+    );
 
   public ISqLiteJsonCacheManager CreateFromStream(string streamId)
   {

--- a/src/Speckle.Sdk/SQLite/SqLiteJsonCacheManagerFactory.cs
+++ b/src/Speckle.Sdk/SQLite/SqLiteJsonCacheManagerFactory.cs
@@ -21,6 +21,8 @@ public sealed class SqLiteJsonCacheManagerFactory : ISqLiteJsonCacheManagerFacto
     {
       pool.Value.Dispose();
     }
+
+    _pools.Clear();
   }
 
   private ISqliteJsonCachePool Create(string path, int concurrency) => new SqliteJsonCachePool(path, concurrency);

--- a/src/Speckle.Sdk/SQLite/SqLiteJsonCacheManagerFactory.cs
+++ b/src/Speckle.Sdk/SQLite/SqLiteJsonCacheManagerFactory.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.InterfaceGenerator;
+﻿using System.Collections.Concurrent;
+using Speckle.InterfaceGenerator;
 using Speckle.Sdk.Logging;
 using Speckle.Sdk.Serialisation.Utilities;
 
@@ -8,12 +9,21 @@ namespace Speckle.Sdk.SQLite;
 public class SqLiteJsonCacheManagerFactory : ISqLiteJsonCacheManagerFactory
 {
   public const int INITIAL_CONCURRENCY = 4;
+  
+  private readonly ConcurrentDictionary<string, ISqLiteJsonCacheManager> _cachedManagers = new();
 
   private ISqLiteJsonCacheManager Create(string path, int concurrency) => new SqLiteJsonCacheManager(path, concurrency);
 
   public ISqLiteJsonCacheManager CreateForUser(string scope) =>
     Create(Path.Combine(SpecklePathProvider.UserApplicationDataPath(), "Speckle", $"{scope}.db"), 1);
 
-  public ISqLiteJsonCacheManager CreateFromStream(string streamId) =>
-    Create(SqlitePaths.GetDBPath(streamId), INITIAL_CONCURRENCY);
+  public ISqLiteJsonCacheManager CreateFromStream(string streamId)
+  {
+    if (!_cachedManagers.TryGetValue(streamId, out var manager))
+    {
+      manager = Create(SqlitePaths.GetDBPath(streamId), INITIAL_CONCURRENCY);
+      _cachedManagers.TryAdd(streamId, manager);
+    }
+    return manager;
+  }
 }

--- a/src/Speckle.Sdk/SQLite/SqliteJsonCachePool.cs
+++ b/src/Speckle.Sdk/SQLite/SqliteJsonCachePool.cs
@@ -1,0 +1,98 @@
+using Microsoft.Data.Sqlite;
+using Speckle.InterfaceGenerator;
+
+namespace Speckle.Sdk.SQLite;
+public partial interface ISqliteJsonCachePool : IDisposable
+{
+  T Use<T>(CacheOperation type, Func<SqliteCommand, T> handler);
+}
+[GenerateAutoInterface]
+public sealed class SqliteJsonCachePool : ISqliteJsonCachePool
+{
+  private readonly CacheDbCommandPool _pool;
+  public SqliteJsonCachePool(string path, int concurrency)
+  {
+    Path = path;
+    Concurrency = concurrency;
+    //disable pooling as we pool ourselves
+    var builder = new SqliteConnectionStringBuilder { Pooling = false, DataSource = path };
+    _pool = new CacheDbCommandPool(builder.ToString(), concurrency);
+    Initialize();
+  }
+  
+  public string Path { get; }
+  public int Concurrency { get; }
+  
+  
+  private void Initialize()
+  {
+    // NOTE: used for creating partioned object tables.
+    //string[] HexChars = new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f" };
+    //var cart = new List<string>();
+    //foreach (var str in HexChars)
+    //  foreach (var str2 in HexChars)
+    //    cart.Add(str + str2);
+
+    _pool.Use(c =>
+    {
+      const string COMMAND_TEXT =
+        @"
+            CREATE TABLE IF NOT EXISTS objects(
+              hash TEXT PRIMARY KEY,
+              content TEXT
+            ) WITHOUT ROWID;
+          ";
+      using (var command = new SqliteCommand(COMMAND_TEXT, c))
+      {
+        command.ExecuteNonQuery();
+      }
+
+      // Insert Optimisations
+
+      //Note / Hack: This setting has the potential to corrupt the db.
+      //cmd = new SqliteCommand("PRAGMA synchronous=OFF;", Connection);
+      //cmd.ExecuteNonQuery();
+
+      using (SqliteCommand cmd1 = new("PRAGMA count_changes=OFF;", c))
+      {
+        cmd1.ExecuteNonQuery();
+      }
+
+      using (SqliteCommand cmd2 = new("PRAGMA temp_store=MEMORY;", c))
+      {
+        cmd2.ExecuteNonQuery();
+      }
+
+      using (SqliteCommand cmd3 = new("PRAGMA mmap_size = 30000000000;", c))
+      {
+        cmd3.ExecuteNonQuery();
+      }
+
+      using (SqliteCommand cmd4 = new("PRAGMA page_size = 32768;", c))
+      {
+        cmd4.ExecuteNonQuery();
+      }
+
+      using (SqliteCommand cmd5 = new("PRAGMA journal_mode='wal';", c))
+      {
+        cmd5.ExecuteNonQuery();
+      }
+      //do this to wait 5 seconds to avoid db lock exceptions, this is 0 by default
+      using (SqliteCommand cmd6 = new("PRAGMA busy_timeout=5000;", c))
+      {
+        cmd6.ExecuteNonQuery();
+      }
+    });
+  }
+  
+  public void Use(Action<SqliteConnection> handler) => _pool.Use(handler);
+  
+  
+  public void Use(CacheOperation type, Action<SqliteCommand> handler) => _pool.Use(type, handler);
+  
+  [AutoInterfaceIgnore]
+  public T Use<T>(CacheOperation type, Func<SqliteCommand, T> handler) => _pool.Use(type, handler);
+
+  [AutoInterfaceIgnore]
+  public void Dispose() => _pool.Dispose();
+}

--- a/src/Speckle.Sdk/SQLite/SqliteJsonCachePool.cs
+++ b/src/Speckle.Sdk/SQLite/SqliteJsonCachePool.cs
@@ -2,14 +2,17 @@ using Microsoft.Data.Sqlite;
 using Speckle.InterfaceGenerator;
 
 namespace Speckle.Sdk.SQLite;
+
 public partial interface ISqliteJsonCachePool : IDisposable
 {
   T Use<T>(CacheOperation type, Func<SqliteCommand, T> handler);
 }
+
 [GenerateAutoInterface]
 public sealed class SqliteJsonCachePool : ISqliteJsonCachePool
 {
   private readonly CacheDbCommandPool _pool;
+
   public SqliteJsonCachePool(string path, int concurrency)
   {
     Path = path;
@@ -19,11 +22,10 @@ public sealed class SqliteJsonCachePool : ISqliteJsonCachePool
     _pool = new CacheDbCommandPool(builder.ToString(), concurrency);
     Initialize();
   }
-  
+
   public string Path { get; }
   public int Concurrency { get; }
-  
-  
+
   private void Initialize()
   {
     // NOTE: used for creating partioned object tables.
@@ -84,12 +86,11 @@ public sealed class SqliteJsonCachePool : ISqliteJsonCachePool
       }
     });
   }
-  
+
   public void Use(Action<SqliteConnection> handler) => _pool.Use(handler);
-  
-  
+
   public void Use(CacheOperation type, Action<SqliteCommand> handler) => _pool.Use(type, handler);
-  
+
   [AutoInterfaceIgnore]
   public T Use<T>(CacheOperation type, Func<SqliteCommand, T> handler) => _pool.Use(type, handler);
 

--- a/src/Speckle.Sdk/Serialisation/V2/MemoryJsonCacheManager.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/MemoryJsonCacheManager.cs
@@ -7,6 +7,10 @@ namespace Speckle.Sdk.Serialisation.V2;
 public class MemoryJsonCacheManager(ConcurrentDictionary<Id, Json> jsonCache) : ISqLiteJsonCacheManager
 #pragma warning restore CA1063
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+  public int Concurrency => throw new NotImplementedException();
+#pragma warning restore CA1065
   public IReadOnlyCollection<(string Id, string Json)> GetAllObjects() =>
     jsonCache.Select(x => (x.Key.Value, x.Value.Value)).ToList();
 

--- a/src/Speckle.Sdk/Serialisation/V2/MemoryJsonCacheManager.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/MemoryJsonCacheManager.cs
@@ -8,8 +8,7 @@ public class MemoryJsonCacheManager(ConcurrentDictionary<Id, Json> jsonCache) : 
 #pragma warning restore CA1063
 {
 #pragma warning disable CA1065
-  public string Path => throw new NotImplementedException();
-  public int Concurrency => throw new NotImplementedException();
+  public ISqliteJsonCachePool Pool => throw new NotImplementedException();
 #pragma warning restore CA1065
   public IReadOnlyCollection<(string Id, string Json)> GetAllObjects() =>
     jsonCache.Select(x => (x.Key.Value, x.Value.Value)).ToList();

--- a/src/Speckle.Sdk/ServiceRegistration.cs
+++ b/src/Speckle.Sdk/ServiceRegistration.cs
@@ -99,7 +99,7 @@ public static class ServiceRegistration
     );
     serviceCollection.AddMatchingInterfacesAsTransient(typeof(GraphQLRetry).Assembly);
     //we want to make sqlite pools be singletons per stream so needs a singleton factory
-    serviceCollection.TryAddSingleton<ISqLiteJsonCacheManagerFactory, SqLiteJsonCacheManagerFactory>();
+    serviceCollection.AddSingleton<ISqLiteJsonCacheManagerFactory, SqLiteJsonCacheManagerFactory>();
     return serviceCollection;
   }
 

--- a/src/Speckle.Sdk/ServiceRegistration.cs
+++ b/src/Speckle.Sdk/ServiceRegistration.cs
@@ -97,6 +97,8 @@ public static class ServiceRegistration
       typeof(Client)
     );
     serviceCollection.AddMatchingInterfacesAsTransient(typeof(GraphQLRetry).Assembly);
+    //we want to make sqlite pools be singletons per stream so needs a singleton factory
+    serviceCollection.TryAddSingleton<ISqLiteJsonCacheManagerFactory, SqLiteJsonCacheManagerFactory>();
     return serviceCollection;
   }
 

--- a/src/Speckle.Sdk/ServiceRegistration.cs
+++ b/src/Speckle.Sdk/ServiceRegistration.cs
@@ -94,7 +94,8 @@ public static class ServiceRegistration
       typeof(DeserializeProcess),
       typeof(ObjectLoader),
       typeof(TraversalRule),
-      typeof(Client)
+      typeof(Client),
+      typeof(SqliteJsonCachePool)
     );
     serviceCollection.AddMatchingInterfacesAsTransient(typeof(GraphQLRetry).Assembly);
     //we want to make sqlite pools be singletons per stream so needs a singleton factory

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -373,6 +373,10 @@ public class DummyServerObjectManager : IServerObjectManager
 
 public class DummySendCacheManager(Dictionary<string, string> objects) : ISqLiteJsonCacheManager
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+  public int Concurrency => throw new NotImplementedException();
+#pragma warning restore CA1065
   public void Dispose() { }
 
   public IReadOnlyCollection<(string, string)> GetAllObjects() => throw new NotImplementedException();

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -374,8 +374,7 @@ public class DummyServerObjectManager : IServerObjectManager
 public class DummySendCacheManager(Dictionary<string, string> objects) : ISqLiteJsonCacheManager
 {
 #pragma warning disable CA1065
-  public string Path => throw new NotImplementedException();
-  public int Concurrency => throw new NotImplementedException();
+  public ISqliteJsonCachePool Pool => throw new NotImplementedException();
 #pragma warning restore CA1065
   public void Dispose() { }
 

--- a/tests/Speckle.Sdk.Serialization.Tests/DummyCancellationSqLiteSendManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DummyCancellationSqLiteSendManager.cs
@@ -5,8 +5,7 @@ namespace Speckle.Sdk.Serialization.Tests;
 public class DummyCancellationSqLiteSendManager : ISqLiteJsonCacheManager
 {
 #pragma warning disable CA1065
-  public string Path => throw new NotImplementedException();
-  public int Concurrency => throw new NotImplementedException();
+  public ISqliteJsonCachePool Pool => throw new NotImplementedException();
 #pragma warning restore CA1065
   public string? GetObject(string id) => null;
 

--- a/tests/Speckle.Sdk.Serialization.Tests/DummyCancellationSqLiteSendManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DummyCancellationSqLiteSendManager.cs
@@ -4,6 +4,10 @@ namespace Speckle.Sdk.Serialization.Tests;
 
 public class DummyCancellationSqLiteSendManager : ISqLiteJsonCacheManager
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+  public int Concurrency => throw new NotImplementedException();
+#pragma warning restore CA1065
   public string? GetObject(string id) => null;
 
   public void SaveObject(string id, string json) => throw new NotImplementedException();

--- a/tests/Speckle.Sdk.Serialization.Tests/Framework/ExceptionSendCacheManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/Framework/ExceptionSendCacheManager.cs
@@ -5,8 +5,7 @@ namespace Speckle.Sdk.Serialization.Tests.Framework;
 public class ExceptionSendCacheManager(bool? hasObject = null, int? exceptionsAfter = null) : ISqLiteJsonCacheManager
 {
 #pragma warning disable CA1065
-  public string Path => throw new NotImplementedException();
-  public int Concurrency => throw new NotImplementedException();
+  public ISqliteJsonCachePool Pool => throw new NotImplementedException();
 #pragma warning restore CA1065
   private readonly object _lock = new();
   private int _count;

--- a/tests/Speckle.Sdk.Serialization.Tests/Framework/ExceptionSendCacheManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/Framework/ExceptionSendCacheManager.cs
@@ -4,6 +4,10 @@ namespace Speckle.Sdk.Serialization.Tests.Framework;
 
 public class ExceptionSendCacheManager(bool? hasObject = null, int? exceptionsAfter = null) : ISqLiteJsonCacheManager
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+  public int Concurrency => throw new NotImplementedException();
+#pragma warning restore CA1065
   private readonly object _lock = new();
   private int _count;
 

--- a/tests/Speckle.Sdk.Testing/Framework/DummySqLiteReceiveManager.cs
+++ b/tests/Speckle.Sdk.Testing/Framework/DummySqLiteReceiveManager.cs
@@ -6,8 +6,7 @@ public sealed class DummySqLiteReceiveManager(IReadOnlyDictionary<string, string
   : ISqLiteJsonCacheManager
 {
 #pragma warning disable CA1065
-  public string Path => throw new NotImplementedException();
-  public int Concurrency => throw new NotImplementedException();
+  public ISqliteJsonCachePool Pool => throw new NotImplementedException();
 #pragma warning restore CA1065
   public void Dispose() { }
 

--- a/tests/Speckle.Sdk.Testing/Framework/DummySqLiteReceiveManager.cs
+++ b/tests/Speckle.Sdk.Testing/Framework/DummySqLiteReceiveManager.cs
@@ -5,6 +5,10 @@ namespace Speckle.Sdk.Testing.Framework;
 public sealed class DummySqLiteReceiveManager(IReadOnlyDictionary<string, string> savedObjects)
   : ISqLiteJsonCacheManager
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+  public int Concurrency => throw new NotImplementedException();
+#pragma warning restore CA1065
   public void Dispose() { }
 
   public IReadOnlyCollection<(string, string)> GetAllObjects() => throw new NotImplementedException();

--- a/tests/Speckle.Sdk.Testing/Framework/DummySqLiteSendManager.cs
+++ b/tests/Speckle.Sdk.Testing/Framework/DummySqLiteSendManager.cs
@@ -5,8 +5,7 @@ namespace Speckle.Sdk.Testing.Framework;
 public class DummySqLiteSendManager : ISqLiteJsonCacheManager
 {
 #pragma warning disable CA1065
-  public string Path => throw new NotImplementedException();
-  public int Concurrency => throw new NotImplementedException();
+  public ISqliteJsonCachePool Pool => throw new NotImplementedException();
 #pragma warning restore CA1065
   public string? GetObject(string id) => throw new NotImplementedException();
 

--- a/tests/Speckle.Sdk.Testing/Framework/DummySqLiteSendManager.cs
+++ b/tests/Speckle.Sdk.Testing/Framework/DummySqLiteSendManager.cs
@@ -4,6 +4,10 @@ namespace Speckle.Sdk.Testing.Framework;
 
 public class DummySqLiteSendManager : ISqLiteJsonCacheManager
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+  public int Concurrency => throw new NotImplementedException();
+#pragma warning restore CA1065
   public string? GetObject(string id) => throw new NotImplementedException();
 
   public void SaveObject(string id, string json) => throw new NotImplementedException();

--- a/tests/Speckle.Sdk.Tests.Unit/SQLite/SQLiteJsonCacheManagerTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/SQLite/SQLiteJsonCacheManagerTests.cs
@@ -22,7 +22,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   public void TestGetAll()
   {
     var data = new List<(string id, string json)>() { ("id1", "1"), ("id2", "2") };
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = new SqLiteJsonCacheManager(new SqliteJsonCachePool(_basePath, 2), true);
     manager.SaveObjects(data);
     var items = manager.GetAllObjects();
     items.Count.Should().Be(data.Count);
@@ -38,7 +38,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   public void TestGet()
   {
     var data = new List<(string id, string json)>() { ("id1", "1"), ("id2", "2") };
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = new SqLiteJsonCacheManager(new SqliteJsonCachePool(_basePath, 2), true);
     foreach (var d in data)
     {
       manager.SaveObject(d.id, d.json);
@@ -84,7 +84,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   public void TestLargeJsonPayload()
   {
     var largeJson = new string('a', 100_000);
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = new SqLiteJsonCacheManager(new SqliteJsonCachePool(_basePath, 2), true);
     manager.SaveObject("large", largeJson);
     var result = manager.GetObject("large");
     result.Should().Be(largeJson);
@@ -96,7 +96,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
     var id = "spécial_字符_!@#$%^&*()";
     var json = /*lang=json,strict*/
       "{\"value\": \"特殊字符!@#$%^&*()\"}";
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = new SqLiteJsonCacheManager(new SqliteJsonCachePool(_basePath, 2), true);
     manager.SaveObject(id, json);
     var result = manager.GetObject(id);
     result.Should().Be(json);
@@ -108,7 +108,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   [Fact]
   public void TestBulkInsertEmptyCollection()
   {
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = new SqLiteJsonCacheManager(new SqliteJsonCachePool(_basePath, 2), true);
     manager.SaveObjects(new List<(string, string)>());
     manager.GetAllObjects().Count.Should().Be(0);
   }
@@ -116,7 +116,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   [Fact]
   public void TestRepeatedUpdateAndDelete()
   {
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = new SqLiteJsonCacheManager(new SqliteJsonCachePool(_basePath, 2), true);
     manager.SaveObject("id", "1");
     manager.UpdateObject("id", "2");
     manager.UpdateObject("id", "3");
@@ -129,7 +129,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   [Fact]
   public void TestGetAndDeleteNonExistentId()
   {
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = new SqLiteJsonCacheManager(new SqliteJsonCachePool(_basePath, 2), true);
     manager.GetObject("doesnotexist").Should().BeNull();
     manager.HasObject("doesnotexist").Should().BeFalse();
     manager.DeleteObject("doesnotexist"); // Should not throw
@@ -138,7 +138,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   [Fact]
   public void TestNullOrEmptyInput()
   {
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = new SqLiteJsonCacheManager(new SqliteJsonCachePool(_basePath, 2), true);
     // Empty id
     Assert.Throws<ArgumentException>(() => manager.SaveObject("", "emptyid"));
     // Empty json

--- a/tests/Speckle.Sdk.Tests.Unit/SQLite/SqLiteJsonCacheManagerFactoryTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/SQLite/SqLiteJsonCacheManagerFactoryTests.cs
@@ -1,0 +1,81 @@
+﻿using FluentAssertions;
+using Speckle.Sdk.Logging;
+using Speckle.Sdk.Serialisation.Utilities;
+using Speckle.Sdk.SQLite;
+
+namespace Speckle.Sdk.Tests.Unit.SQLite;
+
+public class SqLiteJsonCacheManagerFactoryTests
+{
+  [Fact]
+  public void CreateForUser_ShouldReturnManagerWithCorrectPathAndConcurrency()
+  {
+    // Arrange
+    var factory = new SqLiteJsonCacheManagerFactory();
+    var scope = "testuser";
+    var expectedPath = Path.Combine(SpecklePathProvider.UserApplicationDataPath(), "Speckle", $"{scope}.db");
+
+    // Act
+    using (var manager = factory.CreateForUser(scope))
+    {
+      // Assert
+      manager.Should().NotBeNull();
+      manager.Path.Should().Be(expectedPath);
+      manager.Concurrency.Should().Be(1);
+    }
+
+    // Cleanup
+    if (File.Exists(expectedPath))
+    {
+      File.Delete(expectedPath);
+    }
+  }
+
+  [Fact]
+  public void CreateFromStream_ShouldReturnManagerWithCorrectPathAndConcurrency_AndCleanup()
+  {
+    // Arrange
+    var factory = new SqLiteJsonCacheManagerFactory();
+    var streamId = "stream123";
+    var expectedPath = SqlitePaths.GetDBPath(streamId);
+
+    // Act
+    using (var manager = factory.CreateFromStream(streamId))
+    {
+      // Assert
+      manager.Should().NotBeNull();
+      manager.Path.Should().Be(expectedPath);
+      manager.Concurrency.Should().Be(SqLiteJsonCacheManagerFactory.INITIAL_CONCURRENCY);
+    }
+
+    // Cleanup
+    if (File.Exists(expectedPath))
+    {
+      File.Delete(expectedPath);
+    }
+  }
+
+  [Fact]
+  public void CreateFromStream_ShouldReturnCachedManagerForSameStreamId_AndCleanup()
+  {
+    // Arrange
+    var factory = new SqLiteJsonCacheManagerFactory();
+    var streamId = "stream123";
+    var expectedPath = SqlitePaths.GetDBPath(streamId);
+
+    // Act
+    using (var manager1 = factory.CreateFromStream(streamId))
+    {
+      using var manager2 = factory.CreateFromStream(streamId);
+
+      // Assert
+      manager1.Should().BeSameAs(manager2);
+    }
+
+    // Cleanup
+    if (File.Exists(expectedPath))
+    {
+      File.Delete(expectedPath);
+    }
+  }
+}


### PR DESCRIPTION
I don't like this solution (keep pools around forever) but need a way to track multiple sends THEN dispose.

This is just for the lifetime of a local app so it's not so bad