### PR TITLE
ensure channels is inside il repacked project

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Glob" Version="1.1.9" />
     <PackageVersion Include="HttpMultipartParser" Version="9.0.0" />
     <PackageVersion Include="ILRepack.FullAuto" Version="1.6.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.1" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <!-- Keep at exactly 7.0.5 for side by side with V2 -->
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="[7.0.5,)" />

--- a/src/Speckle.Automate.Sdk/packages.lock.json
+++ b/src/Speckle.Automate.Sdk/packages.lock.json
@@ -86,14 +86,6 @@
         "resolved": "6.0.0",
         "contentHash": "yg72rrYDapfsIUrul7aF6wwNnTJBOFvuA9VdDTQpPa8AlAriHbufeXYLBcodKjfUdkCnaiggX1U/nEP08Zb5GA=="
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "E1HSLkPHXEO30JEij2pWbOuzz1Z5ND4a5l7IP1T2RgQuE0a0NzEIvtO64RNy3Otn6PFezbT80cfm3M/Cgt70PA==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.6.3"
-        }
-      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -289,14 +281,14 @@
         "type": "Project",
         "dependencies": {
           "GraphQL.Client": "[6.0.0, )",
+          "Microsoft.Bcl.AsyncInterfaces": "[10.0.1, )",
           "Microsoft.CSharp": "[4.7.0, )",
           "Microsoft.Data.Sqlite": "[7.0.5, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[2.2.0, )",
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -311,6 +303,15 @@
           "GraphQL.Client.Abstractions": "6.0.0",
           "GraphQL.Client.Abstractions.Websocket": "6.0.0",
           "System.Reactive": "5.0.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "E1HSLkPHXEO30JEij2pWbOuzz1Z5ND4a5l7IP1T2RgQuE0a0NzEIvtO64RNy3Otn6PFezbT80cfm3M/Cgt70PA==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.6.3"
         }
       },
       "Microsoft.CSharp": {
@@ -358,16 +359,6 @@
         "requested": "[13.0.2, )",
         "resolved": "13.0.2",
         "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.1",
-          "System.Threading.Tasks.Extensions": "4.6.3"
-        }
       }
     },
     "net8.0": {
@@ -565,8 +556,7 @@
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -622,12 +612,6 @@
         "requested": "[13.0.2, )",
         "resolved": "13.0.2",
         "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg=="
       }
     }
   }

--- a/src/Speckle.Objects/packages.lock.json
+++ b/src/Speckle.Objects/packages.lock.json
@@ -54,14 +54,6 @@
         "resolved": "6.0.0",
         "contentHash": "yg72rrYDapfsIUrul7aF6wwNnTJBOFvuA9VdDTQpPa8AlAriHbufeXYLBcodKjfUdkCnaiggX1U/nEP08Zb5GA=="
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "E1HSLkPHXEO30JEij2pWbOuzz1Z5ND4a5l7IP1T2RgQuE0a0NzEIvtO64RNy3Otn6PFezbT80cfm3M/Cgt70PA==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.6.3"
-        }
-      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -236,14 +228,14 @@
         "type": "Project",
         "dependencies": {
           "GraphQL.Client": "[6.0.0, )",
+          "Microsoft.Bcl.AsyncInterfaces": "[10.0.1, )",
           "Microsoft.CSharp": "[4.7.0, )",
           "Microsoft.Data.Sqlite": "[7.0.5, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[2.2.0, )",
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -258,6 +250,15 @@
           "GraphQL.Client.Abstractions": "6.0.0",
           "GraphQL.Client.Abstractions.Websocket": "6.0.0",
           "System.Reactive": "5.0.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "E1HSLkPHXEO30JEij2pWbOuzz1Z5ND4a5l7IP1T2RgQuE0a0NzEIvtO64RNy3Otn6PFezbT80cfm3M/Cgt70PA==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.6.3"
         }
       },
       "Microsoft.CSharp": {
@@ -305,16 +306,6 @@
         "requested": "[13.0.2, )",
         "resolved": "13.0.2",
         "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.1",
-          "System.Threading.Tasks.Extensions": "4.6.3"
-        }
       }
     },
     "net8.0": {
@@ -486,8 +477,7 @@
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -543,12 +533,6 @@
         "requested": "[13.0.2, )",
         "resolved": "13.0.2",
         "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg=="
       }
     }
   }

--- a/src/Speckle.Sdk.Dependencies/RepackedChannel.cs
+++ b/src/Speckle.Sdk.Dependencies/RepackedChannel.cs
@@ -2,6 +2,19 @@
 
 namespace Speckle.Sdk.Dependencies;
 
