### PR TITLE
Update docker-compose-internal.yml

### DIFF
--- a/.github/workflows/integration-test-callable-from-server-repo.yml
+++ b/.github/workflows/integration-test-callable-from-server-repo.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.2xx
+          dotnet-version: 10.0.2xx #Keep aligned with global.json
       #          cache: true
       #          cache-dependency-path: "**/packages.lock.json"
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.2xx
+          dotnet-version: 10.0.2xx #Keep aligned with global.json
           cache: true
           cache-dependency-path: "**/packages.lock.json"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.2xx
+          dotnet-version: 10.0.2xx #Keep aligned with global.json
           cache: true
           cache-dependency-path: "**/packages.lock.json"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.2xx
+          dotnet-version: 10.0.2xx #Keep aligned with global.json
           cache: true
           cache-dependency-path: "**/packages.lock.json"
 

--- a/docker-compose-internal.yml
+++ b/docker-compose-internal.yml
@@ -5,20 +5,23 @@ services:
   # Speckle Server dependencies
   #######
   postgres:
-    image: "postgres:16.4-alpine3.20@sha256:d898b0b78a2627cb4ee63464a14efc9d296884f1b28c841b0ab7d7c42f1fffdf"
+    image: 'postgres:18.3-alpine3.23@sha256:54451ecb8ab38c24c3ec123f2fd501303a3a1856a5c66e98cecf2460d5e1e9d7'
     restart: always
     environment:
       POSTGRES_DB: speckle
       POSTGRES_USER: speckle
       POSTGRES_PASSWORD: speckle
     volumes:
-      - ./.volumes/postgres-data:/var/lib/postgresql/data/
+      - ./.volumes/postgres-data:/var/lib/postgresql
+      - ./setup/db/10-docker_postgres_init.sql:/docker-entrypoint-initdb.d/10-docker_postgres_init.sql
+      - ./setup/db/11-docker_postgres_authentik_init.sql:/docker-entrypoint-initdb.d/11-docker_postgres_authentik_init.sql
+    command: postgres -c max_prepared_transactions=150
     healthcheck:
-      # the -U user has to match the POSTGRES_USER value
-      test: ["CMD-SHELL", "pg_isready -U speckle"]
-      interval: 5s
+      test: ["CMD-SHELL", "pg_isready -U speckle -d speckle"]
+      interval: 10s
       timeout: 5s
-      retries: 30
+      retries: 5
+      start_period: 20s
 
   redis:
     image: "valkey/valkey:8.1-alpine@sha256:0d27f0bca0249f61d060029a6aaf2e16b2c417d68d02a508e1dfb763fa2948b4"
@@ -32,7 +35,7 @@ services:
       retries: 30
 
   minio:
-    image: "minio/minio:RELEASE.2023-10-25T06-33-25Z"
+    image: "minio/minio:RELEASE.2025-09-07T16-13-09Z"
     command: server /data --console-address ":9001"
     restart: always
     volumes:
@@ -74,11 +77,11 @@ services:
       minio:
         condition: service_healthy
     environment:
-      # TODO: Change this to the URL of the speckle server, as accessed from the network
-      CANONICAL_URL: "http://127.0.0.1:8080"
+      CANONICAL_URL: "http://127.0.0.1:3000"
       SPECKLE_AUTOMATE_URL: "http://127.0.0.1:3030"
       FRONTEND_ORIGIN: "http://127.0.0.1:8081"
-
+      BIND_ADDRESS: "0.0.0.0"
+      
       # TODO: Change thvolumes:
       REDIS_URL: "redis://redis"
 
@@ -101,9 +104,6 @@ services:
       ENABLE_MP: "false"
 
       LOG_PRETTY: "true"
-
-      FF_NEXT_GEN_FILE_IMPORTER_ENABLED: "true"
-      FF_LARGE_FILE_IMPORTS_ENABLED: "true"
 
 networks:
   default:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.200",
-    "rollForward": "latestMinor"
+    "rollForward": "latestPatch"
   }
 }

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ProjectResourceTests.cs
@@ -94,10 +94,7 @@ public class ProjectResourceTests
     await Sut.Delete(toDelete.id);
 
     // Assert
-    await FluentActions
-      .Invoking(async () => await Sut.Get(toDelete.id))
-      .Should()
-      .ThrowAsync<SpeckleGraphQLStreamNotFoundException>();
+    await FluentActions.Invoking(async () => await Sut.Get(toDelete.id)).Should().ThrowAsync<Exception>();
   }
 
   [Fact]


### PR DESCRIPTION
Integration tests are broken because they are failing to connect to the local docker server

3.0.23-alpha.2087 <- not working - https://github.com/specklesystems/speckle-server-internal/pull/1716 
3.0.23-alpha.2086* <- last working

https://github.com/specklesystems/speckle-server-internal/pull/1716 introduced a change to the way the server binds to the network.

