### PR TITLE
fix(api): Added WORKSPACE project visibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,8 @@ services:
       POSTGRES_PASSWORD: "speckle"
       POSTGRES_DB: "speckle"
       ENABLE_MP: "false"
+      
+      LOG_PRETTY: "true"
 
 networks:
   default:

--- a/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
@@ -2,9 +2,10 @@
 
 public enum ProjectVisibility
 {
-  Private = 0,
+  Private,
 
-  [Obsolete("Use Unlisted instead", true)]
-  Public = 1,
-  Unlisted = 2,
+  [Obsolete("Use Unlisted instead")]
+  Public,
+  Unlisted,
+  Workspaces,
 }

--- a/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
@@ -1,4 +1,4 @@
-﻿namespace Speckle.Sdk.Api.GraphQL.Enums;
+namespace Speckle.Sdk.Api.GraphQL.Enums;
 
 public enum ProjectVisibility
 {
@@ -7,5 +7,5 @@ public enum ProjectVisibility
   [Obsolete("Use Unlisted instead")]
   Public,
   Unlisted,
-  Workspaces,
+  Workspace,
 }

--- a/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
@@ -4,6 +4,7 @@ public enum ProjectVisibility
 {
   Private,
   Public,
+
   [Obsolete("Use Public instead")]
   Unlisted,
   Workspace,

--- a/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
@@ -3,9 +3,8 @@ namespace Speckle.Sdk.Api.GraphQL.Enums;
 public enum ProjectVisibility
 {
   Private,
-
-  [Obsolete("Use Unlisted instead")]
   Public,
+  [Obsolete("Use Public instead")]
   Unlisted,
   Workspace,
 }

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectInviteResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectInviteResourceTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Api.GraphQL;
+using Speckle.Sdk.Api.GraphQL.Enums;
 using Speckle.Sdk.Api.GraphQL.Inputs;
 using Speckle.Sdk.Api.GraphQL.Models;
 using Speckle.Sdk.Common;
@@ -18,7 +19,7 @@ public class ProjectInviteResourceTests : IAsyncLifetime
   {
     _inviter = await Fixtures.SeedUserWithClient();
     _invitee = await Fixtures.SeedUserWithClient();
-    _project = await _inviter.Project.Create(new("test", null, null));
+    _project = await _inviter.Project.Create(new("test", null, ProjectVisibility.Public));
     _createdInvite = await SeedInvite();
   }
 

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceExceptionalTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceExceptionalTests.cs
@@ -90,7 +90,7 @@ public class ProjectResourceExceptionalTests : IAsyncLifetime
   {
     var ex = await Assert.ThrowsAsync<AggregateException>(async () =>
       _ = await _unauthedUser.Project.CreateInWorkspace(
-        new(_testProject.id, "My new name", ProjectVisibility.Unlisted, "NonExistentWorkspace")
+        new(_testProject.id, "My new name", ProjectVisibility.Public, "NonExistentWorkspace")
       )
     );
     ex.InnerExceptions.Single().Should().BeOfType<SpeckleGraphQLException>();

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
@@ -29,7 +29,7 @@ public class ProjectResourceTests
 
   [Theory]
   [InlineData("Very private project", "My secret project", ProjectVisibility.Private)]
-  [InlineData("Very unlisted project", null, ProjectVisibility.Unlisted)]
+  [InlineData("Very unlisted project", null, ProjectVisibility.Public)]
   public async Task ProjectCreate_Should_CreateProjectSuccessfully(
     string name,
     string? description,
@@ -70,7 +70,7 @@ public class ProjectResourceTests
     // Arrange
     const string NEW_NAME = "MY new name";
     const string NEW_DESCRIPTION = "MY new desc";
-    const ProjectVisibility NEW_VISIBILITY = ProjectVisibility.Unlisted;
+    const ProjectVisibility NEW_VISIBILITY = ProjectVisibility.Public;
 
     // Act
     var newProject = await Sut.Update(

--- a/tests/Speckle.Sdk.Tests.Performance/Benchmarks/GeneralSendTest.cs
+++ b/tests/Speckle.Sdk.Tests.Performance/Benchmarks/GeneralSendTest.cs
@@ -57,7 +57,7 @@ public class GeneralSendTest
     client = TestDataHelper.ServiceProvider.GetRequiredService<IClientFactory>().Create(acc);
 
     _project = await client.Project.Create(
-      new($"General Send Test run {Guid.NewGuid()}", null, ProjectVisibility.Unlisted)
+      new($"General Send Test run {Guid.NewGuid()}", null, ProjectVisibility.Public)
     );
     _remote = TestDataHelper.ServiceProvider.GetRequiredService<IServerTransportFactory>().Create(acc, _project.id);
   }


### PR DESCRIPTION
A new ProjectVisiblity value was added to the schema - `WORKSPACES`
![image](https://github.com/user-attachments/assets/cb4aa8ba-ae9b-47a2-b731-6ba4b41fd779)

This change broke the SDKs ability to receive projects.

Luckily, impact is minimal (grasshopper v3, and workspace model creation in v2)