### PR TITLE
Remove MD5 hashing and use SHA256 for Account IDs

### DIFF
--- a/src/Speckle.Sdk/Credentials/Account.cs
+++ b/src/Speckle.Sdk/Credentials/Account.cs
@@ -25,7 +25,7 @@ public class Account : IEquatable<Account>
           throw new InvalidOperationException("Incomplete account info: cannot generate id.");
         }
 
-        _id = Crypt.Md5(userInfo.email + serverInfo.url, "X2");
+        _id = Crypt.Sha256(userInfo.email + serverInfo.url, "X2");
       }
       return _id;
     }
@@ -62,13 +62,13 @@ public class Account : IEquatable<Account>
   public string GetHashedEmail()
   {
     string email = userInfo?.email ?? "unknown";
-    return "@" + Crypt.Md5(email, "X2");
+    return "@" + Crypt.Sha256(email, "X2");
   }
 
   public string GetHashedServer()
   {
     string url = serverInfo?.url ?? AccountManager.DEFAULT_SERVER_URL;
-    return Crypt.Md5(CleanURL(url), "X2");
+    return Crypt.Sha256(CleanURL(url), "X2");
   }
 
   public override string ToString()

--- a/src/Speckle.Sdk/Helpers/Crypt.cs
+++ b/src/Speckle.Sdk/Helpers/Crypt.cs
@@ -67,30 +67,4 @@ public static class Crypt
 
     return sb.ToString(0, length);
   }
-
-  /// <inheritdoc cref="Sha256(string, string?, int)"/>
-  /// <remarks>MD5 is a broken cryptographic algorithm and should be used subject to review see CA5351</remarks>
-  [Pure]
-  [SuppressMessage("Security", "CA5351:Do Not Use Broken Cryptographic Algorithms")]
-  public static string Md5(
-    string input,
-    [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = "x2",
-    int length = 32
-  )
-  {
-    byte[] inputBytes = Encoding.ASCII.GetBytes(input.ToLowerInvariant());
-#if NETSTANDARD2_0
-    using MD5 md5 = MD5.Create();
-    byte[] hashBytes = md5.ComputeHash(inputBytes);
-#else
-    byte[] hashBytes = MD5.HashData(inputBytes);
-#endif
-    StringBuilder sb = new(32);
-    for (int i = 0; i < hashBytes.Length; i++)
-    {
-      sb.Append(hashBytes[i].ToString(format));
-    }
-
-    return sb.ToString(0, length);
-  }
 }

--- a/tests/Speckle.Sdk.Tests.Unit/Models/UtilitiesTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Models/UtilitiesTests.cs
@@ -45,9 +45,6 @@ public sealed class HashUtilityTests
     }
   }
 
-  public static IEnumerable<object[]> SmallTestCasesMd5() =>
-    SmallTestCases(SmallTestCases(), EnumerableExtensions.RangeFrom(0, 32));
-
   public static IEnumerable<object[]> SmallTestCasesSha256() =>
     SmallTestCases(SmallTestCases(), EnumerableExtensions.RangeFrom(2, 64));
 
@@ -67,18 +64,6 @@ public sealed class HashUtilityTests
       new string(Enumerable.Range(0, 10_000_000).Select(_ => (char)random.Next(32, 127)).ToArray()),
       "f2e83101c3066c8a2983acdb92df53504ec00ac1e5afb71b7c3798cb4daf6162",
     ];
-  }
-
-  [Theory]
-  [MemberData(nameof(SmallTestCasesMd5))]
-  public void Md5(string input, string _, string expected, int length)
-  {
-    var resultLower = Crypt.Md5(input, "x2", length);
-    var resultUpper = Crypt.Md5(input, "X2", length);
-
-    resultLower.Should().Be(new string(expected.ToLower()[..length]));
-
-    resultUpper.Should().Be(new string(expected.ToUpper()[..length]));
   }
 
   [Theory]


### PR DESCRIPTION
Remove MD5 for FIPS mode on Windows