### PR TITLE
ENG-8795: carry layer + object display colours through the artefact b…

### DIFF
--- a/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
@@ -276,12 +276,14 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   /// parent collection node (null = top-level, directly under the excluded root) — the parent chain IS the
   /// source hierarchy. <paramref name="subtype"/> is a tag (e.g. "Layer" / "Collection" / source
   /// collectionType) carried in the <c>subtype</c> column for the loader to label it.</summary>
-  public int AddCollection(string collectionKey, string? name, int? parentCollectionK, string? subtype)
+  public int AddCollection(string collectionKey, string? name, int? parentCollectionK, string? subtype, int? argb = null)
   {
     if (_nodeInterner.GetOrAdd("coll:" + collectionKey, out var k))
     {
-      // v5: a collection is a CONTAINER whose `subtype` carries its tag; the IN_COLLECTION rel marks the axis.
-      _envelopeWriter.AddNode(k, NodeKind.Container, name, parentCollectionK, null, null, subtype, null, null, null, null, null);
+      // v5: a collection is a CONTAINER whose `subtype` carries its tag; the IN_COLLECTION rel marks the axis. The
+      // optional argb carries the collection's display colour (e.g. a Rhino/AutoCAD layer colour) in the shared
+      // node `argb` column — receivers colour the layer from it; null = no colour authored.
+      _envelopeWriter.AddNode(k, NodeKind.Container, name, parentCollectionK, null, null, subtype, argb, null, null, null, null);
     }
     return k;
   }

--- a/src/Speckle.Sdk/Pipelines/Receive/Artifacts/ArtefactBundle.cs
+++ b/src/Speckle.Sdk/Pipelines/Receive/Artifacts/ArtefactBundle.cs
@@ -59,6 +59,10 @@ public sealed class ArtefactRelations
   /// target node). Used to resolve scene-view grouping tiers (e.g. an object's level/model/container) to a layer path.</summary>
   public Dictionary<int, Dictionary<int, int>> ObjectNodeByRel { get; } = new();
   public Dictionary<int, int> MaterialByGeometry { get; } = new();
+
+  /// <summary>HAS_COLOR: geometry → COLOR node. The object's by-object display colour (distinct from a render material);
+  /// resolved back to the owning object via <see cref="ObjectByGeometry"/>, mirroring <see cref="MaterialByGeometry"/>.</summary>
+  public Dictionary<int, int> ColorByGeometry { get; } = new();
   public Dictionary<int, List<int>> DefinesByDefinition { get; } = new();
   public Dictionary<int, List<int>> DefinesInstanceByDefinition { get; } = new();
 
@@ -345,6 +349,9 @@ public static class ArtefactBundleReader
           break;
         case RelKind.HasMaterial:
           sets.MaterialByGeometry[src[i]] = dst[i];
+          break;
+        case RelKind.HasColor:
+          sets.ColorByGeometry[src[i]] = dst[i];
           break;
         case RelKind.Defines:
           sets.Add(sets.DefinesByDefinition, src[i], dst[i]);

--- a/src/Speckle.Sdk/Pipelines/Receive/Artifacts/SceneViewResolver.cs
+++ b/src/Speckle.Sdk/Pipelines/Receive/Artifacts/SceneViewResolver.cs
@@ -41,6 +41,50 @@ public static class SceneViewResolver
     return segments;
   }
 
+  /// <summary>Like <see cref="Segments"/> but pairs each segment with its source node's colour (argb) for node ("rel")
+  /// tiers, so a host can colour layers, not just name them. eav tiers carry no node → null colour.</summary>
+  public static IReadOnlyList<(string Name, int? Argb)> SegmentsWithColor(ArtefactBundle bundle, int objK)
+  {
+    var segments = new List<(string, int?)>();
+    foreach (var tier in bundle.DefaultSceneView)
+    {
+      if (tier.Source == "rel")
+      {
+        if (
+          int.TryParse(tier.Ref, NumberStyles.Integer, CultureInfo.InvariantCulture, out int relNum)
+          && bundle.Relations.ObjectNodeByRel.TryGetValue(relNum, out var map)
+          && map.TryGetValue(objK, out int nodeK)
+        )
+        {
+          segments.AddRange(NodeAncestryWithColor(bundle.Nodes, nodeK));
+        }
+      }
+      else if (tier.Source == "eav" && ResolveEav(bundle.Properties, objK, tier.Ref) is { Length: > 0 } val)
+      {
+        segments.Add((val, null));
+      }
+    }
+    return segments;
+  }
+
+  /// <summary>A node + its grouping ancestry (via <see cref="ArtefactNode.DefRef"/>), outermost→leaf, each paired with
+  /// its <see cref="ArtefactNode.Argb"/> colour (null when the node has none).</summary>
+  public static IReadOnlyList<(string Name, int? Argb)> NodeAncestryWithColor(
+    IReadOnlyDictionary<int, ArtefactNode> nodes,
+    int nodeK
+  )
+  {
+    var result = new List<(string, int?)>();
+    int? cursor = nodeK;
+    int guard = 0;
+    while (cursor is int c && nodes.TryGetValue(c, out var n) && guard++ < ANCESTRY_GUARD)
+    {
+      result.Insert(0, (n.Name is { Length: > 0 } nm ? nm : "unnamed", n.Argb));
+      cursor = n.DefRef;
+    }
+    return result;
+  }
+
   /// <summary>A node + its grouping ancestry (via <see cref="ArtefactNode.DefRef"/>), outermost→leaf. Levels have no
   /// parent (single segment); collections/containers nest.</summary>
   public static IReadOnlyList<string> NodeAncestry(IReadOnlyDictionary<int, ArtefactNode> nodes, int nodeK)


### PR DESCRIPTION
…undle

Adds colour to the 4.0 artefact graph, both tiers:

- ObjectsArtifactPipeline.AddCollection gains an optional argb so a CONTAINER (layer) node can carry its display colour.
- SceneViewResolver.SegmentsWithColor / NodeAncestryWithColor pair each scene-view segment with its node's argb, so a host can colour layers, not just name them (eav tiers carry no node -> null colour).
- ArtefactBundle now loads HAS_COLOR (COLOR node <- geometry) into ColorByGeometry, mirroring HAS_MATERIAL, so the receive side can apply by-object display colours. Old bundles (no HAS_COLOR) resolve empty.