### PR TITLE
feat(artifacts-harness): fall back to embedded per-mesh renderMaterial

### DIFF
--- a/tests/Speckle.Sdk.Artifacts.Harness/GraphArtifactProducer.cs
+++ b/tests/Speckle.Sdk.Artifacts.Harness/GraphArtifactProducer.cs
@@ -86,6 +86,11 @@ public static class GraphArtifactProducer
     // object appId → the geometry appIds of its DISPLAY meshes — lets OBJECT-grained material/colour proxy
     // refs (which name the DataObject, not its mesh — Navis/CAD) bind to the object's display geometry.
     var objectDisplayGeomKeys = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+    // geometry appId → the mesh's embedded RenderMaterial. Old-style sends (pre-proxy Revit/Rhino) attach
+    // the material inline on each display mesh (or its parent element) instead of publishing root-level
+    // renderMaterialProxies — collected during the walk, folded into the material bindings in EmitProxies
+    // (a root-proxy claim wins over this fallback).
+    var embeddedMaterialByGeom = new Dictionary<string, RenderMaterial>(StringComparer.Ordinal);
 
     // Instance-definition source members: appIds in `instanceDefinitionProxies[].objects[]`. These are the
     // definition's content (rendered via instance placements, never directly), NOT atomic scene objects —
@@ -104,11 +109,11 @@ public static class GraphArtifactProducer
     {
       if (defSourceAppIds.Contains(Aid(obj)))
       {
-        EmitDefinitionMember(pipeline, obj, stats, seenGeometryAppIds, instanceNodeByAppId, objectDisplayGeomKeys);
+        EmitDefinitionMember(pipeline, obj, stats, seenGeometryAppIds, instanceNodeByAppId, objectDisplayGeomKeys, embeddedMaterialByGeom);
         continue;
       }
 
-      var objK = EmitObject(pipeline, obj, stats, seenObjectAppIds, seenGeometryAppIds, instanceNodeByAppId, objectDisplayGeomKeys);
+      var objK = EmitObject(pipeline, obj, stats, seenObjectAppIds, seenGeometryAppIds, instanceNodeByAppId, objectDisplayGeomKeys, embeddedMaterialByGeom);
 
       // IN_COLLECTION: the object's direct membership in its enclosing scene-tree container (null parent or a
       // non-collection parent — e.g. an object directly under the root — gets no edge).
@@ -125,7 +130,7 @@ public static class GraphArtifactProducer
         {
           continue;
         }
-        var childK = EmitObject(pipeline, child, stats, seenObjectAppIds, seenGeometryAppIds, instanceNodeByAppId, objectDisplayGeomKeys);
+        var childK = EmitObject(pipeline, child, stats, seenObjectAppIds, seenGeometryAppIds, instanceNodeByAppId, objectDisplayGeomKeys, embeddedMaterialByGeom);
         pipeline.Subelement(objK, childK, stats.SubelementEdges++);
       }
     }
@@ -135,7 +140,7 @@ public static class GraphArtifactProducer
     var layerGeomKeys = BuildLayerGeomKeys(root, objectDisplayGeomKeys, out var layerDepth);
 
     // 2) Value-nodes + their edges, from the root collection's proxy arrays.
-    EmitProxies(pipeline, root, stats, seenObjectAppIds, seenGeometryAppIds, instanceNodeByAppId, objectDisplayGeomKeys, layerGeomKeys, layerDepth);
+    EmitProxies(pipeline, root, stats, seenObjectAppIds, seenGeometryAppIds, instanceNodeByAppId, objectDisplayGeomKeys, layerGeomKeys, layerDepth, embeddedMaterialByGeom);
 
     stats.Geometries = seenGeometryAppIds.Count;
 
@@ -152,7 +157,8 @@ public static class GraphArtifactProducer
     HashSet<string> seenObjectAppIds,
     HashSet<string> seenGeometryAppIds,
     Dictionary<string, int> instanceNodeByAppId,
-    Dictionary<string, List<string>> objectDisplayGeomKeys
+    Dictionary<string, List<string>> objectDisplayGeomKeys,
+    Dictionary<string, RenderMaterial> embeddedMaterialByGeom
   )
   {
     var appId = Aid(obj);
@@ -187,6 +193,9 @@ public static class GraphArtifactProducer
     var displayValue = GetBaseList(obj, "displayValue").ToList();
     if (displayValue.Count > 0)
     {
+      // Element-level embedded material: some old-style hosts (Revit walls/openings) carry the material on
+      // the ELEMENT while their meshes carry their own — the mesh's wins, the element's fills the gaps.
+      var objMaterial = ReadEmbeddedMaterial(obj);
       int ord = 0;
       foreach (var item in displayValue)
       {
@@ -204,6 +213,10 @@ public static class GraphArtifactProducer
             pipeline.Display(objK, pipeline.InternGeometryId(gAppId), ord++);
             stats.DisplayEdges++;
             RecordObjectGeom(objectDisplayGeomKeys, appId, "g:" + gAppId);
+            if ((ReadEmbeddedMaterial(item) ?? objMaterial) is { } rm)
+            {
+              embeddedMaterialByGeom.TryAdd(gAppId, rm);
+            }
           }
         }
       }
