### PR TITLE
Fix(account): Fixed bug in account validity checks when DB contains empty rows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,8 @@ services:
       POSTGRES_PASSWORD: "speckle"
       POSTGRES_DB: "speckle"
       ENABLE_MP: "false"
+      
+      LOG_PRETTY: "true"
 
 networks:
   default:

--- a/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Enums/ProjectVisibility.cs
@@ -1,10 +1,11 @@
-﻿namespace Speckle.Sdk.Api.GraphQL.Enums;
+namespace Speckle.Sdk.Api.GraphQL.Enums;
 
 public enum ProjectVisibility
 {
-  Private = 0,
+  Private,
+  Public,
 
-  [Obsolete("Use Unlisted instead", true)]
-  Public = 1,
-  Unlisted = 2,
+  [Obsolete("Use Public instead")]
+  Unlisted,
+  Workspace,
 }

--- a/src/Speckle.Sdk/Credentials/AccountManager.cs
+++ b/src/Speckle.Sdk/Credentials/AccountManager.cs
@@ -328,7 +328,7 @@ public sealed class AccountManager(
   /// <returns>Un-enumerated enumerable of accounts</returns>
   public IEnumerable<Account> GetAccounts()
   {
-    static bool IsInvalid(Account ac) => ac.userInfo == null || ac.serverInfo == null;
+    static bool IsInvalid(Account? ac) => ac?.userInfo == null || ac.serverInfo == null;
 
     var sqlAccounts = _accountStorage.GetAllObjects().Select(x => JsonConvert.DeserializeObject<Account>(x.Json));
     var localAccounts = GetLocalAccounts();

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectInviteResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectInviteResourceTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Api.GraphQL;
+using Speckle.Sdk.Api.GraphQL.Enums;
 using Speckle.Sdk.Api.GraphQL.Inputs;
 using Speckle.Sdk.Api.GraphQL.Models;
 using Speckle.Sdk.Common;
@@ -18,7 +19,7 @@ public class ProjectInviteResourceTests : IAsyncLifetime
   {
     _inviter = await Fixtures.SeedUserWithClient();
     _invitee = await Fixtures.SeedUserWithClient();
-    _project = await _inviter.Project.Create(new("test", null, null));
+    _project = await _inviter.Project.Create(new("test", null, ProjectVisibility.Public));
     _createdInvite = await SeedInvite();
   }
 

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceExceptionalTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceExceptionalTests.cs
@@ -90,7 +90,7 @@ public class ProjectResourceExceptionalTests : IAsyncLifetime
   {
     var ex = await Assert.ThrowsAsync<AggregateException>(async () =>
       _ = await _unauthedUser.Project.CreateInWorkspace(
-        new(_testProject.id, "My new name", ProjectVisibility.Unlisted, "NonExistentWorkspace")
+        new(_testProject.id, "My new name", ProjectVisibility.Public, "NonExistentWorkspace")
       )
     );
     ex.InnerExceptions.Single().Should().BeOfType<SpeckleGraphQLException>();

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
@@ -29,7 +29,7 @@ public class ProjectResourceTests
 
   [Theory]
   [InlineData("Very private project", "My secret project", ProjectVisibility.Private)]
-  [InlineData("Very unlisted project", null, ProjectVisibility.Unlisted)]
+  [InlineData("Very unlisted project", null, ProjectVisibility.Public)]
   public async Task ProjectCreate_Should_CreateProjectSuccessfully(
     string name,
     string? description,
@@ -70,7 +70,7 @@ public class ProjectResourceTests
     // Arrange
     const string NEW_NAME = "MY new name";
     const string NEW_DESCRIPTION = "MY new desc";
-    const ProjectVisibility NEW_VISIBILITY = ProjectVisibility.Unlisted;
+    const ProjectVisibility NEW_VISIBILITY = ProjectVisibility.Public;
 
     // Act
     var newProject = await Sut.Update(

--- a/tests/Speckle.Sdk.Tests.Performance/Benchmarks/GeneralSendTest.cs
+++ b/tests/Speckle.Sdk.Tests.Performance/Benchmarks/GeneralSendTest.cs
@@ -57,7 +57,7 @@ public class GeneralSendTest
     client = TestDataHelper.ServiceProvider.GetRequiredService<IClientFactory>().Create(acc);
 
     _project = await client.Project.Create(
-      new($"General Send Test run {Guid.NewGuid()}", null, ProjectVisibility.Unlisted)
+      new($"General Send Test run {Guid.NewGuid()}", null, ProjectVisibility.Public)
     );
     _remote = TestDataHelper.ServiceProvider.GetRequiredService<IServerTransportFactory>().Create(acc, _project.id);
   }


### PR DESCRIPTION
This was completely a problem of my own making. I was experimenting yesterday with accounts, and got my DB in a weird state where there was an empty row.

![image](https://github.com/user-attachments/assets/7c7912cc-e102-45d8-960d-767294786141)

This was causing a big issue with connectors however, failing to load the UI completely
![image](https://github.com/user-attachments/assets/47df1dd1-e239-48f1-9af8-47dad4210180)
