### PR TITLE
feat(perf): Stream blobs todisk

### DIFF
--- a/src/Speckle.Sdk/Api/Blob/BlobApi.cs
+++ b/src/Speckle.Sdk/Api/Blob/BlobApi.cs
@@ -90,7 +90,10 @@ public sealed class BlobApi : IBlobApi
 
     var url = new Uri($"api/stream/{projectId}/blob/{blobId}", UriKind.Relative);
 
-    using var response = await _authedClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+    using var response = await _authedClient
+      .GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+      .ConfigureAwait(false);
+
     response.EnsureSuccessStatusCode();
 
     string fileLocation = pathOverride ?? GetBlobDownloadPath(blobId, response);
@@ -105,7 +108,14 @@ public sealed class BlobApi : IBlobApi
       true
     );
 
-    using var fs = new FileStream(fileLocation, FileMode.OpenOrCreate);
+    using var fs = new FileStream(
+      fileLocation,
+      FileMode.Create,
+      FileAccess.Write,
+      FileShare.None,
+      1024 * 1024,
+      FileOptions.Asynchronous
+    );
 #if NET5_0_OR_GREATER
     await source.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
 #else


### PR DESCRIPTION
Currently, we're buffering blob responses entirely in memory. Blobs greater than ~2GB fail to download because that exceeds `int32.MaxValue`

Streaming to disk properly should avoid this problem; allowing us to download larger files and with higher performance