### PR TITLE
(fix) Remove DistinctBy

### DIFF
--- a/src/Speckle.Sdk.Dependencies/Collections.cs
+++ b/src/Speckle.Sdk.Dependencies/Collections.cs
@@ -22,23 +22,4 @@ public static class Collections
 public static class EnumerableExtensions
 {
   public static IEnumerable<int> RangeFrom(int from, int to) => Enumerable.Range(from, to - from + 1);
-
-#if NETSTANDARD2_0
-  public static IEnumerable<TSource> DistinctBy<TSource, TKey>(
-    this IEnumerable<TSource> source,
-    Func<TSource, TKey> keySelector
-  )
-  {
-    var keys = new HashSet<TKey>();
-    foreach (var element in source)
-    {
-      if (keys.Contains(keySelector(element)))
-      {
-        continue;
-      }
-      keys.Add(keySelector(element));
-      yield return element;
-    }
-  }
-#endif
 }


### PR DESCRIPTION
https://github.com/specklesystems/speckle-sharp-sdk/issues/341

I made this as some point when doing serialization changes but we don't need it.  Somehow it's causing conflicts.  Easiest to just remove it.