### PR TITLE
Record applied reference-point offset in bundle meta (ENG-8947)

### DIFF
--- a/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
@@ -474,6 +474,14 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   /// <see cref="CameraView.Fov"/> vertical DEGREES (perspective only). Add none and the table is absent.</summary>
   public void AddCameraView(CameraView view) => _envelopeWriter.AddCameraView(view);
 
+  // ── reference point (ENG-8947) ─────────────────────────────────────────────────────────
+
+  /// <summary>Records the applied reference-point re-basing in the bundle <c>meta</c> so it is recoverable
+  /// downstream (federation/georeferencing). <paramref name="kind"/> ∈ <c>projectBasePoint | surveyPoint |
+  /// internalOriginFallback</c> (null = internal origin); <paramref name="offset"/> is <c>"x,y,z"</c> in display
+  /// units — the vector subtracted from world-space output. Call before <see cref="Complete"/>.</summary>
+  public void SetReferencePoint(string? kind, string? offset) => _envelopeWriter.SetReferencePoint(kind, offset);
+
   /// <summary>REMOVED — the <c>proxies(type, data JSON)</c> envelope is gone; use the typed
   /// node/relation API (<see cref="AddDefinition"/>, <see cref="AddMaterial"/>, <see cref="Display"/>, …).
   /// Kept (non-<c>[Obsolete]</c>, to avoid breaking the warnings-as-errors build of the parked Navis

--- a/src/Speckle.Objects/Utils/ObjectsArtifactReader.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactReader.cs
@@ -33,6 +33,12 @@ public sealed class ObjectsArtifactReader
   private const string RenderMaterialProxiesKey = "renderMaterialProxies";
   private const string InstanceDefinitionProxiesKey = "instanceDefinitionProxies";
 
+  // ENG-8947: the v1 (net48) reconstruction path rebuilds the reference-point transform from the bundle meta offset
+  // and lifts it onto the reconstructed root as the metadata dict Speckle.Connectors...RevitShared.RevitHostObjectBuilder
+  // expects (a FEET matrix), so its untouched reference-point composition just works. MUST match
+  // Speckle.Connectors.Common.Operations.RootKeys.REFERENCE_POINT_TRANSFORM; hardcoded here (like the proxy keys).
+  private const string ReferencePointTransformKey = "referencePointTransform";
+
   public async Task<Base> ReadAsync(
     string bundleDir,
     ArtifactReceiveOptions options,
@@ -95,8 +101,60 @@ public sealed class ObjectsArtifactReader
     // ── instance definitions (DEFINITION nodes + DEFINES/DEFINES_INSTANCE) ────────────────────────────
     AttachInstanceDefinitions(nodes, rels, objByGeom, bundle.ObjectAppIds, root);
 
+    // ENG-8947/8808: rebuild the reference-point transform from the bundle meta offset and lift it onto the root so
+    // the v1 Revit host builder can undo/redo it (translation kinds only; the offset is in display units).
+    if (BuildReferencePointRootValue(bundle) is { } refPointRootValue)
+    {
+      root[ReferencePointTransformKey] = refPointRootValue;
+    }
+
     root["units"] = bundle.Units;
     return root;
+  }
+
+  // ENG-8947: rebuild the v1 root reference-point transform from the meta offset. Only the translation kinds carry an
+  // offset; the display-unit offset is converted to feet (the internal unit v1 applies the transform in) and packed as
+  // the 16-value matrix (identity basis + translation) ReferencePointHelper.GetTransformFromRootObject expects.
+  private static Dictionary<string, object>? BuildReferencePointRootValue(ArtefactBundle bundle)
+  {
+    if (bundle.ReferencePointOffset is not { Length: > 0 } offsetCsv)
+    {
+      return null;
+    }
+    var parts = offsetCsv.Split(',');
+    if (parts.Length != 3)
+    {
+      return null;
+    }
+    var o = new double[3];
+    for (int i = 0; i < 3; i++)
+    {
+      if (!double.TryParse(parts[i], NumberStyles.Float, CultureInfo.InvariantCulture, out o[i]))
+      {
+        return null;
+      }
+    }
+    double toFeet = Units.GetConversionFactor(bundle.Units, Units.Feet);
+    var m = new double[]
+    {
+      1,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+      o[0] * toFeet,
+      o[1] * toFeet,
+      o[2] * toFeet,
+      1,
+    };
+    return new Dictionary<string, object> { ["transform"] = m };
   }
 
   // ── collections (layers) ──────────────────────────────────────────────────────────────────────────────

