### PR TITLE
feat(sgeo): add Text primitive (Objects.Annotation.Text, code 12)

### DIFF
--- a/plans/speckle-4.0/sgeo-binary-format.md
+++ b/plans/speckle-4.0/sgeo-binary-format.md
@@ -8,7 +8,8 @@
 > Every primitive type in `Speckle.Objects/Geometry` was reviewed. The renderable
 > ones get an SGEO body below. The fidelity types (`Brep`, `BrepX`, `ExtrusionX`,
 > `SubDX`, `SolidX`) are **not** SGEO primitives — see *Fidelity types* at the end.
-> `Surface` (NURBS) and `Region` are **out of scope** for SGEO v1.
+> `Surface` (NURBS) is **out of scope** for SGEO v1. (`Region` and
+> `Objects.Annotation.Text` were added post-v1-spec as codes 11 and 12.)
 
 ## Conventions (apply to every primitive)
 
@@ -57,6 +58,8 @@
 | 8 | ellipse | `Ellipse` |
 | 9 | spiral | `Spiral` |
 | 10 | box | `Box` |
+| 11 | region | `Region` |
+| 12 | text | `Objects.Annotation.Text` |
 
 `Vector`, `Plane`, `Interval`, `ControlPoint` are building blocks embedded in the
 bodies above, never top-level blobs.
@@ -74,6 +77,8 @@ bodies above, never top-level blobs.
 | 6 | has colors | mesh, points |
 | 7 | has sizes | points |
 | 8 | has trimDomain | ellipse |
+| 9 | screen oriented (camera-aligned, plane axes ignored) | text |
+| 10 | has maxWidth (wrap width) | text |
 | others | reserved = 0 | |
 
 ## Primitive bodies (one by one)
@@ -263,6 +268,42 @@ def_off+0x00  u32  spiral_type            (enum ordinal)
 0x70  f64  xSize.start  0x78 f64 xSize.end
 0x80  f64  ySize.start  0x88 f64 ySize.end
 0x90  f64  zSize.start  0x98 f64 zSize.end