+/// <summary>
+/// For various reasons related to our use of ILRepack.FullAuto,
+/// we cannot use Channels from the SDK project.
+/// We have to keep usage of it inside the Sdk.Dependencies project.
+///
+/// For the sake of quick development, I've wrapped the <see cref="Channel"/> class here in a type
+/// that is safe to use from the SDK project.
+///
+/// As and when we need more functions, we can add them here.
+///
+/// And yes... I'm not very happy about the way we've set this up
+/// </summary>
+/// <typeparam name="T"></typeparam>
 public sealed class RepackedChannel<T>
 {
   private readonly Channel<T> _channel;
@@ -25,12 +38,4 @@ public sealed class RepackedChannel<T>
 
   public IAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken) =>
     _channel.Reader.ReadAllAsync(cancellationToken);
-
-  public async Task ReadAllAsync(Func<T, Task> callback, CancellationToken cancellationToken)
-  {
-    await foreach (var item in _channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
-    {
-      await callback(item).ConfigureAwait(false);
-    }
-  }
 }

--- a/src/Speckle.Sdk.Dependencies/RepackedChannel.cs
+++ b/src/Speckle.Sdk.Dependencies/RepackedChannel.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading.Channels;
+
+namespace Speckle.Sdk.Dependencies;
+
+public sealed class RepackedChannel<T>
+{
+  private readonly Channel<T> _channel;
+
+  public RepackedChannel(int capacity, bool singleReader, bool singleWriter)
+  {
+    _channel = Channel.CreateBounded<T>(
+      new BoundedChannelOptions(capacity)
+      {
+        FullMode = BoundedChannelFullMode.Wait,
+        SingleReader = singleReader,
+        SingleWriter = singleWriter,
+      }
+    );
+  }
+
+  public void CompleteWriter() => _channel.Writer.Complete();
+
+  public ValueTask WriteAsync(T item, CancellationToken cancellationToken) =>
+    _channel.Writer.WriteAsync(item, cancellationToken);
+
+  public IAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken) =>
+    _channel.Reader.ReadAllAsync(cancellationToken);
+
+  public async Task ReadAllAsync(Func<T, Task> callback, CancellationToken cancellationToken)
+  {
+    await foreach (var item in _channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+    {
+      await callback(item).ConfigureAwait(false);
+    }
+  }
+}

--- a/src/Speckle.Sdk.Dependencies/packages.lock.json
+++ b/src/Speckle.Sdk.Dependencies/packages.lock.json
@@ -95,14 +95,6 @@
         "resolved": "2.0.33",
         "contentHash": "xb2h1CsOepoYwdXEPui9VcQglwABQwNf9cccZbf+acarEzF5PUp8Xx71nFXIhOgEdm6wrxAoF6xAxK4m/XFRUQ=="
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "E1HSLkPHXEO30JEij2pWbOuzz1Z5ND4a5l7IP1T2RgQuE0a0NzEIvtO64RNy3Otn6PFezbT80cfm3M/Cgt70PA==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.6.3"
-        }
-      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -158,6 +150,15 @@
         "contentHash": "7sCiwilJLYbTZELaKnc7RecBBXWXA+xMLQWZKWawBxYjp6DBlSE3v9/UcvKBvr1vv2tTOhipiogM8rRmxlhrVA==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.1.2"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "E1HSLkPHXEO30JEij2pWbOuzz1Z5ND4a5l7IP1T2RgQuE0a0NzEIvtO64RNy3Otn6PFezbT80cfm3M/Cgt70PA==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.6.3"
         }
       }
     },

--- a/src/Speckle.Sdk/Pipelines/Send/DiskStore.cs
+++ b/src/Speckle.Sdk/Pipelines/Send/DiskStore.cs
@@ -2,6 +2,7 @@ using System.IO.Compression;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Speckle.InterfaceGenerator;
+using Speckle.Sdk.Dependencies;
 using Speckle.Sdk.Helpers;
 
 namespace Speckle.Sdk.Pipelines.Send;
@@ -14,7 +15,7 @@ public sealed class DiskStoreFactory(ILogger<DiskStore> logger) : IDiskStoreFact
 
 public sealed class DiskStore
 {
-  private readonly Channel<UploadItem> _channel;
+  private readonly RepackedChannel<UploadItem> _channel;
   private readonly Task<DisposableFile> _writeToDiskTask;
   private readonly ILogger<DiskStore> _logger;
   private readonly CancellationToken _cancellationToken;
@@ -24,17 +25,15 @@ public sealed class DiskStore
     _logger = logger;
     _cancellationToken = cancellationToken;
 
-    _channel = Channel.CreateBounded<UploadItem>(
-      new BoundedChannelOptions(1000) { FullMode = BoundedChannelFullMode.Wait, SingleReader = true }
-    );
+    _channel = new RepackedChannel<UploadItem>(1000, true, false);
     _writeToDiskTask = Task.Run(WriteFile, cancellationToken);
   }
 
