### PR TITLE
chore(ci): Remove Gitversion

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,13 +8,6 @@
         "csharpier"
       ],
       "rollForward": false
-    },
-    "gitversion.tool": {
-      "version": "6.1.0",
-      "commands": [
-        "dotnet-gitversion"
-      ],
-      "rollForward": false
     }
   }
 }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,8 +32,12 @@ jobs:
         
         echo $SEMVER
         echo $FILE_VERSION
+        
     - name: 🔫 Build All
       run: ./build.sh
+      env:
+        SEMVER: ${{ steps.set-version.outputs.SEMVER }}
+        FILE_VERSION: ${{ steps.set-version.outputs.FILE_VERSION }}
       
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
       name: Set version to output
       run: |
         SEMVER="3.0.99.${{ github.run_number }}"
-        FILE_VERSION=$(echo "$TAG" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+        FILE_VERSION=$(echo "$SEMVER" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
         FILE_VERSION="$FILE_VERSION.${{ github.run_number }}"
         
         echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,19 @@ jobs:
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
-
+        
+    - id: set-version
+      name: Set version to output
+      run: |
+        $SEMVER="3.0.99.${{ github.run_number }}"
+        FILE_VERSION=$(echo "$TAG" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+        FILE_VERSION="$FILE_VERSION.${{ github.run_number }}"
+        
+        echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
+        echo "fileVersion=$FILE_VERSION" >> "$GITHUB_OUTPUT"
+        
+        echo $SEMVER
+        echo $FILE_VERSION
     - name: 🔫 Build All
       run: ./build.sh
       

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
     - id: set-version
       name: Set version to output
       run: |
-        $SEMVER="3.0.99.${{ github.run_number }}"
+        SEMVER="3.0.99.${{ github.run_number }}"
         FILE_VERSION=$(echo "$TAG" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
         FILE_VERSION="$FILE_VERSION.${{ github.run_number }}"
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,10 @@ jobs:
               
       - name: 🔫 Build and Pack
         run: ./build.sh pack
-        
+        env:
+          SEMVER: ${{ steps.set-version.outputs.SEMVER }}
+          FILE_VERSION: ${{ steps.set-version.outputs.FILE_VERSION }}
+          
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: .NET Build and Publish
 
 on:
   push:
-    branches: ["main", "dev"] 
     tags: ["3.*"]
 
 jobs:
@@ -11,18 +10,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
+        
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.x.x
-          
+
       - uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          
+      - id: set-version
+        name: Set version to output
+        run: |
+          TAG=${{ github.ref_name }}
+          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
+            TAG="3.0.99.${{ github.run_number }}"
+          fi
+          SEMVER="${TAG}"
+          FILE_VERSION=$(echo "$TAG" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          FILE_VERSION="$FILE_VERSION.${{ github.run_number }}"
+
+          echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
+          echo "fileVersion=$FILE_VERSION" >> "$GITHUB_OUTPUT"
+
+          echo $SEMVER
+          echo $FILE_VERSION
               
       - name: 🔫 Build and Pack
         run: ./build.sh pack

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,0 @@
-workflow: GitFlow/v1
-next-version: 3.0.0
-branches:
-  main:
-    prevent-increment:
-      when-current-commit-tagged: true

--- a/Speckle.Sdk.sln
+++ b/Speckle.Sdk.sln
@@ -23,7 +23,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "config", "config", "{DA2AED
 		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		README.md = README.md
-		GitVersion.yml = GitVersion.yml
 		docker-compose.yml = docker-compose.yml
 		CodeMetricsConfig.txt = CodeMetricsConfig.txt
 		Directory.Build.Targets = Directory.Build.Targets

--- a/Speckle.Sdk.slnx
+++ b/Speckle.Sdk.slnx
@@ -11,7 +11,6 @@
     <File Path="Directory.Build.Targets" />
     <File Path="Directory.Packages.props" />
     <File Path="docker-compose.yml" />
-    <File Path="GitVersion.yml" />
     <File Path="global.json" />
     <File Path="README.md" />
     <File Path=".github\copilot-instructions.md" />


### PR DESCRIPTION
We have problems with continuous delivery on this repo where gitversion will pick a semver that it already has picked.
It will count up correctly, but whenever a tag is pushed, it will reset the counter back to zero.

I don't think we're getting anything from git version right now, so I propose that we remove it, and embrace the tag based deployment as the only way to deploy from this repo.
I think this method's success has already been proven as simpler to maintain, understand, and more reliable.

---

This PR removes gitversion, and replaces the semver generation with equivalent logic that we already have in many other repos.

Pushed [3.5.0-alpha.10](https://github.com/specklesystems/speckle-sharp-sdk/releases/tag/3.5.0-alpha.10) just to test things work as expected.