### PR TITLE
fix(objects): Collection will enforce a non-nullable name

### DIFF
--- a/src/Speckle.Sdk/Models/Collections/Collection.cs
+++ b/src/Speckle.Sdk/Models/Collections/Collection.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Speckle.Sdk.Models.Collections;
 
 /// <summary>
@@ -20,6 +22,8 @@ public class Collection : Base
   /// Constructor for a basic collection.
   /// </summary>
   /// <param name="name">The human-readable name of this collection</param>
+  [SetsRequiredMembers]
+  [Obsolete("Use parameterless constructor with initialiser")]
   public Collection(string name)
   {
     this.name = name;
@@ -29,7 +33,7 @@ public class Collection : Base
   /// The human-readable name of the <see cref="Collection"/>.
   /// </summary>
   /// <remarks>This name is not necessarily unique within a commit. Set the applicationId for a unique identifier.</remarks>
-  public string name { get; set; }
+  public required string name { get; set; }
 
   /// <summary>
   /// The type of this collection. Note: Claire and Dim would propose we deprecate this prop. Do not use, please!

--- a/src/Speckle.Sdk/Models/Collections/RootCollection.cs
+++ b/src/Speckle.Sdk/Models/Collections/RootCollection.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Speckle.Sdk.Models.Data;
 
 namespace Speckle.Sdk.Models.Collections;
@@ -11,6 +12,8 @@ public class RootCollection : Collection, IProperties
 {
   public RootCollection() { }
 
+  [SetsRequiredMembers]
+  [Obsolete("Use parameterless constructor with initialiser")]
   public RootCollection(string name)
     : base(name) { }
 

--- a/tests/Speckle.Sdk.Tests.Unit/Models/GraphTraversal/TraversalContextExtensionsTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Models/GraphTraversal/TraversalContextExtensionsTests.cs
@@ -58,7 +58,8 @@ public class TraversalContextExtensionsTests
   [MemberData(nameof(GetTestDepths))]
   public void GetAscendantOfType_EveryOtherIsCollection(int depth)
   {
-    var testData = CreateLinkedList(depth, i => i % 2 == 0 ? new Base() : new Collection()).NotNull();
+    var testData = CreateLinkedList(depth, i => i % 2 == 0 ? new Base() : new Collection() { name = "a collection" })
+      .NotNull();
 
     var all = testData.GetAscendantOfType<Collection>().ToArray();
 


### PR DESCRIPTION
`Collection.name` is not nullable in our schema, and yet the `Collection` class did not mark it as `required`.
This leads to issues, since the Navisworks file importer was sending Collections with `null` name, which broke when receiving in python SDK and Blender.

see https://speckle.community/t/can-not-load-model-python-error/22462/5

This PR makes `name` required.
I've also deprecated the parameter constructor on `Collection`, since `required` keyword is more flexible and fits our needs better, and it to mix and match isn't fun.
