### PR TITLE
perf: Avoid writing root object twice to ndjson

### DIFF
--- a/src/Speckle.Sdk/Pipelines/Send/SendPipeline.cs
+++ b/src/Speckle.Sdk/Pipelines/Send/SendPipeline.cs
@@ -36,28 +36,22 @@ public sealed class SendPipeline : IDisposable
     _diskStore = diskStore;
   }
 
-  private UploadItem _lastItem;
-
   public async Task<ObjectReference> Process(Base @base)
   {
     var results = _serializer.Serialize(@base).ToArray();
     var first = results.First();
-    foreach (var item in results)
+    // .Reverse ensures the root commit object is written last.
+    foreach (var item in results.Reverse())
     {
       // we're not doing fire and forget here so that we get the backpressure from the uploader
       await _diskStore.PushAsync(item).ConfigureAwait(false);
     }
 
-    // NOTE: this is important to keep track of. When we serialze an object, we get back a list of objects, with the first one being the original root.
-    // In the case of the commit root object, this means the last object is not necessarily the root; we therefore need to manually track its existance here
-    // and ensure it's the last one through in the uploader's stream. See WaitForUpload down below.
-    _lastItem = first;
     return first.Reference;
   }
 
   public async Task WaitForUpload()
   {
-    await _diskStore.PushAsync(_lastItem).ConfigureAwait(false);
     using DisposableFile tempFile = await _diskStore.CompleteAsync().ConfigureAwait(false);
 
     using Stream fileStreamUpload = new FileStream(


### PR DESCRIPTION
It's a requirement that the root object be the last line int the ndjson file

The way we previously ensured this, was to store the last item until we start uploading, and then re-write the root object as the last  item.
This meant that the root object always appears twice in the file.

We're noticing with large files, the root object tends to be very large.

However, it's not like the server is processing the root twice, or the clients are serializing it twice.
simply writing and reading it twice.

I don't expect this PR to make a huge difference, but instead it's a cheap win.