### PR TITLE
Add compatibility with `:local` docker images

### DIFF
--- a/src/Speckle.Sdk/Api/GraphQL/GraphQLHttpClientExtensions.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/GraphQLHttpClientExtensions.cs
@@ -40,7 +40,8 @@ public static class GraphQLHttpClientExtensions
     response.EnsureGraphQLSuccess();
 
     string versionString = response.Data.data.data;
-    if (versionString == "dev")
+    //Local server builds will have a non-numerical version string
+    if (versionString == "dev" || versionString == "custom")
     {
       return new Version(999, 999, 999);
     }


### PR DESCRIPTION
Local speckle-server dockerfile builds respond with a "custom" version string.
![image](https://github.com/user-attachments/assets/a131f2a5-0cec-4870-83a5-880f9618f330)


We handled local yarn builds previously (which responded with "dev"), but I suspect that this "custom" string is relatively new.

Previously reported by https://speckle.community/t/all-next-gen-connectors-are-black/18414/8