### PR TITLE
feat(artifacts): HostedOn facade const + pipeline emit method (ENG-8693)

### DIFF
--- a/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
@@ -418,6 +418,13 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   public void ConnectsTo(int sourceObjectK, int targetObjectK, int scope) =>
     _envelopeWriter.AddRelation(RelKind.ConnectsTo, sourceObjectK, targetObjectK, scope);
 
+  /// <summary>object → object: hosted element → its HOST (door/window → wall, fixture → ceiling/floor/face).
+  /// A DIFFERENT semantic from <see cref="Subelement"/> ownership: a hosted element is PLACED ON its host, not
+  /// a component of it. Precedence matches the producers: a valid owner wins (SUBELEMENT), hosting is the
+  /// fallback. Emit only when BOTH endpoints are sent objects (no dangling edges). Un-retired post-v5 (ENG-8867).</summary>
+  public void HostedOn(int hostedObjectK, int hostObjectK) =>
+    _envelopeWriter.AddRelation(RelKind.HostedOn, hostedObjectK, hostObjectK, 0);
+
   /// <summary>object → object: a room-bounding element → the ROOM object it bounds (which walls/separators form a
   /// room's footprint, for egress / plan analysis). Both are interned objects.</summary>
   public void Bounds(int boundingObjectK, int roomObjectK, int ord) =>

--- a/src/Speckle.Sdk.Parquet/Pipelines/Nodes.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Nodes.cs
@@ -26,6 +26,7 @@ public static class RelKind
   public const byte InSystem = (byte)SpecRel.IN_SYSTEM;
   public const byte InGroup = (byte)SpecRel.IN_GROUP;
   public const byte ConnectsTo = (byte)SpecRel.CONNECTS_TO;
+  public const byte HostedOn = (byte)SpecRel.HOSTED_ON;
   public const byte Bounds = (byte)SpecRel.BOUNDS;
 }
 


### PR DESCRIPTION
HOSTED_ON (22) went live in the spec (ENG-8867, rvextract emits it) but the managed facade had no `RelKind` const or `ObjectsArtifactPipeline` method, so managed connectors couldn't emit hosting edges. Mirrors ConnectsTo/Bounds: object ? object, ord 0, hosted element ? host, emit only when both endpoints are sent objects.

The catalog-test sync for the new live row already landed via #510.

?? Generated with [Claude Code](https://claude.com/claude-code)