### PR TITLE
fix(artifacts): emit structural_results.parquet, not structural-results

### DIFF
--- a/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
@@ -426,7 +426,7 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   // ── structural results ─────────────────────────────────────────────────────────────────
 
   /// <summary>
-  /// Appends one structural analysis/design result value to <c>{base}.eav.structural-results.parquet</c>
+  /// Appends one structural analysis/design result value to <c>{base}.eav.structural_results.parquet</c>
   /// (see <see cref="StructuralResultsWriter"/>). <b>Object-level</b> results pass the member/joint's
   /// <paramref name="objectApplicationId"/> (resolved to the SAME dense K the object was interned with, so
   /// results join back to it) and leave <paramref name="location"/> null; <b>model-level</b> results (story

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/StructuralResultsWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/StructuralResultsWriter.cs
@@ -5,7 +5,7 @@ namespace Speckle.Sdk.Pipelines.Send.Artifacts;
 /// <summary>
 /// Speckle 4.0 structural-analysis results writer — direct Zstd Parquet, one table:
 /// <code>
-///   {base}.eav.structural-results.parquet(
+///   {base}.eav.structural_results.parquet(
 ///       object_index, location, result_type, load_case, component, station, step, value, value_text)
 /// </code>
 /// A per-DOMAIN (not per-connector) long/fact table for structural analysis + design results, shared by
@@ -20,8 +20,9 @@ namespace Speckle.Sdk.Pipelines.Send.Artifacts;
 /// The axes (<c>load_case</c> / <c>station</c> / <c>step</c> / <c>component</c>) are typed columns, NOT baked
 /// into a property path — so the eav path dictionary stays tiny and results stay queryable/range-able.
 /// <c>value</c> holds numeric results; <c>value_text</c> holds non-numeric design verdicts (e.g. PASS/FAIL).
-/// Other domains (environmental, thermal, …) get their own <c>{base}.eav.{domain}-results.parquet</c> when
-/// they arrive. Not thread-safe: calls are sequential.
+/// Other domains (environmental, thermal, …) get their own <c>{base}.eav.{domain}_results.parquet</c> when
+/// they arrive. The file name is snake_case to match its logical table name (<c>structural_results</c> in
+/// <c>bundle_files</c>) — kebab-case breaks DuckDB view-name lookups. Not thread-safe: calls are sequential.
 /// </summary>
 public sealed class StructuralResultsWriter : IDisposable
 {
@@ -38,7 +39,7 @@ public sealed class StructuralResultsWriter : IDisposable
     BaseName = baseName;
 
     _results = new ParquetTableWriter(
-      System.IO.Path.Combine(outputDir, $"{baseName}.eav.structural-results.parquet"),
+      System.IO.Path.Combine(outputDir, $"{baseName}.eav.structural_results.parquet"),
       new ParquetSchema(
         new DataField<int?>("object_index"),
         S("location"),

--- a/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
@@ -67,7 +67,7 @@ public sealed class EnvelopeWriterTests : IDisposable
     Scalar(db, $"SELECT elevation FROM nodes WHERE kind = {NodeKind.Level}").Should().Be(3000.0);
 
     // self-describing catalog (SOT §6) — sourced from speckle-bundle-spec (v5: live + reserved rows).
-    Scalar(db, "SELECT count(*) FROM rel_types").Should().Be(16L); // 15 live + SOLID (reserved); retired ids absent
+    Scalar(db, "SELECT count(*) FROM rel_types").Should().Be(17L); // 16 live + SOLID (reserved); retired ids absent
     Scalar(db, "SELECT count(*) FROM node_kinds").Should().Be(6L); // COLLECTION folded into CONTAINER
     Scalar(db, $"SELECT name FROM rel_types WHERE rel = {RelKind.DisplayInstance}").Should().Be("DISPLAY_INSTANCE");
     Scalar(db, $"SELECT name FROM rel_types WHERE rel = {RelKind.DefinesInstance}").Should().Be("DEFINES_INSTANCE");
@@ -89,8 +89,11 @@ public sealed class EnvelopeWriterTests : IDisposable
     // IN_GROUP (17) un-retired post-v5: authored scene groups (Rhino/AutoCAD) → CONTAINER(Group).
     Scalar(db, $"SELECT name FROM rel_types WHERE rel = {RelKind.InGroup}").Should().Be("IN_GROUP");
     Scalar(db, $"SELECT dst_ns FROM rel_types WHERE rel = {RelKind.InGroup}").Should().Be("node");
-    // retired ids (IN_NETWORK 15, IN_SPACE 13, HOSTED_ON 22, …) are absent from the catalog.
-    Scalar(db, "SELECT count(*) FROM rel_types WHERE rel IN (13, 15, 16, 18, 19, 20, 22)").Should().Be(0L);
+    // HOSTED_ON (22) un-retired post-v5: Revit hosting (door/window → wall), object→object (ENG-8867).
+    Scalar(db, "SELECT name FROM rel_types WHERE rel = 22").Should().Be("HOSTED_ON");
+    Scalar(db, "SELECT dst_ns FROM rel_types WHERE rel = 22").Should().Be("object");
+    // retired ids (IN_NETWORK 15, IN_SPACE 13, …) are absent from the catalog.
+    Scalar(db, "SELECT count(*) FROM rel_types WHERE rel IN (13, 15, 16, 18, 19, 20)").Should().Be(0L);
     Scalar(db, "SELECT schema_version FROM meta").Should().Be(5);
 
     // No scene views / camera views authored ⇒ the tables are absent (consumer feature-detects by file presence).


### PR DESCRIPTION


The file name now matches its logical table name in bundle_files (snake_case) — kebab-case breaks DuckDB view-name lookups. Pairs with the same rename on the bundle-spec structural-results-purpose-file branch (rebased onto main, bundle_files ord 15 after camera_views).

Also syncs the EnvelopeWriterTests catalog assertions with spec main: HOSTED_ON (22) is live now (ENG-8867) -> 17 rel_types rows, 22 removed from the retired-absent set.