--- a/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
@@ -158,6 +158,13 @@ public sealed class ArtefactBundle
   public required ArtefactRelations Relations { get; init; }
   public required string Units { get; init; }
 
+  /// <summary>ENG-8947 reference-point provision from the bundle <c>meta</c> (null = internal origin / absent).
+  /// <see cref="ReferencePointKind"/> ∈ <c>projectBasePoint | surveyPoint | internalOriginFallback</c>;
+  /// <see cref="ReferencePointOffset"/> is <c>"x,y,z"</c> in <see cref="Units"/> — the vector subtracted from
+  /// world-space output (null for the fallback / non-translation kinds).</summary>
+  public string? ReferencePointKind { get; init; }
+  public string? ReferencePointOffset { get; init; }
+
   /// <summary>The default scene view's grouping tiers (outermost→innermost), or empty if the bundle has none. Drives
   /// the received layer hierarchy (e.g. Revit: Model → Level → Category → Family).</summary>
   public required IReadOnlyList<SceneViewTier> DefaultSceneView { get; init; }
@@ -183,10 +190,12 @@ public static class ArtefactBundleReader
       .ConfigureAwait(false);
     var cameraViewsT = await TryReadTableAsync(bundleDir, ".envelope.camera_views.parquet", cancellationToken)
       .ConfigureAwait(false);
+    var metaT = await TryReadTableAsync(bundleDir, ".envelope.meta.parquet", cancellationToken).ConfigureAwait(false);
 
     var objIdToApp = BuildObjectIds(objectsT);
     var pathById = BuildPaths(pathsT);
     var propsByObject = BuildProperties(eavT, pathById);
+    var (refPointKind, refPointOffset) = LoadReferencePoint(metaT);
 
     return new ArtefactBundle
     {
@@ -198,7 +207,24 @@ public static class ArtefactBundleReader
       Units = InferUnits(propsByObject),
       DefaultSceneView = LoadDefaultSceneView(sceneViewsT),
       CameraViews = LoadCameraViews(cameraViewsT),
+      ReferencePointKind = refPointKind,
+      ReferencePointOffset = refPointOffset,
     };
+  }
+
+  // ENG-8947: the reference-point provision from meta (single row). Columns are nullable + additive — older
+  // bundles without them yield (null, null), i.e. internal origin.
+  private static (string? kind, string? offset) LoadReferencePoint(ParquetTable? t)
+  {
+    if (t is null || !t.Has("reference_point_kind"))
+    {
+      return (null, null);
+    }
+    var kinds = t.Strings("reference_point_kind");
+    var offsets = t.Has("reference_point_offset") ? t.Strings("reference_point_offset") : null;
+    var kind = kinds.Length > 0 ? kinds[0] : null;
+    var offset = offsets is { Length: > 0 } ? offsets[0] : null;
+    return (kind, offset);
   }
 
   // object→node relations (per envelope rel_types) whose target node can form a scene-view grouping tier.

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
@@ -97,6 +97,12 @@ public sealed class EnvelopeWriter : IDisposable
   private readonly List<CameraView> _cameraViews = new();
   private bool _completed;
 
+  // ENG-8947: reference-point provision recorded in meta when a producer re-based geometry by a source
+  // reference point. kind ∈ projectBasePoint | surveyPoint | internalOriginFallback; offset "x,y,z" in
+  // display units (the vector subtracted). Both null = internal origin (no re-basing). See SetReferencePoint.
+  private string? _referencePointKind;
+  private string? _referencePointOffset;
+
   public EnvelopeWriter(string outputDir, string baseName, ParquetWriteScheduler scheduler)
   {
     Directory.CreateDirectory(outputDir);
@@ -169,6 +175,18 @@ public sealed class EnvelopeWriter : IDisposable
     _cameraViews.Add(view);
   }
 
