### PR TITLE
chore: Supress SQLite vulnerability

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,6 +57,10 @@
     </NoWarn
     >
   </PropertyGroup>
+  <ItemGroup>
+      <!--Waiting for microsoft to update Microsoft.Data.Sqlite-->
+      <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
   <PropertyGroup>
     <!-- Expose the repository root to all projects -->
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,8 +24,8 @@
      or where ILRepack affords us extra flexibility.
      
    - Avoid having production versions of our SDKs depend on pre-release packages
-     If you must suppress NU5104, do so inline e.g. `<PackageReference Include="System.CommandLine" NoWarn="NU5104" />`.
- 
+     If you must suppress nuget warnings (NU1901, NU1902, NU1903, NU1904), do so inline e.g. `<PackageReference Include="System.CommandLine" NoWarn="NU5104" />`.
+     or use NuGetAuditSuppress
   -->
   <ItemGroup>
     <PackageVersion Include="altcover" Version="9.0.102" />


### PR DESCRIPTION
Our C# code bases are failing to restore because a [high severity vulnerability](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) has just been published for `SQLitePCLRaw.lib.e_sqlite3`, but Microsoft haven't updated `Microsoft.Data.Sqlite` so there's not a fix available for .NET yet 🤦‍♂️

Until a fix is made by MS, our best course of action is to supress the vulnerability