@@ -220,6 +233,10 @@ public static class GraphArtifactProducer
         stats.DisplayEdges++;
         stats.MeshAtomics++;
         RecordObjectGeom(objectDisplayGeomKeys, appId, "g:" + appId);
+        if (ReadEmbeddedMaterial(obj) is { } rm)
+        {
+          embeddedMaterialByGeom.TryAdd(appId, rm);
+        }
       }
     }
 
@@ -316,7 +333,8 @@ public static class GraphArtifactProducer
     Stats stats,
     HashSet<string> seenGeometryAppIds,
     Dictionary<string, int> instanceNodeByAppId,
-    Dictionary<string, List<string>> objectDisplayGeomKeys
+    Dictionary<string, List<string>> objectDisplayGeomKeys,
+    Dictionary<string, RenderMaterial> embeddedMaterialByGeom
   )
   {
     var appId = Aid(obj);
@@ -354,6 +372,10 @@ public static class GraphArtifactProducer
     {
       pipeline.AddGeometry(appId, geometry);
       stats.DefinitionGeometries++;
+      if ((ReadEmbeddedMaterial(geometry) ?? ReadEmbeddedMaterial(obj)) is { } rm)
+      {
+        embeddedMaterialByGeom.TryAdd(appId, rm);
+      }
       // Record the definition geometry under its own appId so the ByLayer walk (CollectDescendantGeom) can
       // reach it: block content sits under its SOURCE layer Collection in the tree, and ByLayer colour must
       // bind to this shared geometry-K (fixed across placements) — NOT flood from the instance's layer. The
@@ -382,7 +404,8 @@ public static class GraphArtifactProducer
     Dictionary<string, int> instanceNodeByAppId,
     Dictionary<string, List<string>> objectDisplayGeomKeys,
     Dictionary<string, List<string>> layerGeomKeys,
-    Dictionary<string, int> layerDepth
+    Dictionary<string, int> layerDepth,
+    Dictionary<string, RenderMaterial> embeddedMaterialByGeom
   )
   {
     // DIRECT resolve of a proxy ref to TAGGED appearance targets ("g:<geomAppId>" mesh | "o:<objAppId>"
@@ -513,6 +536,29 @@ public static class GraphArtifactProducer
     }
     var matBindings = BindWithPrecedence(matProxies, out var matSkipped);
     stats.SkippedMaterial += matSkipped;
+
+    // Fallback tier: embedded per-mesh materials, for old-style sends that carry no root proxies (pre-proxy
+    // Revit embeds a RenderMaterial on each display mesh). A proxy claim wins; otherwise the mesh's own
+    // material binds directly. Deduped by material identity so 400 meshes sharing "Concrete - Cast In Situ"
+    // mint one MATERIAL node. NOT placeholder-eligible: an embedded black is an explicit assignment
+    // ("Black Glass"), not the CAD no-material sentinel.
+    var embeddedMatKs = new Dictionary<string, int>(StringComparer.Ordinal);
+    foreach (var (gAppId, rm) in embeddedMaterialByGeom)
+    {
+      var gk = "g:" + gAppId;
+      if (matBindings.ContainsKey(gk))
+      {
+        continue;
+      }
+      var key = rm.applicationId ?? "mat:" + (rm.id ?? rm.diffuse.ToString(CultureInfo.InvariantCulture));
+      if (!embeddedMatKs.TryGetValue(key, out var matK))
+      {
+        matK = pipeline.AddMaterial(key, rm.diffuse, rm.opacity, rm.metalness, rm.roughness);
+        embeddedMatKs[key] = matK;
+        stats.Materials++;
+      }
+      matBindings[gk] = matK;
+    }
 
     // Colors: HAS_COLOR(mesh → colour), per-mesh — same 3-tier resolve + object>layer precedence.
     var colProxies = new List<(int, List<string>)>();
@@ -823,6 +869,15 @@ public static class GraphArtifactProducer
 
   private static bool IsGeometry(Base b) =>
     b.speckle_type.StartsWith("Objects.Geometry.", StringComparison.Ordinal);
+
+  // The inline `renderMaterial` member old-style sends attach to a display mesh (or its parent element) —
+  // dynamic on Mesh, so read via members (typed OR `@`-prefixed detached key).
+  private static RenderMaterial? ReadEmbeddedMaterial(Base host)
+  {
+    var members = host.GetMembers(DynamicBaseMemberType.Instance | DynamicBaseMemberType.Dynamic);
+    return (members.GetValueOrDefault("renderMaterial") ?? members.GetValueOrDefault("@renderMaterial"))
+      as RenderMaterial;
+  }
 
   private static IEnumerable<Base> GetBaseList(Base b, string key)
   {

--- a/tests/Speckle.Sdk.Artifacts.Harness/packages.lock.json
+++ b/tests/Speckle.Sdk.Artifacts.Harness/packages.lock.json
@@ -24,11 +24,6 @@
         "resolved": "0.9.6",
         "contentHash": "HKH7tYrYYlCK1ct483hgxERAdVdMtl7gUKW9ijWXxA1UsYR4Z+TrRHYmzZ9qmpu1NnTycSrp005NYM78GDKV1w=="
       },
-      "DuckDB.NET.Bindings.Full": {
-        "type": "Transitive",
-        "resolved": "1.5.3",
-        "contentHash": "3vkxzLkCmPUTRtEBBYrXvl9jOTXJ42uYswsokpysTulOS963ZIcMJRKpcHH2zwa63YI4YchjYvPz0pcR2Helbg=="
-      },
       "GraphQL.Client.Abstractions": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -168,7 +163,6 @@
       "speckle.sdk": {
         "type": "Project",
         "dependencies": {
-          "DuckDB.NET.Data.Full": "[1.5.3, )",
           "GraphQL.Client": "[6.0.0, )",
           "Microsoft.Data.Sqlite": "[7.0.5, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
@@ -181,15 +175,6 @@
       },
       "speckle.sdk.dependencies": {
         "type": "Project"
-      },
-      "DuckDB.NET.Data.Full": {
-        "type": "CentralTransitive",
-        "requested": "[1.5.3, )",
-        "resolved": "1.5.3",
-        "contentHash": "B0E3JH6nM9CeYLzmOIGGTz7R5vAKf10516Jiz7VnWj4kV7uMoh8m5mTB6IxTGFJMG6i6aOANwjwP7ud7kA87+Q==",
-        "dependencies": {
-          "DuckDB.NET.Bindings.Full": "1.5.3"
-        }
       },
       "GraphQL.Client": {
         "type": "CentralTransitive",

--- a/tests/Speckle.Sdk.Artifacts.Harness/packages.lock.json
+++ b/tests/Speckle.Sdk.Artifacts.Harness/packages.lock.json
@@ -165,8 +165,8 @@
         "dependencies": {
           "GraphQL.Client": "[6.0.0, )",
           "Microsoft.Data.Sqlite": "[7.0.5, )",
-          "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
           "Microsoft.Extensions.Logging": "[8.0.0, )",
+          "Microsoft.Extensions.ObjectPool": "[8.0.0, )",
           "Parquet.Net": "[5.3.0, )",
           "Speckle.DoubleNumerics": "[4.1.0, )",
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
@@ -216,6 +216,12 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
           "Microsoft.Extensions.Options": "8.0.0"
         }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "8.0.0",
+        "contentHash": "4pm+XgxSukskwjzDDfSjG4KNUIOdFF2VaqZZDtTzoyQMOVSnlV6ZM8a9aVu5dg9LVZTB//utzSc8fOi0b0Mb2Q=="
       },
       "Parquet.Net": {
         "type": "CentralTransitive",


### PR DESCRIPTION
cc @oguzhankoral

## What

Old-style sends (pre-proxy Revit v2 connector) attach materials inline as a `renderMaterial` member on each display mesh (sometimes on the parent element) instead of publishing root-level `renderMaterialProxies`. The producer only read the root proxies, so those graphs silently derived `MATERIAL=0` — everything rendered materialless.

This adds a fallback tier in `GraphArtifactProducer`:

- during the object walk, collect each display mesh's embedded `RenderMaterial` (the mesh's own wins over the parent element's);
- after proxy binding, fold the embedded materials into the material bindings — a root-proxy claim always wins;
- bindings dedupe by material identity, so N meshes sharing "Concrete - Cast In Situ" mint one MATERIAL node;
- an embedded black diffuse is kept as-is (it's an explicit assignment like "Black Glass", not the CAD no-material placeholder — that heuristic only applies to the proxy tier).

## Validation

Ran on a real old-style Revit 2022 send (alex-tests `ea3522f732`, version `7e3f978dc8`): 80 MATERIAL nodes / 403 HAS_MATERIAL edges (out of 422 display meshes; matches the raw closure exactly), zero dangling refs — previously 0/0. Migrated end-to-end to next.speckle.dev and confirmed materials render in the viewer, including glass opacities.

## Note

The `Speckle.Sdk.Artifacts.Harness` project is **not in the solution file** — so far we've only used it from the command line (`dotnet build` on the csproj directly; see its README for the migration recipes).