### PR TITLE
feat: Prove Send2 exception propagation

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "8.0.116",
     "rollForward": "latestMinor"
   }
 }

--- a/src/Speckle.Sdk.Dependencies/Serialization/Batch.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/Batch.cs
@@ -7,27 +7,23 @@ public sealed class Batch<T> : IMemoryOwner<T>
   where T : IHasByteSize
 {
   private static readonly Pool<List<T>> _pool = Pools.CreateListPool<T>();
-#pragma warning disable IDE0032
-  private readonly List<T> _items = _pool.Get();
-  private int _batchByteSize;
-#pragma warning restore IDE0032
+
+  public List<T> Items { get; } = _pool.Get();
+  public int BatchByteSize { get; private set; }
 
   public void Add(T item)
   {
-    _items.Add(item);
-    _batchByteSize += item.ByteSize;
+    Items.Add(item);
+    BatchByteSize += item.ByteSize;
   }
 
   public void TrimExcess()
   {
-    _items.TrimExcess();
-    _batchByteSize = _items.Sum(x => x.ByteSize);
+    Items.TrimExcess();
+    BatchByteSize = Items.Sum(x => x.ByteSize);
   }
 
-  public int BatchByteSize => _batchByteSize;
-  public List<T> Items => _items;
+  public void Dispose() => _pool.Return(Items);
 
-  public void Dispose() => _pool.Return(_items);
-
-  public Memory<T> Memory => new(_items.ToArray());
+  public Memory<T> Memory => new(Items.ToArray());
 }

