### PR TITLE
refactor(otel)!: better expose tracecontext

### DIFF
--- a/src/Speckle.Sdk.Dependencies/ISdkActivity.cs
+++ b/src/Speckle.Sdk.Dependencies/ISdkActivity.cs
@@ -3,7 +3,14 @@ namespace Speckle.Sdk.Logging;
 public interface ISdkActivity : IDisposable
 {
   void SetTag(string key, object? value);
-  void RecordException(Exception e);
+  void RecordException(Exception ex);
+
+  // W3C <c>tracestate</c> header
+  string? TraceState { get; }
+
+  // W3C <c>traceparent</c> header
+  string TraceParent { get; }
+
   string TraceId { get; }
   string SpanId { get; }
   void SetStatus(SdkActivityStatusCode code);

--- a/src/Speckle.Sdk.Dependencies/ISdkActivity.cs
+++ b/src/Speckle.Sdk.Dependencies/ISdkActivity.cs
@@ -5,10 +5,10 @@ public interface ISdkActivity : IDisposable
   void SetTag(string key, object? value);
   void RecordException(Exception ex);
 
-  // W3C <c>tracestate</c> header
+  ///<summary> W3C <c>tracestate</c> header</summary>
   string? TraceState { get; }
 
-  // W3C <c>traceparent</c> header
+  ///<summary> W3C <c>traceparent</c> header</summary>
   string TraceParent { get; }
 
   string TraceId { get; }

--- a/src/Speckle.Sdk.Dependencies/ISdkActivityFactory.cs
+++ b/src/Speckle.Sdk.Dependencies/ISdkActivityFactory.cs
@@ -8,13 +8,18 @@ public interface ISdkActivityFactory : IDisposable
   ISdkActivity? Start(
     string? name = null,
     SdkActivityKind kind = SdkActivityKind.Internal,
+    IReadOnlyDictionary<string, object?>? tags = null,
+    DateTimeOffset startTime = default,
     [CallerMemberName] string source = ""
   );
 
   ISdkActivity? StartRemote(
-    string traceContext,
+    string? traceParent,
+    string? traceState,
     SdkActivityKind kind,
     string? name = null,
+    IReadOnlyDictionary<string, object?>? tags = null,
+    DateTimeOffset startTime = default,
     [CallerMemberName] string source = ""
   );
 }

--- a/src/Speckle.Sdk/Logging/NullActivityFactory.cs
+++ b/src/Speckle.Sdk/Logging/NullActivityFactory.cs
@@ -6,7 +6,21 @@ public sealed class NullActivityFactory : ISdkActivityFactory
 {
   public void Dispose() { }
 
-  public ISdkActivity? Start(string? name, SdkActivityKind kind, string source) => null;
+  public ISdkActivity? Start(
+    string? name = null,
+    SdkActivityKind kind = SdkActivityKind.Internal,
+    IReadOnlyDictionary<string, object?>? tags = null,
+    DateTimeOffset startTime = default,
+    string source = ""
+  ) => null;
 
-  public ISdkActivity? StartRemote(string traceContext, SdkActivityKind kind, string? name, string source) => null;
+  public ISdkActivity? StartRemote(
+    string? traceParent,
+    string? traceState,
+    SdkActivityKind kind,
+    string? name = null,
+    IReadOnlyDictionary<string, object?>? tags = null,
+    DateTimeOffset startTime = default,
+    string source = ""
+  ) => null;
 }

--- a/tests/Speckle.Sdk.Serialization.Tests/Send2/ServerObjectManagerTests.cs
+++ b/tests/Speckle.Sdk.Serialization.Tests/Send2/ServerObjectManagerTests.cs
@@ -52,7 +52,7 @@ public class ServerObjectManagerTests : MoqTest
     http.Setup(x => x.CreateHttpClient(It.IsAny<HttpClientHandler>(), timeout, token)).Returns(httpClient);
 
     var activityFactory = Create<ISdkActivityFactory>();
-    activityFactory.Setup(x => x.Start(null, default, "DownloadObjects")).Returns((ISdkActivity?)null);
+    activityFactory.Setup(x => x.Start(null, default, null, default, "DownloadObjects")).Returns((ISdkActivity?)null);
 
     var serverObjectManager = new ServerObjectManager(
       http.Object,
@@ -91,7 +91,9 @@ public class ServerObjectManagerTests : MoqTest
     http.Setup(x => x.CreateHttpClient(It.IsAny<HttpClientHandler>(), timeout, token)).Returns(httpClient);
 
     var activityFactory = Create<ISdkActivityFactory>();
-    activityFactory.Setup(x => x.Start(null, default, "DownloadSingleObject")).Returns((ISdkActivity?)null);
+    activityFactory
+      .Setup(x => x.Start(null, default, null, default, "DownloadSingleObject"))
+      .Returns((ISdkActivity?)null);
 
     var serverObjectManager = new ServerObjectManager(
       http.Object,
@@ -132,7 +134,7 @@ public class ServerObjectManagerTests : MoqTest
     http.Setup(x => x.CreateHttpClient(It.IsAny<HttpClientHandler>(), timeout, token)).Returns(httpClient);
 
     var activityFactory = Create<ISdkActivityFactory>();
-    activityFactory.Setup(x => x.Start(null, default, "HasObjects")).Returns((ISdkActivity?)null);
+    activityFactory.Setup(x => x.Start(null, default, null, default, "HasObjects")).Returns((ISdkActivity?)null);
 
     var serverObjectManager = new ServerObjectManager(
       http.Object,
@@ -171,7 +173,7 @@ public class ServerObjectManagerTests : MoqTest
     http.Setup(x => x.CreateHttpClient(It.IsAny<HttpClientHandler>(), timeout, token)).Returns(httpClient);
 
     var activityFactory = Create<ISdkActivityFactory>();
-    activityFactory.Setup(x => x.Start(null, default, "UploadObjects")).Returns((ISdkActivity?)null);
+    activityFactory.Setup(x => x.Start(null, default, null, default, "UploadObjects")).Returns((ISdkActivity?)null);
 
     var serverObjectManager = new ServerObjectManager(
       http.Object,


### PR DESCRIPTION
- Expose traceparent header and tracestate header
- Align start activity closer with the real `Activity` constructor.
    - Allow for setting `tags` to allow consumers to more easily create activity with tags (rather than set them post construction)
    - Expose `DateTime` startTime (no real need atm, but aligns with the Activity constructor)