### PR TITLE
fix(blob): Fixed incorrect disposal of the Activity Factory

### DIFF
--- a/src/Speckle.Sdk/Api/Blob/BlobApi.cs
+++ b/src/Speckle.Sdk/Api/Blob/BlobApi.cs
@@ -265,7 +265,6 @@ public sealed class BlobApi : IBlobApi
   [AutoInterfaceIgnore]
   public void Dispose()
   {
-    _activityFactory.Dispose();
     _authedClient.Dispose();
     _unauthedClient.Dispose();
   }


### PR DESCRIPTION
The Blob api previously was disposing of the activity factory
This is incorrect behaviour because the activity factory is a shared singleton.

I wonder if there's a better way to handle this, I think that "stateful `IDisposable`" and "factory pattern" are two things that really shouldn't mix, alas that would require a hefty refactor