### PR TITLE
Stop recording an exception that's rethrown

### DIFF
--- a/src/Speckle.Sdk.Dependencies/SpeckleHttpClientHandler.cs
+++ b/src/Speckle.Sdk.Dependencies/SpeckleHttpClientHandler.cs
@@ -42,10 +42,7 @@ internal sealed class SpeckleHttpClientHandler : DelegatingHandler
 
       var policyResult = await _resiliencePolicy
         .ExecuteAndCaptureAsync(
-          ctx =>
-          {
-            return base.SendAsync(request, cancellationToken);
-          },
+          ctx => base.SendAsync(request, cancellationToken),
           context
         )
         .ConfigureAwait(false);

--- a/src/Speckle.Sdk.Dependencies/SpeckleHttpClientHandler.cs
+++ b/src/Speckle.Sdk.Dependencies/SpeckleHttpClientHandler.cs
@@ -41,10 +41,7 @@ internal sealed class SpeckleHttpClientHandler : DelegatingHandler
       activity?.InjectHeaders((k, v) => request.Headers.TryAddWithoutValidation(k, v));
 
       var policyResult = await _resiliencePolicy
-        .ExecuteAndCaptureAsync(
-          ctx => base.SendAsync(request, cancellationToken),
-          context
-        )
+        .ExecuteAndCaptureAsync(ctx => base.SendAsync(request, cancellationToken), context)
         .ConfigureAwait(false);
       context.TryGetValue("retryCount", out var retryCount);
       activity?.SetTag("retryCount", retryCount);

--- a/src/Speckle.Sdk/Api/GraphQL/Client.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Client.cs
@@ -127,10 +127,10 @@ public sealed class Client : ISpeckleGraphQLClient, IClient
       activity?.SetStatus(SdkActivityStatusCode.Ok);
       return ret;
     }
-    catch (Exception ex)
+    catch (Exception)
     {
       activity?.SetStatus(SdkActivityStatusCode.Error);
-      activity?.RecordException(ex);
+      //don't record exception as it's rethrown
       throw;
     }
   }


### PR DESCRIPTION
This pull request includes two changes aimed at improving code readability and aligning exception handling with the intended behavior. The most important changes are as follows:

### Code readability improvements:
* Simplified the lambda function in `_resiliencePolicy.ExecuteAndCaptureAsync` by directly returning the result of `base.SendAsync` instead of using a block, making the code more concise. (`src/Speckle.Sdk.Dependencies/SpeckleHttpClientHandler.cs`, [src/Speckle.Sdk.Dependencies/SpeckleHttpClientHandler.csL45-R45](diffhunk://#diff-cfdca526750ddf1d4fffeb5e1ba4f5c4b3ef30066178e1583bc1d03bfec28396L45-R45))

### Exception handling adjustments:
* Updated the `ExecuteGraphQLRequest` method to avoid recording exceptions in the activity when they are rethrown. This ensures the activity status reflects the error without duplicating exception handling logic. (`src/Speckle.Sdk/Api/GraphQL/Client.cs`, [src/Speckle.Sdk/Api/GraphQL/Client.csL130-R133](diffhunk://#diff-9744f1e9fad564ba27c599715facc9b540923516c2d857727a6eb44ad4a78d36L130-R133))