-  public ValueTask PushAsync(UploadItem item) => _channel.Writer.WriteAsync(item, _cancellationToken);
+  public ValueTask PushAsync(UploadItem item) => _channel.WriteAsync(item, _cancellationToken);
 
   public async Task<DisposableFile> CompleteAsync()
   {
-    _channel.Writer.Complete();
+    _channel.CompleteWriter();
     return await _writeToDiskTask.ConfigureAwait(false);
   }
 
@@ -55,7 +54,7 @@ public sealed class DiskStore
       using var gzip = new GZipStream(fileStream, CompressionLevel.Optimal);
       using var writer = new StreamWriter(gzip);
 
-      await foreach (var item in _channel.Reader.ReadAllAsync(_cancellationToken).ConfigureAwait(false))
+      await foreach (var item in _channel.ReadAllAsync(_cancellationToken).ConfigureAwait(false))
       {
         await writer.WriteLineAsync($"{item.Id}\t{item.Json}\t{item.SpeckleType}").ConfigureAwait(false);
       }

--- a/src/Speckle.Sdk/Speckle.Sdk.csproj
+++ b/src/Speckle.Sdk/Speckle.Sdk.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Speckle.DoubleNumerics" />
     <PackageReference Include="Speckle.Newtonsoft.Json" />
-    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" OverrideVersion="8.0.0" />
@@ -36,6 +35,7 @@
     <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Speckle.Sdk.Dependencies\Speckle.Sdk.Dependencies.csproj" />

--- a/src/Speckle.Sdk/packages.lock.json
+++ b/src/Speckle.Sdk/packages.lock.json
@@ -13,6 +13,15 @@
           "System.Reactive": "5.0.0"
         }
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "E1HSLkPHXEO30JEij2pWbOuzz1Z5ND4a5l7IP1T2RgQuE0a0NzEIvtO64RNy3Otn6PFezbT80cfm3M/Cgt70PA==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.6.3"
+        }
+      },
       "Microsoft.CSharp": {
         "type": "Direct",
         "requested": "[4.7.0, )",
@@ -90,16 +99,6 @@
         "resolved": "13.0.2",
         "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
       },
-      "System.Threading.Channels": {
-        "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.1",
-          "System.Threading.Tasks.Extensions": "4.6.3"
-        }
-      },
       "GraphQL.Client.Abstractions": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -120,14 +119,6 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "yg72rrYDapfsIUrul7aF6wwNnTJBOFvuA9VdDTQpPa8AlAriHbufeXYLBcodKjfUdkCnaiggX1U/nEP08Zb5GA=="
-      },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "10.0.1",
-        "contentHash": "E1HSLkPHXEO30JEij2pWbOuzz1Z5ND4a5l7IP1T2RgQuE0a0NzEIvtO64RNy3Otn6PFezbT80cfm3M/Cgt70PA==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.6.3"
-        }
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -376,12 +367,6 @@
         "requested": "[13.0.2, )",
         "resolved": "13.0.2",
         "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
-      },
-      "System.Threading.Channels": {
-        "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg=="
       },
       "GraphQL.Client.Abstractions": {
         "type": "Transitive",

--- a/tests/Speckle.Automate.Sdk.Integration/packages.lock.json
+++ b/tests/Speckle.Automate.Sdk.Integration/packages.lock.json
@@ -370,8 +370,7 @@
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -491,12 +490,6 @@
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg=="
       },
       "Verify.Quibble": {
         "type": "CentralTransitive",

--- a/tests/Speckle.Objects.Tests.Unit/packages.lock.json
+++ b/tests/Speckle.Objects.Tests.Unit/packages.lock.json
@@ -348,8 +348,7 @@
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -432,12 +431,6 @@
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg=="
       },
       "Verify.Quibble": {
         "type": "CentralTransitive",

--- a/tests/Speckle.Sdk.Serialization.Testing/packages.lock.json
+++ b/tests/Speckle.Sdk.Serialization.Testing/packages.lock.json
@@ -74,11 +74,6 @@
         "resolved": "1.17.0",
         "contentHash": "8x+HCVTl/HHTGpscH3vMBhV8sknN/muZFw9s3TsI8SA6+c43cOTCi2+jE4KsU8pNLbJ++iF2ZFcpcXHXtDglnw=="
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "1Am6l4Vpn3/K32daEqZI+FFr96OlZkgwK2LcT3pZ2zWubR5zTPW3/FkO1Rat9kb7oQOa4rxgl9LJHc5tspCWfg=="
-      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -342,8 +337,7 @@
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -386,6 +380,12 @@
           "System.Reactive": "5.0.0"
         }
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "1.1.0",
+        "contentHash": "1Am6l4Vpn3/K32daEqZI+FFr96OlZkgwK2LcT3pZ2zWubR5zTPW3/FkO1Rat9kb7oQOa4rxgl9LJHc5tspCWfg=="
+      },
       "Microsoft.Data.Sqlite": {
         "type": "CentralTransitive",
         "requested": "[7.0.5, )",
@@ -425,12 +425,6 @@
         "requested": "[13.0.2, )",
         "resolved": "13.0.2",
         "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg=="
       }
     }
   }

