### PR TITLE
fix: Ensure ingestion progress happens on worker threadpool

### DIFF
--- a/src/Speckle.Sdk/Pipelines/Progress/IngestionProgressManager.cs
+++ b/src/Speckle.Sdk/Pipelines/Progress/IngestionProgressManager.cs
@@ -48,17 +48,20 @@ public sealed class IngestionProgressManager(
 
       trimmedMessage = value.Status.TrimEnd('.');
 
-      LastUpdate = speckleClient
-        .Ingestion.UpdateProgress(
-          new ModelIngestionUpdateInput(ingestion.id, ingestion.projectId, trimmedMessage, value.Progress),
-          cancellationToken
-        )
-        .ContinueWith(
-          Continuation,
-          CancellationToken.None,
-          TaskContinuationOptions.ExecuteSynchronously,
-          TaskScheduler.Default
-        );
+      LastUpdate = Task.Run(async () =>
+        await speckleClient
+          .Ingestion.UpdateProgress(
+            new ModelIngestionUpdateInput(ingestion.id, ingestion.projectId, trimmedMessage, value.Progress),
+            cancellationToken
+          )
+          .ContinueWith(
+            Continuation,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default
+          )
+          .ConfigureAwait(false)
+      );
     }
 
     logger.LogInformation("Progress update {Message} {Progress}", trimmedMessage, value.Progress);


### PR DESCRIPTION
ODA function uses a thread pinning scheduler. This causes some issues because the ingestion manager's update will use it, and cause the threadpool to block