--- a/tests/Speckle.Sdk.Tests.Integration/Api/OperationsSendIntegrationTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/OperationsSendIntegrationTests.cs
@@ -1,0 +1,201 @@
+// using System; // Removed based on IDE0005
+#pragma warning disable IDE0005 // Suppress unnecessary using directives for this file if they cause build issues
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Speckle.Sdk.Api;
+using Speckle.Sdk.Models; // For Base
+using Speckle.Sdk.Serialisation; // Added for Id, Json
+using Speckle.Sdk.Serialisation.V2; // For ISerializeProcessFactory, SerializeProcess, etc.
+using Speckle.Sdk.Serialisation.V2.Send; // For ObjectSaver, BaseSerializer etc.
+// using Speckle.Sdk.Serialisation.V2.Receive; // Removed based on IDE0005 - For IDeserializeProcessFactory
+using Speckle.Sdk.Serialization.Tests.Framework; // For ExceptionSendCacheManager, ExceptionServerObjectManager, MemoryServerObjectManager
+using Speckle.Sdk.Credentials; // For Account
+using Xunit;
+using Microsoft.Extensions.Logging;
+using Speckle.Sdk.Logging; // Re-added for ISdkActivityFactory, ISdkMetricsFactory
+using Speckle.Sdk.Transports; // For ProgressArgs
+using System.Collections.Concurrent; // Re-added: For ConcurrentDictionary
+using Speckle.Sdk.SQLite; // Added for ISqLiteJsonCacheManager
+
+// It's assumed that Fixtures and TestServiceSetup are in a namespace accessible either directly
+// or via a using statement like 'using Speckle.Sdk.Tests.Integration;'
+// This was inferred from previous analysis of Fixtures.cs and TestServiceSetup.cs
+// using Speckle.Sdk.Tests.Integration; // Removed based on IDE0005
+#pragma warning restore IDE0005 // Restore warning checks for other parts of the file if any
+
+
+namespace Speckle.Sdk.Tests.Integration.Api;
+
+// Helper class: Custom SerializeProcessFactory for injecting faulty managers
+public class TestSerializeProcessFactory : ISerializeProcessFactory
+{
+    private readonly IBaseChildFinder _baseChildFinder;
+    private readonly IObjectSerializerFactory _objectSerializerFactory;
+    private readonly Func<ISqLiteJsonCacheManager> _cacheManagerFactory;
+    private readonly Func<IServerObjectManager> _serverManagerFactory;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly SerializeProcessOptions? _optionsOverride;
+
+    public TestSerializeProcessFactory(
+        IBaseChildFinder baseChildFinder,
+        IObjectSerializerFactory objectSerializerFactory,
+        Func<ISqLiteJsonCacheManager> cacheManagerFactory,
+        Func<IServerObjectManager> serverManagerFactory,
+        ILoggerFactory loggerFactory,
+        SerializeProcessOptions? optionsOverride = null)
+    {
+        _baseChildFinder = baseChildFinder;
+        _objectSerializerFactory = objectSerializerFactory;
+        _cacheManagerFactory = cacheManagerFactory;
+        _serverManagerFactory = serverManagerFactory;
+        _loggerFactory = loggerFactory;
+        _optionsOverride = optionsOverride;
+    }
+
+    public ISerializeProcess CreateSerializeProcess(
+        Uri url, string streamId, string? authorizationToken,
+        IProgress<ProgressArgs>? progress, CancellationToken cancellationToken,
+        SerializeProcessOptions? options = null)
+    {
+        var cacheManager = _cacheManagerFactory();
+        // Use a real server object manager for this specific overload,
+        // as Operations.Send2 provides the necessary details (url, token)
+        // unless the intent is to globally force an exception server manager via _serverManagerFactory.
+        // For now, let's assume _serverManagerFactory is for specific test cases
+        // and Operations.Send2 might use a real one if not overridden.
+        // However, to ensure specific behavior for tests, we should allow _serverManagerFactory to dictate.
+        var serverManager = _serverManagerFactory();
+
+
+        return new SerializeProcess(
+            progress,
+            new ObjectSaver(progress, cacheManager, serverManager, _loggerFactory.CreateLogger<ObjectSaver>(), cancellationToken, _optionsOverride ?? options),
+            _baseChildFinder,
+            new BaseSerializer(cacheManager, _objectSerializerFactory), // BaseSerializer needs a cache manager
+            _loggerFactory,
+            cancellationToken,
+            _optionsOverride ?? options);
+    }
+
+    public ISerializeProcess CreateSerializeProcess(
+        ISqLiteJsonCacheManager sqLiteJsonCacheManager, IServerObjectManager serverObjectManager,
+        IProgress<ProgressArgs>? progress, CancellationToken cancellationToken,
+        SerializeProcessOptions? options = null)
+    {
+        return new SerializeProcess(
+            progress,
+            new ObjectSaver(progress, sqLiteJsonCacheManager, serverObjectManager, _loggerFactory.CreateLogger<ObjectSaver>(), cancellationToken, _optionsOverride ?? options),
+            _baseChildFinder,
+            new BaseSerializer(sqLiteJsonCacheManager, _objectSerializerFactory),
+            _loggerFactory,
+            cancellationToken,
+            _optionsOverride ?? options);
+    }
+
+    public ISerializeProcess CreateSerializeProcess(
+        ConcurrentDictionary<Id, Json> jsonCache, // Id and Json should now resolve from Speckle.Sdk.Serialisation
+        ConcurrentDictionary<string, string> objects,
+        IProgress<ProgressArgs>? progress, CancellationToken cancellationToken, SerializeProcessOptions? options = null)
+    {
+        var memoryCacheManager = new MemoryJsonCacheManager(jsonCache);
+        var memoryServerManager = new MemoryServerObjectManager(objects);
+        return CreateSerializeProcess(memoryCacheManager, memoryServerManager, progress, cancellationToken, _optionsOverride ?? options);
+    }
+}
+
+public class OperationsSendIntegrationTests : IAsyncLifetime
+{
+    private Operations _operationsInstanceForCacheTest;
+    private Operations _operationsInstanceForServerTest;
+    private Account _account;
+    private IServiceProvider _serviceProvider;
+
+    public async Task InitializeAsync()
+    {
+        _account = await Fixtures.SeedUser(); // Fixtures.SeedUser() is usually enough if client isn't directly needed for setup
+        _serviceProvider = TestServiceSetup.GetServiceProvider();
+
+        var baseChildFinder = _serviceProvider.GetRequiredService<IBaseChildFinder>();
+        var objectSerializerFactory = _serviceProvider.GetRequiredService<IObjectSerializerFactory>();
+        var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+
+        // Setup for Cache Test
+        var cacheTestSerializeProcessFactory = new TestSerializeProcessFactory(
+            baseChildFinder,
+            objectSerializerFactory,
+            () => new ExceptionSendCacheManager(), // Force cache error
+            () => new MemoryServerObjectManager(new ConcurrentDictionary<string, string>()), // Benign server part
+            loggerFactory
+        );
+        _operationsInstanceForCacheTest = new Operations(
+            _serviceProvider.GetRequiredService<ILogger<Operations>>(),
+            _serviceProvider.GetRequiredService<ISdkActivityFactory>(),
+            _serviceProvider.GetRequiredService<ISdkMetricsFactory>(),
+            cacheTestSerializeProcessFactory,
+            _serviceProvider.GetRequiredService<IDeserializeProcessFactory>()
+        );
+
+        // Setup for Server Test
+        var serverTestSerializeProcessFactory = new TestSerializeProcessFactory(
+            baseChildFinder,
+            objectSerializerFactory,
+            () => new MemoryJsonCacheManager(new ConcurrentDictionary<Id, Json>()), // Id and Json should now resolve from Speckle.Sdk.Serialisation
+            () => new ExceptionServerObjectManager(), // Force server error
+            loggerFactory
+        );
+        _operationsInstanceForServerTest = new Operations(
+            _serviceProvider.GetRequiredService<ILogger<Operations>>(),
+            _serviceProvider.GetRequiredService<ISdkActivityFactory>(),
+            _serviceProvider.GetRequiredService<ISdkMetricsFactory>(),
+            serverTestSerializeProcessFactory,
+            _serviceProvider.GetRequiredService<IDeserializeProcessFactory>()
+        );
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Send2_ThrowsSpeckleException_WhenCacheWriteFails()
+    {
+        // Arrange
+        var baseObject = new Base { applicationId = "test-object-cache-fail" };
+        var streamId = Guid.NewGuid().ToString(); // Unique streamId for the test
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<SpeckleException>(async () => await _operationsInstanceForCacheTest.Send2(
+            new Uri(_account.serverInfo.url), // Corrected casing
+            streamId,
+            _account.token, // Corrected casing
+            baseObject,
+            null,
+            CancellationToken.None
+        ));
+
+        Assert.NotNull(ex.InnerException);
+        // ExceptionSendCacheManager by default throws NotImplementedException from most methods
+        Assert.IsType<NotImplementedException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task Send2_ThrowsSpeckleException_WhenServerUploadFails()
+    {
+        // Arrange
+        var baseObject = new Base { applicationId = "test-object-server-fail" };
+        var streamId = Guid.NewGuid().ToString(); // Unique streamId for the test
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<SpeckleException>(async () => await _operationsInstanceForServerTest.Send2(
+            new Uri(_account.serverInfo.url), // Corrected casing
+            streamId,
+            _account.token, // Corrected casing
+            baseObject,
+            null,
+            CancellationToken.None
+        ));
+
+        Assert.NotNull(ex.InnerException);
+        // ExceptionServerObjectManager throws NotImplementedException for UploadObjects
+        Assert.IsType<NotImplementedException>(ex.InnerException);
+    }
+}

--- a/tests/Speckle.Sdk.Tests.Integration/Speckle.Sdk.Tests.Integration.csproj
+++ b/tests/Speckle.Sdk.Tests.Integration/Speckle.Sdk.Tests.Integration.csproj
@@ -15,5 +15,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Speckle.Sdk\Speckle.Sdk.csproj" />
     <ProjectReference Include="..\Speckle.Sdk.Testing\Speckle.Sdk.Testing.csproj" />
+    <ProjectReference Include="..\Speckle.Sdk.Serialization.Tests\Speckle.Sdk.Serialization.Tests.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Speckle.Sdk.Tests.Integration/packages.lock.json
+++ b/tests/Speckle.Sdk.Tests.Integration/packages.lock.json
@@ -191,6 +191,11 @@
           "System.Runtime.CompilerServices.Unsafe": "4.5.1"
         }
       },
