### PR TITLE
Use an object saver per stream instead of sqlite manager per stream

### DIFF
--- a/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
+++ b/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
@@ -12,16 +12,19 @@ public partial interface ISqLiteJsonCacheManager : IDisposable;
 public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
 {
   private readonly CacheDbCommandPool _pool;
+  
+  public string Path {get;}
 
   public static ISqLiteJsonCacheManager FromMemory(int concurrency) => new SqLiteJsonCacheManager(concurrency);
 
   private SqLiteJsonCacheManager(int concurrency)
   {
+    Path =  ":memory:";
     //disable pooling as we pool ourselves
     var builder = new SqliteConnectionStringBuilder
     {
       Pooling = false,
-      DataSource = ":memory:",
+      DataSource = Path,
       Cache = SqliteCacheMode.Shared,
       Mode = SqliteOpenMode.Memory,
     };
@@ -34,8 +37,9 @@ public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
 
   private SqLiteJsonCacheManager(string path, int concurrency)
   {
+    Path = path;
     //disable pooling as we pool ourselves
-    var builder = new SqliteConnectionStringBuilder { Pooling = false, DataSource = path };
+    var builder = new SqliteConnectionStringBuilder { Pooling = false, DataSource = Path };
     _pool = new CacheDbCommandPool(builder.ToString(), concurrency);
     Initialize();
   }

--- a/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
+++ b/src/Speckle.Sdk/SQLite/SQLiteJsonCacheManager.cs
@@ -12,14 +12,14 @@ public partial interface ISqLiteJsonCacheManager : IDisposable;
 public sealed class SqLiteJsonCacheManager : ISqLiteJsonCacheManager
 {
   private readonly CacheDbCommandPool _pool;
-  
-  public string Path {get;}
+
+  public string Path { get; }
 
   public static ISqLiteJsonCacheManager FromMemory(int concurrency) => new SqLiteJsonCacheManager(concurrency);
 
   private SqLiteJsonCacheManager(int concurrency)
   {
-    Path =  ":memory:";
+    Path = ":memory:";
     //disable pooling as we pool ourselves
     var builder = new SqliteConnectionStringBuilder
     {

--- a/src/Speckle.Sdk/Serialisation/V2/MemoryJsonCacheManager.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/MemoryJsonCacheManager.cs
@@ -8,7 +8,7 @@ public class MemoryJsonCacheManager(ConcurrentDictionary<Id, Json> jsonCache) : 
 #pragma warning restore CA1063
 {
 #pragma warning disable CA1065
-  public string Path => throw new NotImplementedException();
+  public string Path => "MemoryJsonCacheManager";
 #pragma warning restore CA1065
 
   public IReadOnlyCollection<(string Id, string Json)> GetAllObjects() =>

--- a/src/Speckle.Sdk/Serialisation/V2/MemoryJsonCacheManager.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/MemoryJsonCacheManager.cs
@@ -7,6 +7,10 @@ namespace Speckle.Sdk.Serialisation.V2;
 public class MemoryJsonCacheManager(ConcurrentDictionary<Id, Json> jsonCache) : ISqLiteJsonCacheManager
 #pragma warning restore CA1063
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+#pragma warning restore CA1065
+
   public IReadOnlyCollection<(string Id, string Json)> GetAllObjects() =>
     jsonCache.Select(x => (x.Key.Value, x.Value.Value)).ToList();
 

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaverFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaverFactory.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Speckle.InterfaceGenerator;
+using Speckle.Sdk.SQLite;
+using Speckle.Sdk.Transports;
+
+namespace Speckle.Sdk.Serialisation.V2.Send;
+
+public partial interface IObjectSaverFactory : IDisposable;
+[GenerateAutoInterface]
+public sealed class ObjectSaverFactory(  IServerObjectManager serverObjectManager, ILoggerFactory loggerFactory) : IObjectSaverFactory
+{private readonly ConcurrentDictionary<string, IObjectSaver> _savers = new();
+  public IObjectSaver Create(
+    ISqLiteJsonCacheManager sqLiteJsonCacheManager, IProgress<ProgressArgs>? progress,    CancellationToken cancellationToken,
+    SerializeProcessOptions? options = null)
+  {
+    if (!_savers.TryGetValue(sqLiteJsonCacheManager.Path, out var saver))
+    {
+      saver = new ObjectSaver(progress,sqLiteJsonCacheManager, serverObjectManager, loggerFactory.CreateLogger<ObjectSaver>(),
+        cancellationToken, options);
+      _savers.TryAdd(sqLiteJsonCacheManager.Path, saver);
+    }
+
+    return saver;
+  }
+  [AutoInterfaceIgnore]
+  public void Dispose()
+  {
+    foreach (var pool in _savers)
+    {
+      pool.Value.Dispose();
+    }
+
+    _savers.Clear();
+  }
+}

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaverFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaverFactory.cs
@@ -9,12 +9,12 @@ namespace Speckle.Sdk.Serialisation.V2.Send;
 public partial interface IObjectSaverFactory : IDisposable;
 
 [GenerateAutoInterface]
-public sealed class ObjectSaverFactory(IServerObjectManager serverObjectManager, ILoggerFactory loggerFactory)
-  : IObjectSaverFactory
+public sealed class ObjectSaverFactory(ILoggerFactory loggerFactory) : IObjectSaverFactory
 {
   private readonly ConcurrentDictionary<string, IObjectSaver> _savers = new();
 
   public IObjectSaver Create(
+    IServerObjectManager serverObjectManager,
     ISqLiteJsonCacheManager sqLiteJsonCacheManager,
     IProgress<ProgressArgs>? progress,
     CancellationToken cancellationToken,

--- a/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaverFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/ObjectSaverFactory.cs
@@ -7,22 +7,36 @@ using Speckle.Sdk.Transports;
 namespace Speckle.Sdk.Serialisation.V2.Send;
 
 public partial interface IObjectSaverFactory : IDisposable;
+
 [GenerateAutoInterface]
-public sealed class ObjectSaverFactory(  IServerObjectManager serverObjectManager, ILoggerFactory loggerFactory) : IObjectSaverFactory
-{private readonly ConcurrentDictionary<string, IObjectSaver> _savers = new();
+public sealed class ObjectSaverFactory(IServerObjectManager serverObjectManager, ILoggerFactory loggerFactory)
+  : IObjectSaverFactory
+{
+  private readonly ConcurrentDictionary<string, IObjectSaver> _savers = new();
+
   public IObjectSaver Create(
-    ISqLiteJsonCacheManager sqLiteJsonCacheManager, IProgress<ProgressArgs>? progress,    CancellationToken cancellationToken,
-    SerializeProcessOptions? options = null)
+    ISqLiteJsonCacheManager sqLiteJsonCacheManager,
+    IProgress<ProgressArgs>? progress,
+    CancellationToken cancellationToken,
+    SerializeProcessOptions? options = null
+  )
   {
     if (!_savers.TryGetValue(sqLiteJsonCacheManager.Path, out var saver))
     {
-      saver = new ObjectSaver(progress,sqLiteJsonCacheManager, serverObjectManager, loggerFactory.CreateLogger<ObjectSaver>(),
-        cancellationToken, options);
+      saver = new ObjectSaver(
+        progress,
+        sqLiteJsonCacheManager,
+        serverObjectManager,
+        loggerFactory.CreateLogger<ObjectSaver>(),
+        cancellationToken,
+        options
+      );
       _savers.TryAdd(sqLiteJsonCacheManager.Path, saver);
     }
 
     return saver;
   }
+
   [AutoInterfaceIgnore]
   public void Dispose()
   {

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -86,7 +86,6 @@ public sealed class SerializeProcess(
     await WaitForSchedulerCompletion().ConfigureAwait(false);
     await _highest.DisposeAsync().ConfigureAwait(false);
     await _belowNormal.DisposeAsync().ConfigureAwait(false);
-    objectSaver.Dispose();
     _processSource.Dispose();
   }
 

--- a/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
@@ -28,7 +28,7 @@ public class SerializeProcessFactory(
   {
     var sqLiteJsonCacheManager = sqLiteJsonCacheManagerFactory.CreateFromStream(streamId);
     var serverObjectManager = serverObjectManagerFactory.Create(url, streamId, authorizationToken);
-    return CreateSerializeProcess(sqLiteJsonCacheManager, serverObjectManager,  progress, cancellationToken, options);
+    return CreateSerializeProcess(sqLiteJsonCacheManager, serverObjectManager, progress, cancellationToken, options);
   }
 
   public ISerializeProcess CreateSerializeProcess(

--- a/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
@@ -40,7 +40,7 @@ public class SerializeProcessFactory(
   ) =>
     new SerializeProcess(
       progress,
-      objectSaverFactory.Create(sqLiteJsonCacheManager, progress, cancellationToken, options),
+      objectSaverFactory.Create(serverObjectManager, sqLiteJsonCacheManager, progress, cancellationToken, options),
       baseChildFinder,
       new BaseSerializer(sqLiteJsonCacheManager, objectSerializerFactory),
       loggerFactory,

--- a/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
@@ -13,6 +13,7 @@ public class SerializeProcessFactory(
   IObjectSerializerFactory objectSerializerFactory,
   ISqLiteJsonCacheManagerFactory sqLiteJsonCacheManagerFactory,
   IServerObjectManagerFactory serverObjectManagerFactory,
+  IObjectSaverFactory objectSaverFactory,
   ILoggerFactory loggerFactory
 ) : ISerializeProcessFactory
 {
@@ -27,7 +28,7 @@ public class SerializeProcessFactory(
   {
     var sqLiteJsonCacheManager = sqLiteJsonCacheManagerFactory.CreateFromStream(streamId);
     var serverObjectManager = serverObjectManagerFactory.Create(url, streamId, authorizationToken);
-    return CreateSerializeProcess(sqLiteJsonCacheManager, serverObjectManager, progress, cancellationToken, options);
+    return CreateSerializeProcess(sqLiteJsonCacheManager, serverObjectManager,  progress, cancellationToken, options);
   }
 
   public ISerializeProcess CreateSerializeProcess(
@@ -39,13 +40,7 @@ public class SerializeProcessFactory(
   ) =>
     new SerializeProcess(
       progress,
-      new ObjectSaver(
-        progress,
-        sqLiteJsonCacheManager,
-        serverObjectManager,
-        loggerFactory.CreateLogger<ObjectSaver>(),
-        cancellationToken
-      ),
+      objectSaverFactory.Create(sqLiteJsonCacheManager, progress, cancellationToken, options),
       baseChildFinder,
       new BaseSerializer(sqLiteJsonCacheManager, objectSerializerFactory),
       loggerFactory,

--- a/src/Speckle.Sdk/ServiceRegistration.cs
+++ b/src/Speckle.Sdk/ServiceRegistration.cs
@@ -97,6 +97,8 @@ public static class ServiceRegistration
       typeof(Client)
     );
     serviceCollection.AddMatchingInterfacesAsTransient(typeof(GraphQLRetry).Assembly);
+    //we want to make object savers be singletons per stream so needs a singleton factory
+    serviceCollection.AddSingleton<IObjectSaverFactory, ObjectSaverFactory>();
     return serviceCollection;
   }
 

--- a/tests/Speckle.Sdk.Serialization.Tests/DataObjectTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DataObjectTests.cs
@@ -41,7 +41,7 @@ public class DataObjectTests
       new DummyServerObjectManager(),
       null,
       default,
-      new SerializeProcessOptions(true, true, false, true)
+      new SerializeProcessOptions(false, false, false, true)
     );
     await serializeProcess.Serialize(x);
     await VerifyJson(json.Single().Value.Value).UseParameters(type);

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -373,6 +373,9 @@ public class DummyServerObjectManager : IServerObjectManager
 
 public class DummySendCacheManager(Dictionary<string, string> objects) : ISqLiteJsonCacheManager
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+#pragma warning restore CA1065
   public void Dispose() { }
 
   public IReadOnlyCollection<(string, string)> GetAllObjects() => throw new NotImplementedException();

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -41,7 +41,7 @@ public class DetachedTests
       objects,
       null,
       default,
-      new SerializeProcessOptions(false, false, true, true)
+      new SerializeProcessOptions(false, false, false, true)
     );
     await serializeProcess.Serialize(@base);
 
@@ -123,7 +123,7 @@ public class DetachedTests
       objects,
       null,
       default,
-      new SerializeProcessOptions(false, false, true, true) { MaxParallelism = 1, MaxHttpSendBatchSize = 1 }
+      new SerializeProcessOptions(false, false, false, true) { MaxParallelism = 1, MaxHttpSendBatchSize = 1 }
     );
     var results = await serializeProcess.Serialize(@base);
 
@@ -150,7 +150,7 @@ public class DetachedTests
       objects,
       null,
       default,
-      new SerializeProcessOptions(false, false, true, true) { MaxParallelism = 1, MaxHttpSendBatchSize = 1 }
+      new SerializeProcessOptions(false, false, false, true) { MaxParallelism = 1, MaxHttpSendBatchSize = 1 }
     );
     var results = await serializeProcess.Serialize(@base);
 
@@ -172,7 +172,7 @@ public class DetachedTests
       objects,
       null,
       default,
-      new SerializeProcessOptions(false, false, true, true) { MaxParallelism = 1, MaxHttpSendBatchSize = 1 }
+      new SerializeProcessOptions(false, false, false, true) { MaxParallelism = 1, MaxHttpSendBatchSize = 1 }
     );
     var results = await serializeProcess.Serialize(@base);
 
@@ -239,7 +239,7 @@ public class DetachedTests
       objects,
       null,
       default,
-      new SerializeProcessOptions(false, false, true, true)
+      new SerializeProcessOptions(false, false, false, true)
     );
 
     var results = await serializeProcess.Serialize(@base);
@@ -272,7 +272,7 @@ public class DetachedTests
       objects,
       null,
       default,
-      new SerializeProcessOptions(false, false, true, true)
+      new SerializeProcessOptions(false, false, false, true)
     );
     var results = await serializeProcess.Serialize(@base);
     await VerifyJsonDictionary(objects);

--- a/tests/Speckle.Sdk.Serialization.Tests/DummyCancellationSqLiteSendManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DummyCancellationSqLiteSendManager.cs
@@ -4,6 +4,9 @@ namespace Speckle.Sdk.Serialization.Tests;
 
 public class DummyCancellationSqLiteSendManager : ISqLiteJsonCacheManager
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+#pragma warning restore CA1065
   public string? GetObject(string id) => null;
 
   public void SaveObject(string id, string json) => throw new NotImplementedException();

--- a/tests/Speckle.Sdk.Serialization.Tests/Framework/ExceptionSendCacheManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/Framework/ExceptionSendCacheManager.cs
@@ -4,6 +4,9 @@ namespace Speckle.Sdk.Serialization.Tests.Framework;
 
 public class ExceptionSendCacheManager(bool? hasObject = null, int? exceptionsAfter = null) : ISqLiteJsonCacheManager
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+#pragma warning restore CA1065
   private readonly object _lock = new();
   private int _count;
 

--- a/tests/Speckle.Sdk.Serialization.Tests/Framework/ExceptionSendCacheManager.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/Framework/ExceptionSendCacheManager.cs
@@ -4,9 +4,7 @@ namespace Speckle.Sdk.Serialization.Tests.Framework;
 
 public class ExceptionSendCacheManager(bool? hasObject = null, int? exceptionsAfter = null) : ISqLiteJsonCacheManager
 {
-#pragma warning disable CA1065
-  public string Path => throw new NotImplementedException();
-#pragma warning restore CA1065
+  public string Path => "ExceptionSendCacheManager";
   private readonly object _lock = new();
   private int _count;
 

--- a/tests/Speckle.Sdk.Serialization.Tests/ObjectSaverFactoryTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ObjectSaverFactoryTests.cs
@@ -8,17 +8,15 @@ namespace Speckle.Sdk.Serialisation.V2.Send.Tests;
 
 public class ObjectSaverFactoryTests : MoqTest
 {
-  private readonly Mock<IServerObjectManager> _serverObjectManagerMock;
   private readonly Mock<ILoggerFactory> _loggerFactoryMock;
   private readonly Mock<ILogger<ObjectSaver>> _loggerMock;
   private readonly ObjectSaverFactory _factory;
 
   public ObjectSaverFactoryTests()
   {
-    _serverObjectManagerMock = Create<IServerObjectManager>();
     _loggerFactoryMock = Create<ILoggerFactory>();
     _loggerMock = Create<ILogger<ObjectSaver>>();
-    _factory = new ObjectSaverFactory(_serverObjectManagerMock.Object, _loggerFactoryMock.Object);
+    _factory = new ObjectSaverFactory(_loggerFactoryMock.Object);
   }
 
   public override void Dispose()
@@ -35,7 +33,12 @@ public class ObjectSaverFactoryTests : MoqTest
     cacheManagerMock.Setup(x => x.Dispose());
     cacheManagerMock.SetupGet(c => c.Path).Returns("/tmp/test1.db");
 
-    var saver = _factory.Create(cacheManagerMock.Object, null, CancellationToken.None);
+    var saver = _factory.Create(
+      Create<IServerObjectManager>().Object,
+      cacheManagerMock.Object,
+      null,
+      CancellationToken.None
+    );
 
     saver.Should().NotBeNull();
   }
@@ -48,8 +51,18 @@ public class ObjectSaverFactoryTests : MoqTest
     cacheManagerMock.Setup(x => x.Dispose());
     cacheManagerMock.SetupGet(c => c.Path).Returns("/tmp/test2.db");
 
-    var saver1 = _factory.Create(cacheManagerMock.Object, null, CancellationToken.None);
-    var saver2 = _factory.Create(cacheManagerMock.Object, null, CancellationToken.None);
+    var saver1 = _factory.Create(
+      Create<IServerObjectManager>().Object,
+      cacheManagerMock.Object,
+      null,
+      CancellationToken.None
+    );
+    var saver2 = _factory.Create(
+      Create<IServerObjectManager>().Object,
+      cacheManagerMock.Object,
+      null,
+      CancellationToken.None
+    );
 
     saver1.Should().BeSameAs(saver2);
   }

--- a/tests/Speckle.Sdk.Serialization.Tests/ObjectSaverFactoryTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ObjectSaverFactoryTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Speckle.Sdk.SQLite;
+using Speckle.Sdk.Testing;
+
+namespace Speckle.Sdk.Serialisation.V2.Send.Tests;
+
+public class ObjectSaverFactoryTests : MoqTest
+{
+  private readonly Mock<IServerObjectManager> _serverObjectManagerMock;
+  private readonly Mock<ILoggerFactory> _loggerFactoryMock;
+  private readonly Mock<ILogger<ObjectSaver>> _loggerMock;
+  private readonly ObjectSaverFactory _factory;
+
+  public ObjectSaverFactoryTests()
+  {
+    _serverObjectManagerMock = Create<IServerObjectManager>();
+    _loggerFactoryMock = Create<ILoggerFactory>();
+    _loggerMock = Create<ILogger<ObjectSaver>>();
+    _factory = new ObjectSaverFactory(_serverObjectManagerMock.Object, _loggerFactoryMock.Object);
+  }
+
+  public override void Dispose()
+  {
+    _factory.Dispose();
+    base.Dispose();
+  }
+
+  [Fact]
+  public void Create_ShouldReturnObjectSaverInstance()
+  {
+    _loggerFactoryMock.Setup(f => f.CreateLogger(typeof(ObjectSaver).FullName)).Returns(_loggerMock.Object);
+    var cacheManagerMock = Create<ISqLiteJsonCacheManager>();
+    cacheManagerMock.Setup(x => x.Dispose());
+    cacheManagerMock.SetupGet(c => c.Path).Returns("/tmp/test1.db");
+
+    var saver = _factory.Create(cacheManagerMock.Object, null, CancellationToken.None);
+
+    saver.Should().NotBeNull();
+  }
+
+  [Fact]
+  public void Create_ShouldReturnSameInstanceForSamePath()
+  {
+    _loggerFactoryMock.Setup(f => f.CreateLogger(typeof(ObjectSaver).FullName)).Returns(_loggerMock.Object);
+    var cacheManagerMock = Create<ISqLiteJsonCacheManager>();
+    cacheManagerMock.Setup(x => x.Dispose());
+    cacheManagerMock.SetupGet(c => c.Path).Returns("/tmp/test2.db");
+
+    var saver1 = _factory.Create(cacheManagerMock.Object, null, CancellationToken.None);
+    var saver2 = _factory.Create(cacheManagerMock.Object, null, CancellationToken.None);
+
+    saver1.Should().BeSameAs(saver2);
+  }
+
+  [Fact]
+  public void Dispose_ShouldDisposeAllSavers()
+  {
+    var saverMock1 = Create<IObjectSaver>();
+    _factory
+      .GetType()
+      .GetField("_savers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+      ?.SetValue(
+        _factory,
+        new System.Collections.Concurrent.ConcurrentDictionary<string, IObjectSaver>(
+          new[]
+          {
+            new System.Collections.Generic.KeyValuePair<string, IObjectSaver>("/tmp/test3.db", saverMock1.Object),
+          }
+        )
+      );
+    saverMock1.Setup(x => x.Dispose());
+
+    _factory.Dispose();
+  }
+}

--- a/tests/Speckle.Sdk.Testing/Framework/DummySqLiteReceiveManager.cs
+++ b/tests/Speckle.Sdk.Testing/Framework/DummySqLiteReceiveManager.cs
@@ -5,6 +5,9 @@ namespace Speckle.Sdk.Testing.Framework;
 public sealed class DummySqLiteReceiveManager(IReadOnlyDictionary<string, string> savedObjects)
   : ISqLiteJsonCacheManager
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+#pragma warning restore CA1065
   public void Dispose() { }
 
   public IReadOnlyCollection<(string, string)> GetAllObjects() => throw new NotImplementedException();

--- a/tests/Speckle.Sdk.Testing/Framework/DummySqLiteSendManager.cs
+++ b/tests/Speckle.Sdk.Testing/Framework/DummySqLiteSendManager.cs
@@ -4,9 +4,8 @@ namespace Speckle.Sdk.Testing.Framework;
 
 public class DummySqLiteSendManager : ISqLiteJsonCacheManager
 {
-#pragma warning disable CA1065
-  public string Path => throw new NotImplementedException();
-#pragma warning restore CA1065
+  public string Path => "DummySqLiteSendManager";
+
   public string? GetObject(string id) => throw new NotImplementedException();
 
   public void SaveObject(string id, string json) => throw new NotImplementedException();

--- a/tests/Speckle.Sdk.Testing/Framework/DummySqLiteSendManager.cs
+++ b/tests/Speckle.Sdk.Testing/Framework/DummySqLiteSendManager.cs
@@ -4,6 +4,9 @@ namespace Speckle.Sdk.Testing.Framework;
 
 public class DummySqLiteSendManager : ISqLiteJsonCacheManager
 {
+#pragma warning disable CA1065
+  public string Path => throw new NotImplementedException();
+#pragma warning restore CA1065
   public string? GetObject(string id) => throw new NotImplementedException();
 
   public void SaveObject(string id, string json) => throw new NotImplementedException();

--- a/tests/Speckle.Sdk.Testing/MoqTest.cs
+++ b/tests/Speckle.Sdk.Testing/MoqTest.cs
@@ -8,7 +8,7 @@ public abstract class MoqTest : IDisposable
 {
   protected MoqTest() => Repository = new(MockBehavior.Strict);
 
-  public void Dispose() => Repository.VerifyAll();
+  public virtual void Dispose() => Repository.VerifyAll();
 
   protected MockRepository Repository { get; private set; } = new(MockBehavior.Strict);
 

--- a/tests/Speckle.Sdk.Tests.Unit/Serialisation/SerializeProcessRecordExceptionTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Serialisation/SerializeProcessRecordExceptionTests.cs
@@ -21,7 +21,6 @@ public class SerializeProcessRecordExceptionTests : MoqTest
       .Setup(f => f.CreateLogger("Speckle.Sdk.Serialisation.V2.PriorityScheduler"))
       .Returns(Create<ILogger<PriorityScheduler>>().Object);
     var objectSaverMock = Create<IObjectSaver>();
-    objectSaverMock.Setup(x => x.Dispose());
     var baseChildFinderMock = Create<IBaseChildFinder>();
     var baseSerializerMock = Create<IBaseSerializer>();
     using var cts = new CancellationTokenSource();
@@ -57,7 +56,6 @@ public class SerializeProcessRecordExceptionTests : MoqTest
       .Setup(f => f.CreateLogger("Speckle.Sdk.Serialisation.V2.PriorityScheduler"))
       .Returns(Create<ILogger<PriorityScheduler>>().Object);
     var objectSaverMock = Create<IObjectSaver>();
-    objectSaverMock.Setup(x => x.Dispose());
     var baseChildFinderMock = Create<IBaseChildFinder>();
     var baseSerializerMock = Create<IBaseSerializer>();
     using var cts = new CancellationTokenSource();
@@ -88,7 +86,6 @@ public class SerializeProcessRecordExceptionTests : MoqTest
       .Setup(f => f.CreateLogger("Speckle.Sdk.Serialisation.V2.PriorityScheduler"))
       .Returns(Create<ILogger<PriorityScheduler>>().Object);
     var objectSaverMock = Create<IObjectSaver>();
-    objectSaverMock.Setup(x => x.Dispose());
     var baseChildFinderMock = Create<IBaseChildFinder>();
     var baseSerializerMock = Create<IBaseSerializer>();
     using var cts = new CancellationTokenSource();


### PR DESCRIPTION
This should guarantee threads per file across multiple sends instead of at the sqlite level as in https://github.com/specklesystems/speckle-sharp-sdk/pull/302