+```
+
+### 11 — region (`Region`)
+
+Boundary + inner loops as nested SGEO curve blobs (same `[blobLen][reserved][blob][pad8]`
+framing as polycurve segments). Display meshes ride the DISPLAY rel; hatch
+pattern/rotation/scale ride EAV properties — this blob is the authoritative
+boundary geometry only.
+
+```
+0x10  u32  hasHatchPattern       (0|1)
+0x14  u32  inner_loop_count
+0x18  …    boundary              [u32 blobLen][u32 reserved][nested SGEO blob][pad to 8B]
+   +  …    inner loops           inner_loop_count × the same framing
+```
+
+### 12 — text (`Objects.Annotation.Text`)
+
+Parametric annotation, not tessellated glyphs — consumers lay the string out
+themselves. `screenOriented` rides flag bit 9; `maxWidth` presence rides bit 10.
+`height` is linear units, or pixels when `units_code = 0` (none). The value
+string is the first non-numeric SGEO body field: `[u32 byteLen][u32 reserved]`
+then raw UTF-8 bytes, zero-padded to 8 B (byteLen counts bytes, not chars).
+
+```
+0x10  u32  alignmentH            (0 left, 1 center, 2 right)
+0x14  u32  alignmentV            (0 top, 1 center, 2 bottom)
+0x18  f64  height
+   +  f64  maxWidth              if flag bit10
+   +  f64[3]  plane.origin
+   +  f64[3]  plane.normal
+   +  f64[3]  plane.xdir
+   +  f64[3]  plane.ydir
+   +  u32  value_byte_len        (utf8 bytes)
+   +  u32  reserved = 0
+   +  u8[value_byte_len]  value  utf8, then pad to 8B
 ```
 
 ## Fidelity types — route to `blobs.parquet`, not SGEO

--- a/src/Speckle.Objects/Utils/SgeoDecoder.cs
+++ b/src/Speckle.Objects/Utils/SgeoDecoder.cs
@@ -1,4 +1,6 @@
 using System.Buffers.Binary;
+using System.Text;
+using Speckle.Objects.Annotation;
 using Speckle.Objects.Geometry;
 using Speckle.Objects.Primitive;
 using Speckle.Sdk;
@@ -400,6 +402,33 @@ public static class SgeoDecoder
           hasHatchPattern = hasHatchPattern,
           units = units,
           displayValue = new(),
+        };
+      }
+
+      case SgeoPrimitiveType.Text:
+      {
+        var alignmentH = (AlignmentHorizontal)r.U();
+        var alignmentV = (AlignmentVertical)r.U();
+        double height = r.D();
+        double? maxWidth = null;
+        if ((header.Flags & SgeoFlags.HasMaxWidth) != 0)
+        {
+          maxWidth = r.D();
+        }
+        var plane = ReadPlane(ref r, units);
+        int byteLen = r.Count(1); // utf8 bytes
+        _ = r.U(); // reserved
+        string value = Encoding.UTF8.GetString(r.Slice(byteLen).ToArray());
+        return new Text
+        {
+          value = value,
+          height = height,
+          maxWidth = maxWidth,
+          alignmentH = alignmentH,
+          alignmentV = alignmentV,
+          plane = plane,
+          screenOriented = (header.Flags & SgeoFlags.ScreenOriented) != 0,
+          units = units,
         };
       }
 

--- a/src/Speckle.Objects/Utils/SgeoEncoder.cs
+++ b/src/Speckle.Objects/Utils/SgeoEncoder.cs
@@ -1,4 +1,6 @@
 using System.Buffers.Binary;
+using System.Text;
+using Speckle.Objects.Annotation;
 using Speckle.Objects.Geometry;
 using Speckle.Sdk;
 using Speckle.Sdk.Common;
@@ -36,6 +38,7 @@ public static class SgeoEncoder
       Spiral s => EncodeSpiral(s),
       Box b => EncodeBox(b),
       Region rg => EncodeRegion(rg),
+      Text t => EncodeText(t),
       _ => throw new SpeckleException($"No SGEO encoding for geometry type '{geometry.GetType().Name}'."),
     };
   }
@@ -57,6 +60,7 @@ public static class SgeoEncoder
       Spiral => SgeoPrimitiveType.Spiral,
       Box => SgeoPrimitiveType.Box,
       Region => SgeoPrimitiveType.Region,
+      Text => SgeoPrimitiveType.Text,
       _ => (SgeoPrimitiveType)255,
     };
     return (byte)type != 255;
@@ -296,6 +300,29 @@ public static class SgeoEncoder
     AddDouble(body, b.zSize.start);
     AddDouble(body, b.zSize.end);
     return Assemble(SgeoPrimitiveType.Box, SgeoFlags.None, b.units, body);
+  }
+
+  // Text blob = alignmentH/alignmentV (u32 pair) + height + optional wrap width (HasMaxWidth) + plane + the value
+  // string. screenOriented rides the ScreenOriented header flag. The string is the first non-numeric SGEO body
+  // field: [byteLen][reserved][utf8 bytes][pad-to-8], the same framing AddCurveBlob uses for nested blobs.
+  private static byte[] EncodeText(Text t)
+  {
+    var flags = SgeoFlags.None;
+    if (t.screenOriented) { flags |= SgeoFlags.ScreenOriented; }
+    if (t.maxWidth != null) { flags |= SgeoFlags.HasMaxWidth; }
+
+    byte[] valueBytes = Encoding.UTF8.GetBytes(t.value);
+    var body = new List<byte>(128 + valueBytes.Length);
+    AddUInt32(body, (uint)t.alignmentH);
+    AddUInt32(body, (uint)t.alignmentV);
+    AddDouble(body, t.height);
+    if (t.maxWidth is double maxWidth) { AddDouble(body, maxWidth); }
+    AddPlane(body, t.plane);
+    AddUInt32(body, (uint)valueBytes.Length);
+    AddUInt32(body, 0);
+    body.AddRange(valueBytes);
+    Pad8(body);
+    return Assemble(SgeoPrimitiveType.Text, flags, t.units, body);
   }
 
   // ── assembly + low-level writers ───────────────────────────────────────

--- a/src/Speckle.Objects/Utils/SgeoFormat.cs
+++ b/src/Speckle.Objects/Utils/SgeoFormat.cs
@@ -49,6 +49,7 @@ public enum SgeoPrimitiveType
   Spiral = 9,
   Box = 10,
   Region = 11,
+  Text = 12,
 }
 
 /// <summary>SGEO header flags (offset 0x06, stored as a uint16 bitfield).</summary>
@@ -83,6 +84,12 @@ public enum SgeoFlags
 
   /// <summary>ellipse has a trim domain.</summary>
   HasTrimDomain = 1 << 8,
+
+  /// <summary>text is camera-aligned (plane axes ignored).</summary>
+  ScreenOriented = 1 << 9,
+
+  /// <summary>text has a wrap width.</summary>
+  HasMaxWidth = 1 << 10,
 }
 
 /// <summary>The decoded SGEO header, without expanding the body.</summary>

--- a/tests/Speckle.Objects.Tests.Unit/Geometry/SgeoParityTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Geometry/SgeoParityTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Speckle.Objects.Annotation;
 using Speckle.Objects.Geometry;
 using Speckle.Objects.Primitive;
 using Speckle.Objects.Utils;
@@ -416,5 +417,57 @@ public class SgeoParityTests
     d.zSize.end.Should().Be(3);
     d.units.Should().Be(M);
     d.volume.Should().BeApproximately(original.volume, Tol); // derived
+  }
+
+  // ── 12 text ───────────────────────────────────────────────────────────────
+  [Fact]
+  public void Text_AllFields_LosesNothing()
+  {
+    var original = new Text
+    {
+      value = "Multi-line\nannotation — ünïcödé ✓",
+      height = 3.25,
+      units = M,
+      screenOriented = false,
+      alignmentH = AlignmentHorizontal.Right,
+      alignmentV = AlignmentVertical.Center,
+      plane = XYPlane(),
+      maxWidth = 42.5,
+    };
+
+    var d = RoundTrip<Text>(original);
+
+    d.value.Should().Be(original.value);
+    d.height.Should().Be(3.25);
+    d.screenOriented.Should().BeFalse();
+    d.alignmentH.Should().Be(AlignmentHorizontal.Right);
+    d.alignmentV.Should().Be(AlignmentVertical.Center);
+    AssertSamePlane(d.plane, original.plane);
+    d.maxWidth.Should().Be(42.5);
+    d.units.Should().Be(M);
+  }
+
+  [Fact]
+  public void Text_ScreenOrientedPixelSized_LosesNothing()
+  {
+    var original = new Text
+    {
+      value = "17px viewer label",
+      height = 17,
+      units = Units.None, // pixel-sized (viewer measurements)
+      screenOriented = true,
+      alignmentH = AlignmentHorizontal.Left,
+      alignmentV = AlignmentVertical.Top,
+      plane = XYPlane(Units.None),
+      maxWidth = null,
+    };
+
+    var d = RoundTrip<Text>(original);
+
+    d.value.Should().Be(original.value);
+    d.height.Should().Be(17);
+    d.screenOriented.Should().BeTrue();
+    d.maxWidth.Should().BeNull();
+    d.units.Should().Be(Units.None);
   }
 }

--- a/tests/Speckle.Objects.Tests.Unit/Geometry/SgeoTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Geometry/SgeoTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using AwesomeAssertions;
+using Speckle.Objects.Annotation;
 using Speckle.Objects.Geometry;
 using Speckle.Objects.Primitive;
 using Speckle.Objects.Utils;
@@ -490,6 +491,98 @@ public class SgeoTests
     decoded.innerLoops.Should().HaveCount(1);
     decoded.innerLoops[0].Should().BeOfType<Circle>();
     ((Circle)decoded.innerLoops[0]).radius.Should().Be(0.5);
+  }
+
+  [Fact]
+  public void Text_RoundTrips()
+  {
+    var text = new Text
+    {
+      value = "Hello, Speckle!",
+      height = 2.5,
+      units = Units.Meters,
+      screenOriented = false,
+      alignmentH = AlignmentHorizontal.Center,
+      alignmentV = AlignmentVertical.Bottom,
+      plane = XYPlane(Units.Meters),
+    };
+
+    var bytes = SgeoEncoder.Encode(text);
+    // 16 header + 8 alignments + 8 height + 96 plane + 8 string framing + 16 padded utf8 ("Hello, Speckle!" = 15B)
+    bytes.Length.Should().Be(152);
+    Magic(bytes).Should().Be("SGEO");
+
+    var header = SgeoDecoder.ReadHeader(bytes);
+    header.PrimitiveType.Should().Be(SgeoPrimitiveType.Text);
+    header.Flags.Should().Be(SgeoFlags.None);
+
+    var decoded = (Text)SgeoDecoder.Decode(bytes);
+    decoded.value.Should().Be("Hello, Speckle!");
+    decoded.height.Should().Be(2.5);
+    decoded.screenOriented.Should().BeFalse();
+    decoded.alignmentH.Should().Be(AlignmentHorizontal.Center);
+    decoded.alignmentV.Should().Be(AlignmentVertical.Bottom);
+    decoded.maxWidth.Should().BeNull();
+    decoded.units.Should().Be(Units.Meters);
+  }
+
+  [Fact]
+  public void Text_WithMaxWidthAndScreenOriented_RoundTrips()
+  {
+    var text = new Text
+    {
+      value = "wrapped billboard",
+      height = 17,
+      units = Units.None, // pixel-sized
+      screenOriented = true,
+      plane = XYPlane(Units.None),
+      maxWidth = 120.5,
+    };
+
+    var bytes = SgeoEncoder.Encode(text);
+    var header = SgeoDecoder.ReadHeader(bytes);
+    header.Flags.Should().HaveFlag(SgeoFlags.ScreenOriented);
+    header.Flags.Should().HaveFlag(SgeoFlags.HasMaxWidth);
+
+    var decoded = (Text)SgeoDecoder.Decode(bytes);
+    decoded.screenOriented.Should().BeTrue();
+    decoded.maxWidth.Should().Be(120.5);
+    decoded.units.Should().Be(Units.None);
+    decoded.alignmentH.Should().Be(AlignmentHorizontal.Left); // enum defaults survive
+    decoded.alignmentV.Should().Be(AlignmentVertical.Top);
+  }
+
+  [Fact]
+  public void Text_UnicodeValue_RoundTrips()
+  {
+    // multi-byte utf8 (13 chars, 24 bytes) — the length prefix counts BYTES, not chars
+    var text = new Text
+    {
+      value = "Ünïcödé ✓ 東京",
+      height = 1,
+      units = Units.Millimeters,
+      screenOriented = false,
+      plane = XYPlane(Units.Millimeters),
+    };
+
+    var decoded = (Text)SgeoDecoder.Decode(SgeoEncoder.Encode(text));
+    decoded.value.Should().Be("Ünïcödé ✓ 東京");
+  }
+
+  [Fact]
+  public void Text_EmptyValue_RoundTrips()
+  {
+    var text = new Text
+    {
+      value = "",
+      height = 1,
+      units = Units.Meters,
+      screenOriented = false,
+      plane = XYPlane(Units.Meters),
+    };
+
+    var decoded = (Text)SgeoDecoder.Decode(SgeoEncoder.Encode(text));
+    decoded.value.Should().Be("");
   }
 
   // ── integrity ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Encodes parametric text annotations: alignmentH/V (u32 pair), height, optional wrap width (HasMaxWidth flag, 1<<10), plane, and the value string as [byteLen][reserved][utf8][pad8] - the first non-numeric SGEO body field, reusing the curve-blob framing. screenOriented rides a new header flag (1<<9). Also documents the previously unspecced Region=11 in the format doc.