### PR TITLE
feat(credentials)!: Account Update functions

### DIFF
--- a/src/Speckle.Sdk/Credentials/Account.cs
+++ b/src/Speckle.Sdk/Credentials/Account.cs
@@ -37,6 +37,8 @@ public class Account : IEquatable<Account>
   public string? refreshToken { get; set; }
 
   public bool isDefault { get; set; }
+
+  [Obsolete("Not used in v3")]
   public bool isOnline { get; set; } = true;
 
   public ServerInfo serverInfo { get; set; }

--- a/tests/Speckle.Sdk.Tests.Integration/Credentials/AccountFactoryTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Credentials/AccountFactoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using GraphQL.Client.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Api.GraphQL.Inputs;
@@ -37,7 +38,7 @@ public class AccountFactoryTests : IAsyncLifetime
   }
 
   [Fact]
-  public async Task GetUserInfo_ExpectFail_NoServer()
+  public async Task GetUserInfo_ExpectException_NoServer()
   {
     Uri server = new("https://non-existing-server.local");
     await Assert.ThrowsAsync<HttpRequestException>(async () =>
@@ -47,12 +48,21 @@ public class AccountFactoryTests : IAsyncLifetime
   }
 
   [Fact]
-  public async Task GetUserInfo_NoUser()
+  public async Task GetUserInfo_NoToken()
   {
     var result = await _sut.GetUserServerInfo(_client.ServerUrl, null, CancellationToken.None);
 
     result.serverInfo.url.Should().Be(Fixtures.Server.url);
     result.activeUser.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task GetUserInfo_ExpectException_ExpiredAuthToken()
+  {
+    await Assert.ThrowsAsync<GraphQLHttpRequestException>(async () =>
+    {
+      _ = await _sut.GetUserServerInfo(_client.ServerUrl, "notarealauthtoken", CancellationToken.None);
+    });
   }
 
   [Fact]

--- a/tests/Speckle.Sdk.Tests.Integration/Credentials/AccountManagerTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Credentials/AccountManagerTests.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Speckle.Sdk.Credentials;
+
+namespace Speckle.Sdk.Tests.Integration.Credentials;
+
+public class AccountManagerTests
+{
+  private readonly IAccountManager _sut;
+
+  public AccountManagerTests()
+  {
+    _sut = Fixtures.ServiceProvider.GetRequiredService<IAccountManager>();
+  }
+
+  [Fact]
+  public async Task TestUpgradeAccount()
+  {
+    Account account = await Fixtures.SeedUser();
+    var expectedName = account.userInfo.name;
+    var expectedEmail = account.userInfo.email;
+    var expectedCompany = account.userInfo.company;
+
+    var expectedServerDescription = account.serverInfo.description;
+    var expectedServerName = account.serverInfo.name;
+    var expectedServerVersion = account.serverInfo.version;
+
+    account.userInfo = new()
+    {
+      name = "abc",
+      email = "abcde",
+      company = "abcdefg",
+    };
+
+    account.serverInfo = new()
+    {
+      url = account.serverInfo.url,
+      description = "old123123",
+      name = "old123",
+      version = "old",
+    };
+
+    await _sut.UpdateAccountInMemory(account);
+
+    Assert.Equal(expectedName, account.userInfo.name);
+    Assert.Equal(expectedEmail, account.userInfo.email);
+    Assert.Equal(expectedCompany, account.userInfo.company);
+
+    Assert.Equal(expectedServerDescription, account.serverInfo.description);
+    Assert.Equal(expectedServerName, account.serverInfo.name);
+    Assert.Equal(expectedServerVersion, account.serverInfo.version);
+  }
+
+  [Fact]
+  public async Task TestTokenRefreshAccount()
+  {
+    Account account = await Fixtures.SeedUser();
+
+    const string INVALID_TOKEN = "emulating an expired token";
+    account.token = INVALID_TOKEN;
+    await _sut.UpdateAccountInMemory(account);
+
+    Assert.NotEqual(INVALID_TOKEN, account.token);
+  }
+}


### PR DESCRIPTION
V3 never updates the account credentials of accounts in the sqlite db
So user and server information remains stale.

I've fixed the functions in the SDK, and also added a way to upgrade only a single account (before you had to upgrade all accounts)
Not sure yet how/where we'll use these functions.