### PR TITLE
Dev to Main (no squash) : Adjustments to avoid sqlite "database is locked" errors (#333)

### DIFF
--- a/src/Speckle.Sdk/SQLite/SqLiteJsonCacheManagerFactory.cs
+++ b/src/Speckle.Sdk/SQLite/SqLiteJsonCacheManagerFactory.cs
@@ -9,7 +9,8 @@ public class SqLiteJsonCacheManagerFactory : ISqLiteJsonCacheManagerFactory
 {
   public const int INITIAL_CONCURRENCY = 4;
 
-  private ISqLiteJsonCacheManager Create(string path, int concurrency) => new SqLiteJsonCacheManager(path, concurrency);
+  private ISqLiteJsonCacheManager Create(string path, int concurrency) =>
+    SqLiteJsonCacheManager.FromFilePath(path, concurrency);
 
   public ISqLiteJsonCacheManager CreateForUser(string scope) =>
     Create(Path.Combine(SpecklePathProvider.UserApplicationDataPath(), "Speckle", $"{scope}.db"), 1);

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -16,8 +16,8 @@ public record SerializeProcessOptions(
   bool SkipFindTotalObjects = false
 )
 {
-  public int? MaxHttpSendSize { get; set; }
-  public int? MaxCacheSize { get; set; }
+  public int? MaxHttpSendBatchSize { get; set; }
+  public int? MaxCacheBatchSize { get; set; }
   public int? MaxParallelism { get; set; }
 }
 
@@ -112,8 +112,8 @@ public sealed class SerializeProcess(
     {
       var channelTask = objectSaver.Start(
         options?.MaxParallelism,
-        options?.MaxHttpSendSize,
-        options?.MaxCacheSize,
+        options?.MaxHttpSendBatchSize,
+        options?.MaxCacheBatchSize,
         _processSource.Token
       );
       var findTotalObjectsTask = Task.CompletedTask;

--- a/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/SerializeProcessFactory.cs
@@ -64,18 +64,10 @@ public class SerializeProcessFactory(
 #pragma warning disable CA2000
     var memoryJsonCacheManager = new MemoryJsonCacheManager(jsonCache);
 #pragma warning restore CA2000
-    return new SerializeProcess(
+    return CreateSerializeProcess(
+      memoryJsonCacheManager,
+      new MemoryServerObjectManager(objects),
       progress,
-      new ObjectSaver(
-        progress,
-        memoryJsonCacheManager,
-        new MemoryServerObjectManager(objects),
-        loggerFactory.CreateLogger<ObjectSaver>(),
-        cancellationToken
-      ),
-      baseChildFinder,
-      new BaseSerializer(memoryJsonCacheManager, objectSerializerFactory),
-      loggerFactory,
       cancellationToken,
       options
     );

--- a/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/DetachedTests.cs
@@ -123,7 +123,7 @@ public class DetachedTests
       objects,
       null,
       default,
-      new SerializeProcessOptions(false, false, true, true) { MaxParallelism = 1, MaxHttpSendSize = 1 }
+      new SerializeProcessOptions(false, false, true, true) { MaxParallelism = 1, MaxHttpSendBatchSize = 1 }
     );
     var results = await serializeProcess.Serialize(@base);
 
@@ -150,7 +150,7 @@ public class DetachedTests
       objects,
       null,
       default,
-      new SerializeProcessOptions(false, false, true, true) { MaxParallelism = 1, MaxHttpSendSize = 1 }
+      new SerializeProcessOptions(false, false, true, true) { MaxParallelism = 1, MaxHttpSendBatchSize = 1 }
     );
     var results = await serializeProcess.Serialize(@base);
 
@@ -172,7 +172,7 @@ public class DetachedTests
       objects,
       null,
       default,
-      new SerializeProcessOptions(false, false, true, true) { MaxParallelism = 1, MaxHttpSendSize = 1 }
+      new SerializeProcessOptions(false, false, true, true) { MaxParallelism = 1, MaxHttpSendBatchSize = 1 }
     );
     var results = await serializeProcess.Serialize(@base);
 

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.cs
@@ -95,8 +95,8 @@ public class ExceptionTests
       default,
       new SerializeProcessOptions(false, false, false, true)
       {
-        MaxHttpSendSize = 1,
-        MaxCacheSize = 1,
+        MaxHttpSendBatchSize = 1,
+        MaxCacheBatchSize = 1,
         MaxParallelism = 1,
       }
     );

--- a/tests/Speckle.Sdk.Tests.Unit/SQLite/SQLiteJsonCacheManagerTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/SQLite/SQLiteJsonCacheManagerTests.cs
@@ -22,7 +22,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   public void TestGetAll()
   {
     var data = new List<(string id, string json)>() { ("id1", "1"), ("id2", "2") };
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = SqLiteJsonCacheManager.FromFilePath(_basePath, 2);
     manager.SaveObjects(data);
     var items = manager.GetAllObjects();
     items.Count.Should().Be(data.Count);
@@ -38,7 +38,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   public void TestGet()
   {
     var data = new List<(string id, string json)>() { ("id1", "1"), ("id2", "2") };
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = SqLiteJsonCacheManager.FromFilePath(_basePath, 2);
     foreach (var d in data)
     {
       manager.SaveObject(d.id, d.json);
@@ -84,7 +84,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   public void TestLargeJsonPayload()
   {
     var largeJson = new string('a', 100_000);
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = SqLiteJsonCacheManager.FromFilePath(_basePath, 2);
     manager.SaveObject("large", largeJson);
     var result = manager.GetObject("large");
     result.Should().Be(largeJson);
@@ -96,7 +96,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
     var id = "spécial_字符_!@#$%^&*()";
     var json = /*lang=json,strict*/
       "{\"value\": \"特殊字符!@#$%^&*()\"}";
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = SqLiteJsonCacheManager.FromFilePath(_basePath, 2);
     manager.SaveObject(id, json);
     var result = manager.GetObject(id);
     result.Should().Be(json);
@@ -108,7 +108,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   [Fact]
   public void TestBulkInsertEmptyCollection()
   {
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = SqLiteJsonCacheManager.FromFilePath(_basePath, 2);
     manager.SaveObjects(new List<(string, string)>());
     manager.GetAllObjects().Count.Should().Be(0);
   }
@@ -116,7 +116,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   [Fact]
   public void TestRepeatedUpdateAndDelete()
   {
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = SqLiteJsonCacheManager.FromFilePath(_basePath, 2);
     manager.SaveObject("id", "1");
     manager.UpdateObject("id", "2");
     manager.UpdateObject("id", "3");
@@ -129,7 +129,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   [Fact]
   public void TestGetAndDeleteNonExistentId()
   {
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = SqLiteJsonCacheManager.FromFilePath(_basePath, 2);
     manager.GetObject("doesnotexist").Should().BeNull();
     manager.HasObject("doesnotexist").Should().BeFalse();
     manager.DeleteObject("doesnotexist"); // Should not throw
@@ -138,7 +138,7 @@ public class SQLiteJsonCacheManagerTests : IDisposable
   [Fact]
   public void TestNullOrEmptyInput()
   {
-    using var manager = new SqLiteJsonCacheManager(_basePath, 2);
+    using var manager = SqLiteJsonCacheManager.FromFilePath(_basePath, 2);
     // Empty id
     Assert.Throws<ArgumentException>(() => manager.SaveObject("", "emptyid"));
     // Empty json


### PR DESCRIPTION
* add new exception test

* Make memory tests and file path tests be explicit

* set the default write parallelism to 1

* set to single reader for caching channel

* format

* Try to have consistent DB locked error test

* always a single reader of the channel

* Remove extra snapshot

* Revert "Try to have consistent DB locked error test"

This reverts commit 93669c57a3c07b18958d3058e0d622041b1c5132.

* remove extra test that doesn't do anything