### PR TITLE
Adds detail to message so that user isn't going WTF SDK

### DIFF
--- a/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectLoader.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Receive/ObjectLoader.cs
@@ -171,7 +171,7 @@ public sealed class ObjectLoader(
     cancellationToken.ThrowIfCancellationRequested();
     if (Exception is not null)
     {
-      throw new SpeckleException("Error while loading", Exception);
+      throw new SpeckleException($"Error while loading: {Exception.Message}", Exception);
     }
   }
 }

--- a/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
+++ b/src/Speckle.Sdk/Serialisation/V2/Send/SerializeProcess.cs
@@ -97,7 +97,7 @@ public sealed class SerializeProcess(
     //order here matters...null with cancellation means a user did it, otherwise it's a real Exception
     if (objectSaver.Exception is not null)
     {
-      throw new SpeckleException("Error while sending", objectSaver.Exception);
+      throw new SpeckleException($"Error while sending: {objectSaver.Exception.Message}", objectSaver.Exception);
     }
     _processSource.Token.ThrowIfCancellationRequested();
   }

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Cache.verified.json
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Cache.verified.json
@@ -6,6 +6,6 @@
     "Message": "The method or operation is not implemented.",
     "Type": "NotImplementedException"
   },
-  "Message": "Error while sending",
+  "Message": "Error while sending: The method or operation is not implemented.",
   "Type": "SpeckleException"
 }

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Cache_ExceptionsAfter_10.verified.json
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Cache_ExceptionsAfter_10.verified.json
@@ -6,6 +6,6 @@
     "Message": "Count exceeded",
     "Type": "Exception"
   },
-  "Message": "Error while sending",
+  "Message": "Error while sending: Count exceeded",
   "Type": "SpeckleException"
 }

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Receive_Cache_fileName=False.verified.json
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Receive_Cache_fileName=False.verified.json
@@ -6,6 +6,6 @@
     "Message": "The method or operation is not implemented.",
     "Type": "NotImplementedException"
   },
-  "Message": "Error while loading",
+  "Message": "Error while loading: The method or operation is not implemented.",
   "Type": "SpeckleException"
 }

--- a/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Upload.verified.json
+++ b/tests/Speckle.Sdk.Serialization.Tests/ExceptionTests.Test_Exceptions_Upload.verified.json
@@ -6,6 +6,6 @@
     "Message": "The method or operation is not implemented.",
     "Type": "NotImplementedException"
   },
-  "Message": "Error while sending",
+  "Message": "Error while sending: The method or operation is not implemented.",
   "Type": "SpeckleException"
 }


### PR DESCRIPTION
Trying to make these errors less cryptic as User would only see "Error in SDK" and maybe not check the logs
![image](https://github.com/user-attachments/assets/2123a78b-49ff-4e18-8e62-fae73c0afbb7)
