### PR TITLE
feat: RhinoObject 

### DIFF
--- a/src/Speckle.Objects/Data/RhinoObject.cs
+++ b/src/Speckle.Objects/Data/RhinoObject.cs
@@ -1,0 +1,20 @@
+using Speckle.Objects.Other;
+using Speckle.Sdk.Models;
+
+namespace Speckle.Objects.Data;
+
+/// <summary>
+/// Represents a Rhino.DocObjects.RhinoObject object in Rhinoceros 3D
+/// </summary>
+[SpeckleType("Objects.Data.RhinoObject")]
+public class RhinoObject : DataObject, IRhinoObject
+{
+  public required string type { get; set; }
+
+  public required string units { get; set; }
+
+  [DetachProperty]
+  public RawEncoding? rawEncoding { get; set; }
+
+  IReadOnlyList<Base> IDisplayValue<IReadOnlyList<Base>>.displayValue => displayValue;
+}

--- a/src/Speckle.Objects/Interfaces.cs
+++ b/src/Speckle.Objects/Interfaces.cs
@@ -171,5 +171,9 @@ public interface IArchicadObject : IDataObject
 
 public interface INavisworksObject : IDataObject { }
 
+public interface IRhinoObject : IDataObject
+{
+  string type { get; }
+}
 
 #endregion

--- a/src/Speckle.Objects/Other/RawEncoding.cs
+++ b/src/Speckle.Objects/Other/RawEncoding.cs
@@ -22,4 +22,6 @@ public static class RawEncodingFormats
   public const string RHINO_3DM = "3dm";
   public const string ACAD_DWG = "dwg";
   public const string ACAD_SAT = "sat";
+  public const string STEP = "stp";
+  
 }

--- a/src/Speckle.Objects/Other/RawEncoding.cs
+++ b/src/Speckle.Objects/Other/RawEncoding.cs
@@ -22,6 +22,4 @@ public static class RawEncodingFormats
   public const string RHINO_3DM = "3dm";
   public const string ACAD_DWG = "dwg";
   public const string ACAD_SAT = "sat";
-  public const string STEP = "stp";
-  
 }


### PR DESCRIPTION
Rhino connector was sending raw geometry directly into collections. This PR is creating the RhinoObject to align Rhino with other connectors.

The rawEncoding field holds the native 3dm blob so Breps/Extrusions/SubDs can roundtrip back to their original form on receive, while displayValue carries mesh primitives for the viewer.

Related connectors PR: https://github.com/specklesystems/speckle-sharp-connectors/pull/1371