### PR TITLE
fix(ci): Update cross repo integration test workflow to use slnx

### DIFF
--- a/.github/workflows/integration-test-callable-from-server-repo.yml
+++ b/.github/workflows/integration-test-callable-from-server-repo.yml
@@ -14,7 +14,7 @@ jobs:
       CLIENT_REPO: "specklesystems/speckle-sharp-sdk"
       SERVER_DIR: "./server"
       SERVER_REPO: "specklesystems/speckle-server-internal"
-      SOLUTION: "Speckle.Sdk.sln"
+      SOLUTION: "Speckle.Sdk.slnx"
       SPECKLE_SERVER_IMAGE: "speckle-server:local"
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +34,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.x.x
+          dotnet-version: 10.x.x
       #          cache: true
       #          cache-dependency-path: "**/packages.lock.json"
 


### PR DESCRIPTION
https://github.com/specklesystems/speckle-sharp-sdk/pull/442 removed the sln file, we should now use the slnx everywhere