### PR TITLE
feat!: Add OTEL to automate sdk

### DIFF
--- a/src/Speckle.Automate.Sdk/AutomateContextFactory.cs
+++ b/src/Speckle.Automate.Sdk/AutomateContextFactory.cs
@@ -2,6 +2,7 @@
 using System.Text.Json;
 using GraphQL;
 using GraphQL.Client.Http;
+using Microsoft.Extensions.Logging;
 using Speckle.Automate.Sdk.Schema;
 using Speckle.InterfaceGenerator;
 using Speckle.Sdk.Api;
@@ -13,7 +14,8 @@ namespace Speckle.Automate.Sdk;
 internal sealed class AutomationContextFactory(
   IClientFactory clientFactory,
   IAccountFactory accountFactory,
-  IOperations operations
+  IOperations operations,
+  ILogger<AutomationContext> logger
 ) : IAutomationContextFactory
 {
   private static readonly JsonSerializerOptions s_jsonSerializerSettings = new()
@@ -49,7 +51,7 @@ internal sealed class AutomationContextFactory(
     IClient client = clientFactory.Create(account);
     Stopwatch initTime = Stopwatch.StartNew();
 
-    return new AutomationContext(operations)
+    return new AutomationContext(operations, logger)
     {
       AutomationRunData = automationRunData,
       SpeckleClient = client,

--- a/src/Speckle.Automate.Sdk/AutomationContext.cs
+++ b/src/Speckle.Automate.Sdk/AutomationContext.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using GraphQL;
+using Microsoft.Extensions.Logging;
 using Speckle.Automate.Sdk.Schema;
 using Speckle.Automate.Sdk.Schema.Triggers;
 using Speckle.InterfaceGenerator;
@@ -16,7 +17,7 @@ using Version = Speckle.Sdk.Api.GraphQL.Models.Version;
 namespace Speckle.Automate.Sdk;
 
 [GenerateAutoInterface(VisibilityModifier = "public")]
-internal sealed class AutomationContext(IOperations operations) : IAutomationContext
+internal sealed class AutomationContext(IOperations operations, ILogger<AutomationContext> logger) : IAutomationContext
 {
   public AutomationRunData AutomationRunData { get; set; }
   public string? ContextView
@@ -77,8 +78,11 @@ internal sealed class AutomationContext(IOperations operations) : IAutomationCon
     await SpeckleClient
       .Version.Received(new(version.id, AutomationRunData.ProjectId, "automate_function"), cancellationToken)
       .ConfigureAwait(false);
-
-    Console.WriteLine($"It took {Elapsed.TotalSeconds} seconds to receive the speckle version {versionId}");
+    logger.LogInformation(
+      "It took {TotalSeconds} seconds to receive the speckle version {VersionId}",
+      Elapsed.TotalSeconds,
+      versionId
+    );
     return rootObject;
   }
 
@@ -245,7 +249,8 @@ internal sealed class AutomationContext(IOperations operations) : IAutomationCon
       .ConfigureAwait(false);
     request.EnsureSuccessStatusCode();
     string responseString = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
-    Console.WriteLine("RESPONSE - " + responseString);
+
+    logger.LogInformation("RESPONSE - {Response}", responseString);
     BlobUploadResponse uploadResponse = JsonConvert.DeserializeObject<BlobUploadResponse>(responseString);
     if (uploadResponse.UploadResults.Count != 1)
     {
@@ -269,7 +274,7 @@ internal sealed class AutomationContext(IOperations operations) : IAutomationCon
       msg += $"\n{statusMessage}";
     }
 
-    Console.WriteLine(msg);
+    logger.LogInformation("Marking run with {Status} {Message}", status, msg);
   }
 
   public void MarkRunFailed(string statusMessage) => MarkRun(AutomationStatus.Failed, statusMessage);
@@ -356,7 +361,12 @@ internal sealed class AutomationContext(IOperations operations) : IAutomationCon
       x => x.applicationId
     );
 
-    Console.WriteLine($"Created new {levelString.ToUpper()} category: {category} caused by: {message}");
+    logger.LogInformation(
+      "Created new {Level} category: {Category} caused by: {Messag}",
+      levelString.ToUpper(),
+      category,
+      message
+    );
 
     ResultCase resultCase = new()
     {
@@ -375,5 +385,5 @@ internal sealed class AutomationContext(IOperations operations) : IAutomationCon
 public partial interface IAutomationContext
 {
   [MemberNotNull(nameof(ContextView))]
-  public void SetContextView(IReadOnlyCollection<string>? resourceIds = null, bool includeSourceModelVersion = true);
+  void SetContextView(IReadOnlyCollection<string>? resourceIds = null, bool includeSourceModelVersion = true);
 }

--- a/src/Speckle.Automate.Sdk/Runner.cs
+++ b/src/Speckle.Automate.Sdk/Runner.cs
@@ -1,13 +1,15 @@
 using System.CommandLine;
-using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Schema;
 using Newtonsoft.Json.Schema.Generation;
 using Newtonsoft.Json.Serialization;
 using Speckle.Automate.Sdk.DataAnnotations;
 using Speckle.Automate.Sdk.Schema;
+using Speckle.Connectors.Logging;
 using Speckle.InterfaceGenerator;
 using Speckle.Sdk;
+using Speckle.Sdk.Logging;
 
 namespace Speckle.Automate.Sdk;
 
@@ -15,9 +17,12 @@ namespace Speckle.Automate.Sdk;
 /// Provides mechanisms to execute any function that conforms to the AutomateFunction "interface"
 /// </summary>
 [GenerateAutoInterface(VisibilityModifier = "public")]
-internal class AutomationRunner(IAutomationContextFactory contextFactory) : IAutomationRunner
+internal sealed class AutomationRunner(
+  IAutomationContextFactory contextFactory,
+  ISdkActivityFactory activityFactory,
+  ILogger<AutomationRunner> logger
+) : IAutomationRunner
 {
-  [SuppressMessage("Design", "CA1031:Do not catch general exception types")]
   public async Task<IAutomationContext> RunFunction<TInput>(
     Func<IAutomationContext, TInput, Task> automateFunction,
     AutomationRunData automationRunData,
@@ -27,7 +32,7 @@ internal class AutomationRunner(IAutomationContextFactory contextFactory) : IAut
     where TInput : struct
   {
     var automationContext = await contextFactory.Initialize(automationRunData, speckleToken).ConfigureAwait(false);
-
+    using ISdkActivity? activity = activityFactory.Start();
     try
     {
       await automateFunction.Invoke(automationContext, inputs).ConfigureAwait(false);
@@ -36,12 +41,20 @@ internal class AutomationRunner(IAutomationContextFactory contextFactory) : IAut
         automationContext.MarkRunSuccess(
           "WARNING: Automate assumed a success status, but it was not marked as so by the function."
         );
+        activity?.SetStatus(SdkActivityStatusCode.Ok);
       }
     }
-    catch (Exception ex) when (!ex.IsFatal())
+    catch (Exception ex)
     {
-      Console.WriteLine(ex.ToString());
+      logger.LogCritical(ex, "Function error: {ExceptionMessage}", ex.ToString());
       automationContext.MarkRunException("Function error. Check the automation run logs for details.");
+      activity?.SetStatus(SdkActivityStatusCode.Error);
+      activity?.RecordException(ex);
+
+      if (ex.IsFatal())
+      {
+        throw;
+      }
     }
     finally
     {
@@ -95,6 +108,7 @@ internal class AutomationRunner(IAutomationContextFactory contextFactory) : IAut
   public async Task<int> Main<TInput>(string[] args, Func<IAutomationContext, TInput, Task> automateFunction)
     where TInput : struct
   {
+    using ISdkActivity? activity = StartActivityFromEnv();
     Argument<string> pathArg = new(name: "Input Path", description: "A file path to retrieve function inputs");
     RootCommand rootCommand = new();
 
@@ -162,9 +176,21 @@ internal class AutomationRunner(IAutomationContextFactory contextFactory) : IAut
 
     await rootCommand.InvokeAsync(args).ConfigureAwait(false);
 
+    activity?.SetStatus(SdkActivityStatusCode.Ok);
     // if we've gotten this far, the execution should technically be completed as expected
     // thus exiting with 0 is the semantically correct thing to do
     return exitCode;
+  }
+
+  /// <summary>
+  /// Propagates trace context from server via environment variables
+  /// </summary>
+  /// <returns></returns>
+  private ISdkActivity? StartActivityFromEnv()
+  {
+    var traceParent = Environment.GetEnvironmentVariable("SPECKLE_OTEL_TRACEPARENT");
+    var traceState = Environment.GetEnvironmentVariable("SPECKLE_OTEL_TRACESTATE");
+    return activityFactory.StartRemote(traceParent, traceState, SdkActivityKind.Server, "Automation Runner");
   }
 }
 

--- a/src/Speckle.Automate.Sdk/Test/TestAutomateUtils.cs
+++ b/src/Speckle.Automate.Sdk/Test/TestAutomateUtils.cs
@@ -7,7 +7,7 @@ using Speckle.Sdk.Api.GraphQL.Models.Responses;
 
 namespace Speckle.Automate.Sdk.Test;
 
-internal class TestAutomationRun
+internal sealed class TestAutomationRun
 {
   [JsonRequired]
   public required string AutomationRunId { get; init; }
@@ -19,7 +19,7 @@ internal class TestAutomationRun
   public required IReadOnlyList<TestAutomationRunTrigger> Triggers { get; init; }
 }
 
-internal class TestAutomationRunTrigger : AutomationRunTriggerBase
+internal sealed class TestAutomationRunTrigger : AutomationRunTriggerBase
 {
   /// <remarks>This should really be a TestAutomationRunTriggerPayload, but right now, they look the samee</remarks>
   public required VersionCreationTriggerPayload Payload { get; init; }


### PR DESCRIPTION
Adds a top level trace to the entry point of automate.
This will grab trace context from `SPECKLE_OTEL_TRACEPARENT` and  `SPECKLE_OTEL_TRACESTATE` env vars (if set)

It's up to the function author to add the extra config that's needed to send the traces anywhere (which I have setup for our  own ODA functions here https://github.com/specklesystems/speckle-oda/pull/276