### PR TITLE
feat(sgeo): add Region primitive (hatch boundary + inner loops)

### DIFF
--- a/src/Speckle.Objects/Utils/SgeoDecoder.cs
+++ b/src/Speckle.Objects/Utils/SgeoDecoder.cs
@@ -205,10 +205,7 @@ public static class SgeoDecoder
         var segments = new List<ICurve>(segCount);
         for (int i = 0; i < segCount; i++)
         {
-          int blobLen = r.Count(1); // bytes
-          _ = r.U(); // reserved
-          segments.Add((ICurve)Decode(r.Slice(blobLen)));
-          r.Align8();
+          segments.Add(ReadCurveBlob(ref r));
         }
         return new Polycurve
         {
@@ -386,6 +383,26 @@ public static class SgeoDecoder
         };
       }
 
+      case SgeoPrimitiveType.Region:
+      {
+        bool hasHatchPattern = r.U() != 0;
+        int loopCount = r.Count(8);
+        var boundary = ReadCurveBlob(ref r);
+        var innerLoops = new List<ICurve>(loopCount);
+        for (int i = 0; i < loopCount; i++)
+        {
+          innerLoops.Add(ReadCurveBlob(ref r));
+        }
+        return new Region
+        {
+          boundary = boundary,
+          innerLoops = innerLoops,
+          hasHatchPattern = hasHatchPattern,
+          units = units,
+          displayValue = new(),
+        };
+      }
+
       default:
         throw new SpeckleException($"Unknown SGEO primitive type {(byte)header.PrimitiveType}.");
     }
@@ -406,6 +423,17 @@ public static class SgeoDecoder
       closed = closed,
       units = units,
     };
+  }
+
+  // Reads one nested curve written by SgeoEncoder.AddCurveBlob ([blobLen][reserved][blob][pad-to-8]) — shared by the
+  // Polycurve segments and Region loops.
+  private static ICurve ReadCurveBlob(ref Reader r)
+  {
+    int blobLen = r.Count(1); // bytes
+    _ = r.U(); // reserved
+    var curve = (ICurve)Decode(r.Slice(blobLen));
+    r.Align8();
+    return curve;
   }
 
   private static Point ReadPoint(ref Reader r, string units)

--- a/src/Speckle.Objects/Utils/SgeoEncoder.cs
+++ b/src/Speckle.Objects/Utils/SgeoEncoder.cs
@@ -35,6 +35,7 @@ public static class SgeoEncoder
       Ellipse e => EncodeEllipse(e),
       Spiral s => EncodeSpiral(s),
       Box b => EncodeBox(b),
+      Region rg => EncodeRegion(rg),
       _ => throw new SpeckleException($"No SGEO encoding for geometry type '{geometry.GetType().Name}'."),
     };
   }
@@ -55,6 +56,7 @@ public static class SgeoEncoder
       Ellipse => SgeoPrimitiveType.Ellipse,
       Spiral => SgeoPrimitiveType.Spiral,
       Box => SgeoPrimitiveType.Box,
+      Region => SgeoPrimitiveType.Region,
       _ => (SgeoPrimitiveType)255,
     };
     return (byte)type != 255;
@@ -121,13 +123,35 @@ public static class SgeoEncoder
     AddUInt32(body, 0);
     foreach (var seg in pc.segments)
     {
-      byte[] blob = Encode((Base)seg);
-      AddUInt32(body, (uint)blob.Length);
-      AddUInt32(body, 0);
-      body.AddRange(blob);
-      Pad8(body);
+      AddCurveBlob(body, seg);
     }
     return Assemble(SgeoPrimitiveType.Polycurve, flags, pc.units, body);
+  }
+
+  // Region blob = hasHatchPattern flag + boundary curve (nested SGEO blob) + N inner-loop curves (nested blobs). The
+  // display meshes and the hatch pattern/rotation/scale are NOT stored here — meshes ride the DISPLAY rel and the
+  // pattern styling rides EAV properties; this blob is the authoritative boundary geometry (host: Hatch/Region).
+  private static byte[] EncodeRegion(Region r)
+  {
+    var body = new List<byte>(256);
+    AddUInt32(body, r.hasHatchPattern ? 1u : 0u);
+    AddUInt32(body, (uint)r.innerLoops.Count);
+    AddCurveBlob(body, r.boundary);
+    foreach (var loop in r.innerLoops)
+    {
+      AddCurveBlob(body, loop);
+    }
+    return Assemble(SgeoPrimitiveType.Region, SgeoFlags.None, r.units, body);
+  }
+
+  // Writes one nested curve as [blobLen][reserved][blob][pad-to-8] — shared by Polycurve segments and Region loops.
+  private static void AddCurveBlob(List<byte> body, ICurve curve)
+  {
+    byte[] blob = Encode((Base)curve);
+    AddUInt32(body, (uint)blob.Length);
+    AddUInt32(body, 0);
+    body.AddRange(blob);
+    Pad8(body);
   }
 
   // Curve blob = the connector-baked smooth `displayValue` polyline LEADING (render: the viewer has no NURBS

