### PR TITLE
bump asyncinterfaces and channels

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="HttpMultipartParser" Version="10.0.0" />
     <PackageVersion Include="ILRepack.FullAuto" Version="1.6.0" />
     <!-- Keep aligned with channels -->
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="[9.0.4,)" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="[9.0.10,)" />
     <!-- Keep version aligned with the lowest .NET framework we need to support (e.g. lowest non-eol) -->
     <PackageVersion Include="Microsoft.CSharp" Version="[4.7.0,)" />
     <!-- Keep at exactly 7.0.5 for side by side with V2 -->
@@ -64,7 +64,7 @@
     <!-- Pinned due to breaking changes in newer versions -->
     <PackageVersion Include="System.CommandLine" Version="[2.0.0-beta4.22272.1]" />
     <!-- 9.0.4 is minimum version for .net standard2.0 because it's the first version to include async enumerables in the .NET standard target -->
-    <PackageVersion Include="System.Threading.Channels" Version="[9.0.4,]" />
+    <PackageVersion Include="System.Threading.Channels" Version="[9.0.10,]" />
     <PackageVersion Include="Verify.Quibble" Version="2.1.1" />
     <PackageVersion Include="Verify.Xunit" Version="31.12.5" />
     <PackageVersion Include="System.Text.Json" Version="10.0.7" />

--- a/src/Speckle.Automate.Sdk/packages.lock.json
+++ b/src/Speckle.Automate.Sdk/packages.lock.json
@@ -351,7 +351,7 @@
       "speckle.sdk.dependencies": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "[9.0.4, )"
+          "Microsoft.Bcl.AsyncInterfaces": "[9.0.10, )"
         }
       },
       "GraphQL.Client": {
@@ -367,7 +367,7 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "CentralTransitive",
-        "requested": "[9.0.4, )",
+        "requested": "[9.0.10, )",
         "resolved": "10.0.7",
         "contentHash": "g0Xp9A+B8jCf5pNIIhFOQXPJkte3D87shfTLY+ylwfSh22U5oQH6tvvmcUuqJvt/wtwKk0WdNp2OGEczHJlJdg==",
         "dependencies": {

--- a/src/Speckle.Objects/packages.lock.json
+++ b/src/Speckle.Objects/packages.lock.json
@@ -307,7 +307,7 @@
       "speckle.sdk.dependencies": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "[9.0.4, )"
+          "Microsoft.Bcl.AsyncInterfaces": "[9.0.10, )"
         }
       },
       "GraphQL.Client": {
@@ -323,7 +323,7 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "CentralTransitive",
-        "requested": "[9.0.4, )",
+        "requested": "[9.0.10, )",
         "resolved": "9.0.10",
         "contentHash": "iUfw06CsVKAliec4ML6Q91ozbQ8SKbiraIiQegECAPeMY8cGGagIbyZ9+PBtTJ0hx1//qpRqdXDkt51SDQ6k+Q==",
         "dependencies": {

--- a/src/Speckle.Sdk.Dependencies/packages.lock.json
+++ b/src/Speckle.Sdk.Dependencies/packages.lock.json
@@ -13,9 +13,9 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Direct",
-        "requested": "[9.0.4, )",
-        "resolved": "9.0.4",
-        "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
+        "requested": "[9.0.10, )",
+        "resolved": "9.0.10",
+        "contentHash": "iUfw06CsVKAliec4ML6Q91ozbQ8SKbiraIiQegECAPeMY8cGGagIbyZ9+PBtTJ0hx1//qpRqdXDkt51SDQ6k+Q==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -91,11 +91,11 @@
       },
       "System.Threading.Channels": {
         "type": "Direct",
-        "requested": "[9.0.4, )",
-        "resolved": "9.0.4",
-        "contentHash": "4qBn2H6/aXBpE/Pm3wY5yusY/pEvQz99NlWHrTUji0qCmOdbhhjaALcpmbfW2ksxlPM6i6S+QFLkpOQdyfeKYQ==",
+        "requested": "[9.0.10, )",
+        "resolved": "9.0.10",
+        "contentHash": "2skUPYIRYwMyOg+BQkHaUDc3mOjHmIqT6U67+oIiRJVVtDrkCG2GZxceui6bos18kosyIE0Eg6FyJWgNsc+6og==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.4",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.10",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
@@ -229,9 +229,9 @@
       },
       "System.Threading.Channels": {
         "type": "Direct",
-        "requested": "[9.0.4, )",
-        "resolved": "9.0.4",
-        "contentHash": "4qBn2H6/aXBpE/Pm3wY5yusY/pEvQz99NlWHrTUji0qCmOdbhhjaALcpmbfW2ksxlPM6i6S+QFLkpOQdyfeKYQ=="
+        "requested": "[9.0.10, )",
+        "resolved": "9.0.10",
+        "contentHash": "2skUPYIRYwMyOg+BQkHaUDc3mOjHmIqT6U67+oIiRJVVtDrkCG2GZxceui6bos18kosyIE0Eg6FyJWgNsc+6og=="
       },
       "ILRepack": {
         "type": "Transitive",
@@ -316,9 +316,9 @@
       },
       "System.Threading.Channels": {
         "type": "Direct",
-        "requested": "[9.0.4, )",
-        "resolved": "9.0.4",
-        "contentHash": "4qBn2H6/aXBpE/Pm3wY5yusY/pEvQz99NlWHrTUji0qCmOdbhhjaALcpmbfW2ksxlPM6i6S+QFLkpOQdyfeKYQ=="
+        "requested": "[9.0.10, )",
+        "resolved": "9.0.10",
+        "contentHash": "2skUPYIRYwMyOg+BQkHaUDc3mOjHmIqT6U67+oIiRJVVtDrkCG2GZxceui6bos18kosyIE0Eg6FyJWgNsc+6og=="
       },
       "ILRepack": {
         "type": "Transitive",

--- a/src/Speckle.Sdk/packages.lock.json
+++ b/src/Speckle.Sdk/packages.lock.json
@@ -386,12 +386,12 @@
       "speckle.sdk.dependencies": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "[9.0.4, )"
+          "Microsoft.Bcl.AsyncInterfaces": "[9.0.10, )"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "CentralTransitive",
-        "requested": "[9.0.4, )",
+        "requested": "[9.0.10, )",
         "resolved": "9.0.10",
         "contentHash": "iUfw06CsVKAliec4ML6Q91ozbQ8SKbiraIiQegECAPeMY8cGGagIbyZ9+PBtTJ0hx1//qpRqdXDkt51SDQ6k+Q==",
         "dependencies": {


### PR DESCRIPTION
Revit 2024 would stuck at sending. It was a mismatch in versions of dependencies. This PR addresses that.