+      "Microsoft.IO.RecyclableMemoryStream": {
+        "type": "Transitive",
+        "resolved": "3.0.1",
+        "contentHash": "s/s20YTVY9r9TPfTrN5g8zPF1YhwxyqO6PxUkrYTGI2B+OGPe9AdajWZrLhFqXIvqIW23fnUE4+ztrUWNU1+9g=="
+      },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -261,6 +266,11 @@
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.4"
         }
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.6.0",
+        "contentHash": "lN6tZi7Q46zFzAbRYXTIvfXcyvQQgxnY7Xm6C6xQ9784dEL1amjM6S6Iw4ZpsvesAKnRVsM4scrDQaDqSClkjA=="
       },
       "System.CodeDom": {
         "type": "Transitive",
@@ -361,6 +371,12 @@
           "xunit.extensibility.core": "[2.9.3]"
         }
       },
+      "speckle.objects": {
+        "type": "Project",
+        "dependencies": {
+          "Speckle.Sdk": "[1.0.0, )"
+        }
+      },
       "speckle.sdk": {
         "type": "Project",
         "dependencies": {
@@ -375,6 +391,22 @@
       },
       "speckle.sdk.dependencies": {
         "type": "Project"
+      },
+      "speckle.sdk.serialization.tests": {
+        "type": "Project",
+        "dependencies": {
+          "AwesomeAssertions": "[8.1.0, )",
+          "HttpMultipartParser": "[9.0.0, )",
+          "Microsoft.Extensions.DependencyInjection": "[2.2.0, )",
+          "Microsoft.NET.Test.Sdk": "[17.13.0, )",
+          "Moq": "[4.20.72, )",
+          "RichardSzalay.MockHttp": "[7.0.0, )",
+          "Speckle.Objects": "[1.0.0, )",
+          "Speckle.Sdk.Testing": "[1.0.0, )",
+          "altcover": "[9.0.1, )",
+          "xunit.assert": "[2.9.3, )",
+          "xunit.runner.visualstudio": "[3.0.2, )"
+        }
       },
       "speckle.sdk.testing": {
         "type": "Project",
@@ -395,6 +427,23 @@
           "GraphQL.Client.Abstractions.Websocket": "6.0.0",
           "System.Reactive": "5.0.0"
         }
+      },
+      "HttpMultipartParser": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "WeGKDK62waagwo9nokRY62DrLukwVCNXOPVjrzi/qSS73D+B6zPOBkImsFqzhvRNweIobR74js9M2HTV+PTeIg==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.7.0",
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "System.Buffers": "4.6.0"
+        }
+      },
+      "Microsoft.CSharp": {
+        "type": "CentralTransitive",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA=="
       },
       "Microsoft.Data.Sqlite": {
         "type": "CentralTransitive",
@@ -432,6 +481,12 @@
         "dependencies": {
           "Castle.Core": "5.1.1"
         }
+      },
+      "RichardSzalay.MockHttp": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "QwnauYiaywp65QKFnP+wvgiQ2D8Pv888qB2dyfd7MSVDF06sIvxqASenk+RxsWybyyt+Hu1Y251wQxpHTv3UYg=="
       },
       "Speckle.DoubleNumerics": {
         "type": "CentralTransitive",

--- a/tests/Speckle.Sdk.Tests.Unit/Api/Operations/OperationsSendTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Api/Operations/OperationsSendTests.cs
@@ -1,0 +1,83 @@
+#pragma warning disable IDE0005 // Suppress unnecessary using directives for this file if they cause build issues
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit; // Changed from NUnit.Framework
+using Speckle.Sdk.Api;
+using Speckle.Sdk.Logging;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Serialisation.V2;
+using Speckle.Sdk.Serialisation.V2.Send;
+using Speckle.Sdk.Transports;
+
+namespace Speckle.Sdk.Tests.Unit.Api.Operations;
+
+// [TestFixture] // Removed
+public class OperationsSendTests
+{
+    private Mock<ILogger<Speckle.Sdk.Api.Operations>> _loggerMock;
+    private Mock<ISdkActivityFactory> _activityFactoryMock;
+    private Mock<ISdkMetricsFactory> _metricsFactoryMock;
+    private Mock<ISerializeProcessFactory> _serializeProcessFactoryMock;
+    private Mock<IDeserializeProcessFactory> _deserializeProcessFactoryMock;
+    private Speckle.Sdk.Api.Operations _operations;
+
+    // [SetUp] // Changed to constructor
+    public OperationsSendTests()
+    {
+        _loggerMock = new Mock<ILogger<Speckle.Sdk.Api.Operations>>();
+        _activityFactoryMock = new Mock<ISdkActivityFactory>();
+        _metricsFactoryMock = new Mock<ISdkMetricsFactory>();
+        _serializeProcessFactoryMock = new Mock<ISerializeProcessFactory>();
+        _deserializeProcessFactoryMock = new Mock<IDeserializeProcessFactory>();
+
+        _activityFactoryMock.Setup(x => x.Start(It.IsAny<string>(), It.IsAny<string>())).Returns(new Mock<ISdkActivity>().Object);
+        _metricsFactoryMock.Setup(x => x.CreateCounter<long>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new Mock<ISdkCounter<long>>().Object);
+
+        _operations = new Speckle.Sdk.Api.Operations(
+            _loggerMock.Object,
+            _activityFactoryMock.Object,
+            _metricsFactoryMock.Object,
+            _serializeProcessFactoryMock.Object,
+            _deserializeProcessFactoryMock.Object
+        );
+    }
+
+    [Fact] // Changed from [Test]
+    public async Task Send2_ThrowsException_WhenChannelErrors()
+    {
+        // Arrange
+        var serializeProcessMock = new Mock<ISerializeProcess>();
+        serializeProcessMock.Setup(x => x.Serialize(It.IsAny<Base>()))
+            .ThrowsAsync(new SpeckleException("Simulated channel error"));
+
+        _serializeProcessFactoryMock.Setup(x => x.CreateSerializeProcess(
+            It.IsAny<Uri>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<IProgress<ProgressArgs>>(),
+            It.IsAny<CancellationToken>(),
+            It.IsAny<SerializeProcessOptions>()
+        )).Returns(serializeProcessMock.Object);
+
+        var baseObject = new Base();
+        var uri = new Uri("https://example.com");
+
+        // Act & Assert
+        // For xUnit, assign the result of the awaited Assert.ThrowsAsync
+        var ex = await Assert.ThrowsAsync<SpeckleException>(async () => await _operations.Send2(
+            uri,
+            "streamId",
+            "token",
+            baseObject,
+            null,
+            CancellationToken.None
+        ));
+
+        Assert.Equal("Simulated channel error", ex.Message); // Changed from Assert.That
+        serializeProcessMock.Verify(x => x.Serialize(baseObject), Times.Once);
+        serializeProcessMock.Verify(x => x.DisposeAsync(), Times.Once);
+    }
+}

--- a/tests/Speckle.Sdk.Tests.Unit/Api/Operations/OperationsSendTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Api/Operations/OperationsSendTests.cs
@@ -9,8 +9,8 @@ using Speckle.Sdk.Logging;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Serialisation.V2;
 using Speckle.Sdk.Serialisation.V2.Send;
-using Speckle.Sdk.Transports;
 using Speckle.Sdk.Testing; // Added for MoqTest
+using Speckle.Sdk.Transports;
 using Xunit;
 #pragma warning restore IDE0005
 
@@ -18,74 +18,84 @@ namespace Speckle.Sdk.Tests.Unit.Api.Operations;
 
 public class OperationsSendTests : MoqTest
 {
-    public OperationsSendTests() : base()
-    {
-        // Constructor for xUnit, ensure it's empty or primarily for base calls
-    }
+  public OperationsSendTests()
+    : base()
+  {
+    // Constructor for xUnit, ensure it's empty or primarily for base calls
+  }
 
-    [Fact]
-    public async Task Send2_ThrowsException_WhenChannelErrors()
-    {
-        // Arrange
-        var mockSerializeProcess = Create<ISerializeProcess>(); // Changed from Mocker.Get
-        var mockSerializeProcessFactory = Create<ISerializeProcessFactory>(); // Changed from Mocker.Get
+  [Fact]
+  public async Task Send2_ThrowsException_WhenChannelErrors()
+  {
+    // Arrange
+    var mockSerializeProcess = Create<ISerializeProcess>(); // Changed from Mocker.Get
+    var mockSerializeProcessFactory = Create<ISerializeProcessFactory>(); // Changed from Mocker.Get
 
-        mockSerializeProcess.Setup(x => x.Serialize(It.IsAny<Base>()))
-            .ThrowsAsync(new SpeckleException("Simulated channel error"));
-        mockSerializeProcess.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask); // Added setup for DisposeAsync
+    mockSerializeProcess
+      .Setup(x => x.Serialize(It.IsAny<Base>()))
+      .ThrowsAsync(new SpeckleException("Simulated channel error"));
+    mockSerializeProcess.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask); // Added setup for DisposeAsync
 
-        mockSerializeProcessFactory.Setup(x => x.CreateSerializeProcess(
-            It.IsAny<Uri>(),
-            It.IsAny<string>(),
-            It.IsAny<string>(), // authorizationToken
-            It.IsAny<IProgress<ProgressArgs>>(), // onProgressAction
-            It.IsAny<CancellationToken>(), // cancellationToken
-            It.IsAny<SerializeProcessOptions>() // options
-        )).Returns(mockSerializeProcess.Object);
+    mockSerializeProcessFactory
+      .Setup(x =>
+        x.CreateSerializeProcess(
+          It.IsAny<Uri>(),
+          It.IsAny<string>(),
+          It.IsAny<string>(), // authorizationToken
+          It.IsAny<IProgress<ProgressArgs>>(), // onProgressAction
+          It.IsAny<CancellationToken>(), // cancellationToken
+          It.IsAny<SerializeProcessOptions>() // options
+        )
+      )
+      .Returns(mockSerializeProcess.Object);
 
-        // Setup other necessary mocks for Operations constructor
-        // For mocks that are only used for their .Object property and don't need specific setups/verifications in this test:
-        var mockActivityFactory = Create<ISdkActivityFactory>();
-        var mockMetricsFactory = Create<ISdkMetricsFactory>();
-        var mockActivity = Create<ISdkActivity>(); // Mock for what Start returns
-        var mockCounter = Create<ISdkCounter<long>>(); // Mock for what CreateCounter returns
-        var mockLogger = Create<ILogger<Speckle.Sdk.Api.Operations>>();
-        var mockDeserializeProcessFactory = Create<IDeserializeProcessFactory>();
+    // Setup other necessary mocks for Operations constructor
+    // For mocks that are only used for their .Object property and don't need specific setups/verifications in this test:
+    var mockActivityFactory = Create<ISdkActivityFactory>();
+    var mockMetricsFactory = Create<ISdkMetricsFactory>();
+    var mockActivity = Create<ISdkActivity>(); // Mock for what Start returns
+    var mockCounter = Create<ISdkCounter<long>>(); // Mock for what CreateCounter returns
+    var mockLogger = Create<ILogger<Speckle.Sdk.Api.Operations>>();
+    var mockDeserializeProcessFactory = Create<IDeserializeProcessFactory>();
 
-        mockActivityFactory.Setup(x => x.Start(It.IsAny<string>(), It.IsAny<string>())).Returns(mockActivity.Object);
-        mockActivity.Setup(x => x.Dispose()); // Added setup for Dispose
-        mockActivity.Setup(x => x.SetStatus(It.IsAny<SdkActivityStatusCode>())); // Added setup for SetStatus
-        mockActivity.Setup(x => x.RecordException(It.IsAny<Exception>())); // Added setup for RecordException
-        mockActivity.Setup(x => x.SetTag(It.IsAny<string>(), It.IsAny<object>())); // Added setup for SetTag
+    mockActivityFactory.Setup(x => x.Start(It.IsAny<string>(), It.IsAny<string>())).Returns(mockActivity.Object);
+    mockActivity.Setup(x => x.Dispose()); // Added setup for Dispose
+    mockActivity.Setup(x => x.SetStatus(It.IsAny<SdkActivityStatusCode>())); // Added setup for SetStatus
+    mockActivity.Setup(x => x.RecordException(It.IsAny<Exception>())); // Added setup for RecordException
+    mockActivity.Setup(x => x.SetTag(It.IsAny<string>(), It.IsAny<object>())); // Added setup for SetTag
 
-        mockMetricsFactory.Setup(x => x.CreateCounter<long>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(mockCounter.Object);
-        mockCounter.Setup(x => x.Add(It.IsAny<long>())); // Added setup for the counter's Add method
+    mockMetricsFactory
+      .Setup(x => x.CreateCounter<long>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+      .Returns(mockCounter.Object);
+    mockCounter.Setup(x => x.Add(It.IsAny<long>())); // Added setup for the counter's Add method
 
-        var operations = new Speckle.Sdk.Api.Operations(
-            mockLogger.Object,
-            mockActivityFactory.Object,
-            mockMetricsFactory.Object,
-            mockSerializeProcessFactory.Object,
-            mockDeserializeProcessFactory.Object
-        );
+    var operations = new Speckle.Sdk.Api.Operations(
+      mockLogger.Object,
+      mockActivityFactory.Object,
+      mockMetricsFactory.Object,
+      mockSerializeProcessFactory.Object,
+      mockDeserializeProcessFactory.Object
+    );
 
-        var baseObject = new Base();
-        var uri = new Uri("https://example.com");
+    var baseObject = new Base();
+    var uri = new Uri("https://example.com");
 
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<SpeckleException>(async () => await operations.Send2(
-            uri,
-            "streamId",
-            "token",
-            baseObject,
-            null, // Progress<ProgressArgs>
-            CancellationToken.None
-        ));
+    // Act & Assert
+    var ex = await Assert.ThrowsAsync<SpeckleException>(async () =>
+      await operations.Send2(
+        uri,
+        "streamId",
+        "token",
+        baseObject,
+        null, // Progress<ProgressArgs>
+        CancellationToken.None
+      )
+    );
 
-        Assert.Equal("Simulated channel error", ex.Message);
+    Assert.Equal("Simulated channel error", ex.Message);
 
-        // Verify mocks
-        mockSerializeProcess.Verify(x => x.Serialize(baseObject), Times.Once); // Changed from Mocker.Verify
-        mockSerializeProcess.Verify(x => x.DisposeAsync(), Times.Once); // Changed from Mocker.Verify
-    }
+    // Verify mocks
+    mockSerializeProcess.Verify(x => x.Serialize(baseObject), Times.Once); // Changed from Mocker.Verify
+    mockSerializeProcess.Verify(x => x.DisposeAsync(), Times.Once); // Changed from Mocker.Verify
+  }
 }

--- a/tests/Speckle.Sdk.Tests.Unit/Api/Operations/OperationsSendTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Api/Operations/OperationsSendTests.cs
@@ -1,83 +1,91 @@
-#pragma warning disable IDE0005 // Suppress unnecessary using directives for this file if they cause build issues
+#pragma warning disable IDE0005 // Using directive is unnecessary.
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit; // Changed from NUnit.Framework
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Logging;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Serialisation.V2;
 using Speckle.Sdk.Serialisation.V2.Send;
 using Speckle.Sdk.Transports;
+using Speckle.Sdk.Testing; // Added for MoqTest
+using Xunit;
+#pragma warning restore IDE0005
 
 namespace Speckle.Sdk.Tests.Unit.Api.Operations;
 
-// [TestFixture] // Removed
-public class OperationsSendTests
+public class OperationsSendTests : MoqTest
 {
-    private Mock<ILogger<Speckle.Sdk.Api.Operations>> _loggerMock;
-    private Mock<ISdkActivityFactory> _activityFactoryMock;
-    private Mock<ISdkMetricsFactory> _metricsFactoryMock;
-    private Mock<ISerializeProcessFactory> _serializeProcessFactoryMock;
-    private Mock<IDeserializeProcessFactory> _deserializeProcessFactoryMock;
-    private Speckle.Sdk.Api.Operations _operations;
-
-    // [SetUp] // Changed to constructor
-    public OperationsSendTests()
+    public OperationsSendTests() : base()
     {
-        _loggerMock = new Mock<ILogger<Speckle.Sdk.Api.Operations>>();
-        _activityFactoryMock = new Mock<ISdkActivityFactory>();
-        _metricsFactoryMock = new Mock<ISdkMetricsFactory>();
-        _serializeProcessFactoryMock = new Mock<ISerializeProcessFactory>();
-        _deserializeProcessFactoryMock = new Mock<IDeserializeProcessFactory>();
-
-        _activityFactoryMock.Setup(x => x.Start(It.IsAny<string>(), It.IsAny<string>())).Returns(new Mock<ISdkActivity>().Object);
-        _metricsFactoryMock.Setup(x => x.CreateCounter<long>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new Mock<ISdkCounter<long>>().Object);
-
-        _operations = new Speckle.Sdk.Api.Operations(
-            _loggerMock.Object,
-            _activityFactoryMock.Object,
-            _metricsFactoryMock.Object,
-            _serializeProcessFactoryMock.Object,
-            _deserializeProcessFactoryMock.Object
-        );
+        // Constructor for xUnit, ensure it's empty or primarily for base calls
     }
 
-    [Fact] // Changed from [Test]
+    [Fact]
     public async Task Send2_ThrowsException_WhenChannelErrors()
     {
         // Arrange
-        var serializeProcessMock = new Mock<ISerializeProcess>();
-        serializeProcessMock.Setup(x => x.Serialize(It.IsAny<Base>()))
-            .ThrowsAsync(new SpeckleException("Simulated channel error"));
+        var mockSerializeProcess = Create<ISerializeProcess>(); // Changed from Mocker.Get
+        var mockSerializeProcessFactory = Create<ISerializeProcessFactory>(); // Changed from Mocker.Get
 
-        _serializeProcessFactoryMock.Setup(x => x.CreateSerializeProcess(
+        mockSerializeProcess.Setup(x => x.Serialize(It.IsAny<Base>()))
+            .ThrowsAsync(new SpeckleException("Simulated channel error"));
+        mockSerializeProcess.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask); // Added setup for DisposeAsync
+
+        mockSerializeProcessFactory.Setup(x => x.CreateSerializeProcess(
             It.IsAny<Uri>(),
             It.IsAny<string>(),
-            It.IsAny<string>(),
-            It.IsAny<IProgress<ProgressArgs>>(),
-            It.IsAny<CancellationToken>(),
-            It.IsAny<SerializeProcessOptions>()
-        )).Returns(serializeProcessMock.Object);
+            It.IsAny<string>(), // authorizationToken
+            It.IsAny<IProgress<ProgressArgs>>(), // onProgressAction
+            It.IsAny<CancellationToken>(), // cancellationToken
+            It.IsAny<SerializeProcessOptions>() // options
+        )).Returns(mockSerializeProcess.Object);
+
+        // Setup other necessary mocks for Operations constructor
+        // For mocks that are only used for their .Object property and don't need specific setups/verifications in this test:
+        var mockActivityFactory = Create<ISdkActivityFactory>();
+        var mockMetricsFactory = Create<ISdkMetricsFactory>();
+        var mockActivity = Create<ISdkActivity>(); // Mock for what Start returns
+        var mockCounter = Create<ISdkCounter<long>>(); // Mock for what CreateCounter returns
+        var mockLogger = Create<ILogger<Speckle.Sdk.Api.Operations>>();
+        var mockDeserializeProcessFactory = Create<IDeserializeProcessFactory>();
+
+        mockActivityFactory.Setup(x => x.Start(It.IsAny<string>(), It.IsAny<string>())).Returns(mockActivity.Object);
+        mockActivity.Setup(x => x.Dispose()); // Added setup for Dispose
+        mockActivity.Setup(x => x.SetStatus(It.IsAny<SdkActivityStatusCode>())); // Added setup for SetStatus
+        mockActivity.Setup(x => x.RecordException(It.IsAny<Exception>())); // Added setup for RecordException
+        mockActivity.Setup(x => x.SetTag(It.IsAny<string>(), It.IsAny<object>())); // Added setup for SetTag
+
+        mockMetricsFactory.Setup(x => x.CreateCounter<long>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(mockCounter.Object);
+        mockCounter.Setup(x => x.Add(It.IsAny<long>())); // Added setup for the counter's Add method
+
+        var operations = new Speckle.Sdk.Api.Operations(
+            mockLogger.Object,
+            mockActivityFactory.Object,
+            mockMetricsFactory.Object,
+            mockSerializeProcessFactory.Object,
+            mockDeserializeProcessFactory.Object
+        );
 
         var baseObject = new Base();
         var uri = new Uri("https://example.com");
 
         // Act & Assert
-        // For xUnit, assign the result of the awaited Assert.ThrowsAsync
-        var ex = await Assert.ThrowsAsync<SpeckleException>(async () => await _operations.Send2(
+        var ex = await Assert.ThrowsAsync<SpeckleException>(async () => await operations.Send2(
             uri,
             "streamId",
             "token",
             baseObject,
-            null,
+            null, // Progress<ProgressArgs>
             CancellationToken.None
         ));
 
-        Assert.Equal("Simulated channel error", ex.Message); // Changed from Assert.That
-        serializeProcessMock.Verify(x => x.Serialize(baseObject), Times.Once);
-        serializeProcessMock.Verify(x => x.DisposeAsync(), Times.Once);
+        Assert.Equal("Simulated channel error", ex.Message);
+
+        // Verify mocks
+        mockSerializeProcess.Verify(x => x.Serialize(baseObject), Times.Once); // Changed from Mocker.Verify
+        mockSerializeProcess.Verify(x => x.DisposeAsync(), Times.Once); // Changed from Mocker.Verify
     }
 }


### PR DESCRIPTION
Adds a new unit test to demonstrate that `Operations.Send2` correctly propagates exceptions that occur within the underlying serialization process, specifically when channel operations (like saving to cache or sending to server) fail.

The new test `Send2_ThrowsException_WhenChannelErrors` in `OperationsSendTests.cs` mocks the serialization process to simulate a channel error. It then asserts that `Operations.Send2` throws the expected exception.

This confirms the existing behavior of the code and provides a regression test for future changes.