--- a/src/Speckle.Objects/Utils/SgeoFormat.cs
+++ b/src/Speckle.Objects/Utils/SgeoFormat.cs
@@ -48,6 +48,7 @@ public enum SgeoPrimitiveType
   Ellipse = 8,
   Spiral = 9,
   Box = 10,
+  Region = 11,
 }
 
 /// <summary>SGEO header flags (offset 0x06, stored as a uint16 bitfield).</summary>

--- a/tests/Speckle.Objects.Tests.Unit/Geometry/SgeoTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Geometry/SgeoTests.cs
@@ -398,6 +398,100 @@ public class SgeoTests
     decoded.volume.Should().Be(6); // derived, recomputed
   }
 
+  [Fact]
+  public void Region_WithHatchAndInnerLoop_RoundTrips()
+  {
+    var region = new Region
+    {
+      boundary = new Polyline
+      {
+        value = [0, 0, 0, 4, 0, 0, 4, 4, 0, 0, 4, 0],
+        closed = true,
+        units = Units.Meters,
+      },
+      innerLoops =
+      [
+        new Polyline
+        {
+          value = [1, 1, 0, 2, 1, 0, 2, 2, 0, 1, 2, 0],
+          closed = true,
+          units = Units.Meters,
+        },
+      ],
+      hasHatchPattern = true,
+      units = Units.Meters,
+      displayValue = new(),
+    };
+
+    var bytes = SgeoEncoder.Encode(region);
+    SgeoDecoder.ReadHeader(bytes).PrimitiveType.Should().Be(SgeoPrimitiveType.Region);
+
+    var decoded = (Region)SgeoDecoder.Decode(bytes);
+    decoded.hasHatchPattern.Should().BeTrue();
+    decoded.boundary.Should().BeOfType<Polyline>();
+    ((Polyline)decoded.boundary).value.Should().Equal(0, 0, 0, 4, 0, 0, 4, 4, 0, 0, 4, 0);
+    decoded.innerLoops.Should().HaveCount(1);
+    ((Polyline)decoded.innerLoops[0]).value.Should().Equal(1, 1, 0, 2, 1, 0, 2, 2, 0, 1, 2, 0);
+  }
+
+  [Fact]
+  public void Region_WithPolycurveBoundary_RoundTrips()
+  {
+    // Realistic hatch: Get3dCurves typically returns a joined Polycurve boundary (Line + Arc segments).
+    var region = new Region
+    {
+      boundary = new Polycurve
+      {
+        segments =
+        [
+          new Line
+          {
+            start = new Point(0, 0, 0, Units.Meters),
+            end = new Point(4, 0, 0, Units.Meters),
+            units = Units.Meters,
+          },
+          new Arc
+          {
+            plane = XYPlane(Units.Meters),
+            startPoint = new Point(4, 0, 0, Units.Meters),
+            midPoint = new Point(2, 2, 0, Units.Meters),
+            endPoint = new Point(0, 0, 0, Units.Meters),
+            units = Units.Meters,
+            domain = Interval.UnitInterval,
+          },
+        ],
+        closed = true,
+        units = Units.Meters,
+      },
+      innerLoops =
+      [
+        new Circle
+        {
+          radius = 0.5,
+          plane = XYPlane(Units.Meters),
+          units = Units.Meters,
+          domain = Interval.UnitInterval,
+        },
+      ],
+      hasHatchPattern = true,
+      units = Units.Meters,
+      displayValue = new(),
+    };
+
+    var bytes = SgeoEncoder.Encode(region);
+    var decoded = (Region)SgeoDecoder.Decode(bytes);
+
+    decoded.boundary.Should().BeOfType<Polycurve>();
+    var pc = (Polycurve)decoded.boundary;
+    pc.segments.Should().HaveCount(2);
+    pc.segments[0].Should().BeOfType<Line>();
+    pc.segments[1].Should().BeOfType<Arc>();
+    ((Line)pc.segments[0]).end.x.Should().Be(4);
+    decoded.innerLoops.Should().HaveCount(1);
+    decoded.innerLoops[0].Should().BeOfType<Circle>();
+    ((Circle)decoded.innerLoops[0]).radius.Should().Be(0.5);
+  }
+
   // ── integrity ─────────────────────────────────────────────────────────────
 
   [Fact]


### PR DESCRIPTION
Non AI note: I am not fun of wrapping decoded objects onto old classes. But OK for now for the sake of speed.

SGEO could not encode Region, so a hatch's authoritative boundary geometry was lost on the 4.0 artefact path (only its display meshes survived, receiving back as a plain Mesh). Add a Region primitive that encodes hasHatchPattern + the boundary curve + N inner-loop curves as nested SGEO curve blobs (reusing every existing curve encoder). Factor the nested-curve framing into shared AddCurveBlob / ReadCurveBlob, now used by both Polycurve and Region.

Roundtrip tests cover a polyline boundary + island and a realistic Polycurve (Line + Arc) boundary + Circle island. 36/36 SGEO + 15/15 parity pass (net8+net10).