--- a/tests/Speckle.Sdk.Serialization.Tests/packages.lock.json
+++ b/tests/Speckle.Sdk.Serialization.Tests/packages.lock.json
@@ -393,8 +393,7 @@
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -474,12 +473,6 @@
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg=="
       },
       "Verify.Quibble": {
         "type": "CentralTransitive",

--- a/tests/Speckle.Sdk.Testing/packages.lock.json
+++ b/tests/Speckle.Sdk.Testing/packages.lock.json
@@ -311,8 +311,7 @@
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -377,12 +376,6 @@
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg=="
       }
     }
   }

--- a/tests/Speckle.Sdk.Tests.Integration/packages.lock.json
+++ b/tests/Speckle.Sdk.Tests.Integration/packages.lock.json
@@ -370,8 +370,7 @@
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -454,12 +453,6 @@
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg=="
       },
       "Verify.Quibble": {
         "type": "CentralTransitive",

--- a/tests/Speckle.Sdk.Tests.Performance/packages.lock.json
+++ b/tests/Speckle.Sdk.Tests.Performance/packages.lock.json
@@ -92,11 +92,6 @@
         "resolved": "1.17.0",
         "contentHash": "8x+HCVTl/HHTGpscH3vMBhV8sknN/muZFw9s3TsI8SA6+c43cOTCi2+jE4KsU8pNLbJ++iF2ZFcpcXHXtDglnw=="
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "1Am6l4Vpn3/K32daEqZI+FFr96OlZkgwK2LcT3pZ2zWubR5zTPW3/FkO1Rat9kb7oQOa4rxgl9LJHc5tspCWfg=="
-      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -360,8 +355,7 @@
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -377,6 +371,12 @@
           "GraphQL.Client.Abstractions.Websocket": "6.0.0",
           "System.Reactive": "5.0.0"
         }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "1.1.0",
+        "contentHash": "1Am6l4Vpn3/K32daEqZI+FFr96OlZkgwK2LcT3pZ2zWubR5zTPW3/FkO1Rat9kb7oQOa4rxgl9LJHc5tspCWfg=="
       },
       "Microsoft.Data.Sqlite": {
         "type": "CentralTransitive",
@@ -417,12 +417,6 @@
         "requested": "[13.0.2, )",
         "resolved": "13.0.2",
         "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg=="
       }
     }
   }

--- a/tests/Speckle.Sdk.Tests.Unit/packages.lock.json
+++ b/tests/Speckle.Sdk.Tests.Unit/packages.lock.json
@@ -363,8 +363,7 @@
           "Microsoft.Extensions.Logging": "[2.2.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
-          "Speckle.Sdk.Dependencies": "[1.0.0, )",
-          "System.Threading.Channels": "[10.0.1, )"
+          "Speckle.Sdk.Dependencies": "[1.0.0, )"
         }
       },
       "speckle.sdk.dependencies": {
@@ -441,12 +440,6 @@
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
-      },
-      "System.Threading.Channels": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "YRqU6Y2Cl6C+HrG5h1ftgKZ5VDTSA7j1wMKs5RtlauPeQ2EZ639Jt5aOFHdX3naP01hDDWFOWPApmNDVKwOpmg=="
       },
       "Verify.Quibble": {
         "type": "CentralTransitive",


### PR DESCRIPTION
The current state of duckdev is broken, and we're unable to run it under Revit and Civil because of DLL problems loading Channels.

This is because Dim added a reference to Channels from the `Speckle.Sdk` while we already have a reference from the `Speckle.Sdk.Dependencies` project.

For various reasons (that quite frankly, I'm quite unhappy with), we cannot use Channels from the SDK project. We have to keep usage of it inside the Sdk.Dependencies project.

This PR wrapps the channels usage in this "Repacked" channel so that the DiskStore can continue to use it fine. 

This was the quickest fix I could think of that doesn't involve moving massive amounts of legacy code.

---

Note, this also means we add a dependency on `Microsoft.Bcl.AsyncInterfaces` for the .NETStandard2.0 target.
This is ok, because we used to have it there anyway up-until recently, when I removed it because it was at the time not needed.