+  /// <summary>
+  /// ENG-8947: records the applied reference-point re-basing in <c>meta</c> (written at <see cref="Complete"/>).
+  /// <paramref name="kind"/> ∈ <c>projectBasePoint | surveyPoint | internalOriginFallback</c> (null = internal
+  /// origin); <paramref name="offset"/> is <c>"x,y,z"</c> in display units — the vector subtracted from world-space
+  /// output (null when not a translation re-basing). Call before <see cref="Complete"/>.
+  /// </summary>
+  public void SetReferencePoint(string? kind, string? offset)
+  {
+    _referencePointKind = kind;
+    _referencePointOffset = offset;
+  }
+
   /// <summary>Flushes the parquet tables and writes the attach manifest.</summary>
   public void Complete()
   {
@@ -179,6 +197,7 @@ public sealed class EnvelopeWriter : IDisposable
     _completed = true;
     _relations.Complete();
     _nodes.Complete();
+    WriteMeta();
     WriteSceneViews();
     WriteCameraViews();
   }
@@ -194,20 +213,23 @@ public sealed class EnvelopeWriter : IDisposable
     SafeDispose(_nodes);
   }
 
-  // Self-describing catalog (SOT §6): the rel/kind vocabulary + schema version, written once from the
+  // meta (SOT §6): schema version + producer + the ENG-8947 reference-point provision. Written at Complete()
+  // (not eagerly in the ctor) so producers can record an applied reference-point re-basing via SetReferencePoint
+  // first. reference_point_kind/_offset are null unless set → NULL columns (readers that ignore them are unaffected).
+  private void WriteMeta()
+  {
+    using var meta = new ParquetTableWriter(
+      P("meta.parquet"),
+      new ParquetSchema(I("schema_version"), S("produced_by"), S("reference_point_kind"), S("reference_point_offset")),
+      _scheduler
+    );
+    meta.AddRow(SpecBundle.SchemaVersion, "Speckle.Sdk EnvelopeWriter", _referencePointKind, _referencePointOffset);
+  }
+
+  // Self-describing catalog (SOT §6): the rel/kind vocabulary, written once from the
   // generated spec catalog (live + reserved rows; retired ids are absent and never reused). Tiny.
   private void WriteCatalog()
   {
-    using (
-      var meta = new ParquetTableWriter(
-        P("meta.parquet"),
-        new ParquetSchema(I("schema_version"), S("produced_by")),
-        _scheduler
-      )
-    )
-    {
-      meta.AddRow(SpecBundle.SchemaVersion, "Speckle.Sdk EnvelopeWriter");
-    }
     using (
       var rt = new ParquetTableWriter(
         P("rel_types.parquet"),


### PR DESCRIPTION
## What

Adds the **ENG-8947** reference-point provision to the artefact bundle `meta`, so a model whose geometry was re-based by a source reference point is recoverable downstream (federation / georeferencing) and reversible on receive.

`meta` gains two nullable columns (matching specklesystems/speckle-bundle-spec#8):

- `reference_point_kind` — `projectBasePoint | surveyPoint | internalOriginFallback` (NULL = internal origin)
- `reference_point_offset` — `"x,y,z"` in the bundle's **display units** (the vector subtracted from world-space output)

Additive + nullable — readers that ignore the columns are unaffected; `schema_version` stays 5.

## Changes

- **`EnvelopeWriter`** — meta schema gains the two columns + `SetReferencePoint(kind, offset)`. The meta row now writes at `Complete()` (so a producer can set it during the send) instead of eagerly in the constructor.
- **`ObjectsArtifactPipeline`** — `SetReferencePoint` pass-through.
- **`ArtefactBundle` / `ArtefactBundleReader`** — reads the `meta` table → `ReferencePointKind` / `ReferencePointOffset`.
- **`ObjectsArtifactReader`** (v1 / net48 reconstruction path) — rebuilds the reference-point transform from the meta offset (display → feet via `Units.GetConversionFactor`) and lifts it onto the reconstructed root, so the existing v1 Revit host builder composes it **unchanged**.

## Companion PR

Producer + consumer wiring and the Revit round-trip live in the connectors repo (ENG-8808): specklesystems/speckle-sharp-connectors#1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
