### PR TITLE
Small fixes to SDK

### DIFF
--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelLoader.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelLoader.cs
@@ -5,7 +5,7 @@ namespace Speckle.Sdk.Dependencies.Serialization;
 
 public abstract class ChannelLoader<T>(CancellationToken cancellationToken)
 {
-  private const int RECEIVE_CAPACITY = 5000;
+  private const int RECEIVE_CAPACITY = 10000;
 
   private const int HTTP_GET_CHUNK_SIZE = 500;
   private const int MAX_PARALLELISM_HTTP = 4;

--- a/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
+++ b/src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs
@@ -8,7 +8,7 @@ namespace Speckle.Sdk.Dependencies.Serialization;
 public abstract class ChannelSaver<T>
   where T : IHasByteSize
 {
-  private const int SEND_CAPACITY = 1000;
+  private const int SEND_CAPACITY = 10000;
   private const int HTTP_SEND_CHUNK_SIZE = 25_000_000; //bytes
   private static readonly TimeSpan HTTP_BATCH_TIMEOUT = TimeSpan.FromSeconds(2);
   private const int MAX_PARALLELISM_HTTP = 4;

--- a/src/Speckle.Sdk/Api/Operations/Operations.Send.cs
+++ b/src/Speckle.Sdk/Api/Operations/Operations.Send.cs
@@ -50,6 +50,7 @@ public partial class Operations
     catch (OperationCanceledException)
     {
       //this is handled by the caller
+      throw;
     }
     catch (Exception ex)
     {

--- a/src/Speckle.Sdk/Api/Operations/Operations.Send.cs
+++ b/src/Speckle.Sdk/Api/Operations/Operations.Send.cs
@@ -47,6 +47,10 @@ public partial class Operations
       receiveActivity?.SetStatus(SdkActivityStatusCode.Ok);
       return results;
     }
+    catch (OperationCanceledException)
+    {
+      //this is handled by the caller
+    }
     catch (Exception ex)
     {
       receiveActivity?.SetStatus(SdkActivityStatusCode.Error);


### PR DESCRIPTION
This pull request introduces changes to improve performance and enhance cancellation handling in the Speckle SDK. The most important changes include increasing buffer capacities for serialization operations, adding robust handling for cancellation tokens, and optimizing object serialization logic.

### Performance Improvements:

* [`src/Speckle.Sdk.Dependencies/Serialization/ChannelLoader.cs`](diffhunk://#diff-b99e7a553fa3b2577a44bc5a2df4b80b8651d16a8850512639e52b5d3d0d2c55L8-R8): Increased `RECEIVE_CAPACITY` from 5000 to 10000 to allow larger data buffers during deserialization.
* [`src/Speckle.Sdk.Dependencies/Serialization/ChannelSaver.cs`](diffhunk://#diff-b1defc14b583aa87d1a6c87f2e3c52a10ed7998577da29b365ac7e47125a4905L11-R11): Increased `SEND_CAPACITY` from 1000 to 10000 to improve throughput during serialization.

### Cancellation Handling Enhancements:

* [`src/Speckle.Sdk/Api/Operations/Operations.Send.cs`](diffhunk://#diff-4084fec877b556e878efb7102abd3bef923ef4cbb9da239af75d3c0f8b74f61fR50-R53): Added handling for `OperationCanceledException` to ensure cancellation logic is managed gracefully by the caller.
* [`src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs`](diffhunk://#diff-59091d6cad6af458bcaf69c0f28eb3aa30692fa97cab57057f71ae7943bc2018R229-R239): Added checks for `_processSource.Token.IsCancellationRequested` to return early and avoid unnecessary processing when cancellation is requested. [[1]](diffhunk://#diff-59091d6cad6af458bcaf69c0f28eb3aa30692fa97cab57057f71ae7943bc2018R229-R239) [[2]](diffhunk://#diff-59091d6cad6af458bcaf69c0f28eb3aa30692fa97cab57057f71ae7943bc2018L255-R270)