### PR TITLE
feat(artifacts): tag the HAS_COLOR source namespace via ord (ENG-8822)

### DIFF
--- a/src/Speckle.Automate.Sdk/packages.lock.json
+++ b/src/Speckle.Automate.Sdk/packages.lock.json
@@ -218,16 +218,6 @@
           "System.Threading.Tasks.Extensions": "4.6.3"
         }
       },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.6.3",
-        "contentHash": "qdcDOgnFZY40+Q9876JUHnlHu7bosOHX8XISRoH94fwk6hgaeQGSgfZd8srWRZNt5bV9ZW2TljcegDNxsf+96A==",
-        "dependencies": {
-          "System.Buffers": "4.6.1",
-          "System.Numerics.Vectors": "4.6.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
-        }
-      },
       "System.Numerics.Vectors": {
         "type": "Transitive",
         "resolved": "4.6.1",
@@ -273,7 +263,8 @@
       "speckle.objects": {
         "type": "Project",
         "dependencies": {
-          "Speckle.Sdk": "[1.0.0, )"
+          "Speckle.Sdk": "[1.0.0, )",
+          "System.Memory": "[4.5.5, )"
         }
       },
       "speckle.sdk": {
@@ -289,6 +280,7 @@
           "Speckle.Newtonsoft.Json": "[13.0.2, )",
           "Speckle.Sdk.Dependencies": "[1.0.0, )",
           "Speckle.Sdk.Parquet": "[1.0.0, )",
+          "System.Memory": "[4.5.5, )",
           "System.Text.Json": "[5.0.2, )"
         }
       },
@@ -375,6 +367,17 @@
         "requested": "[13.0.2, )",
         "resolved": "13.0.2",
         "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
+      },
+      "System.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[4.5.5, )",
+        "resolved": "4.6.3",
+        "contentHash": "qdcDOgnFZY40+Q9876JUHnlHu7bosOHX8XISRoH94fwk6hgaeQGSgfZd8srWRZNt5bV9ZW2TljcegDNxsf+96A==",
+        "dependencies": {
+          "System.Buffers": "4.6.1",
+          "System.Numerics.Vectors": "4.6.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
+        }
       }
     },
     "net10.0": {

--- a/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
@@ -379,8 +379,13 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   public void HasMaterial(int geometryK, int materialK) =>
     _envelopeWriter.AddRelation(RelKind.HasMaterial, geometryK, materialK, 0);
 
-  /// <summary>geometry | object → node(COLOR): display colour.</summary>
-  public void HasColor(int srcK, int colorK) => _envelopeWriter.AddRelation(RelKind.HasColor, srcK, colorK, 0);
+  /// <summary>geometry | object → node(COLOR): display colour. The two source namespaces overlap numerically
+  /// (both are dense int spaces from 0), so <paramref name="srcIsObject"/> tags which one <paramref name="srcK"/>
+  /// belongs to in the edge's <c>ord</c> column: 0 = geometry (the default, and what every pre-tag bundle wrote),
+  /// 1 = object. Without the tag a consumer cannot tell an object-sourced instance colour from a geometry-sourced
+  /// one and must guess — dropping colours or applying them to the wrong element [ENG-8822].</summary>
+  public void HasColor(int srcK, int colorK, bool srcIsObject = false) =>
+    _envelopeWriter.AddRelation(RelKind.HasColor, srcK, colorK, srcIsObject ? 1 : 0);
 
   /// <summary>object → node(LEVEL): level membership.</summary>
   public void OnLevel(int objectK, int levelK) => _envelopeWriter.AddRelation(RelKind.OnLevel, objectK, levelK, 0);

--- a/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
@@ -97,9 +97,16 @@ public sealed class ArtefactRelations
   public Dictionary<int, Dictionary<int, int>> ObjectNodeByRel { get; } = new();
   public Dictionary<int, int> MaterialByGeometry { get; } = new();
 
-  /// <summary>HAS_COLOR: geometry → COLOR node. The object's by-object display colour (distinct from a render material);
-  /// resolved back to the owning object via <see cref="ObjectByGeometry"/>, mirroring <see cref="MaterialByGeometry"/>.</summary>
+  /// <summary>HAS_COLOR (<c>ord</c>=0): geometry → COLOR node. The object's by-object display colour (distinct from a
+  /// render material); resolved back to the owning object via <see cref="ObjectByGeometry"/>, mirroring
+  /// <see cref="MaterialByGeometry"/>.</summary>
   public Dictionary<int, int> ColorByGeometry { get; } = new();
+
+  /// <summary>HAS_COLOR (<c>ord</c>=1): OBJECT → COLOR node — a colour carried by an object that owns no geometry of
+  /// its own, i.e. a block/instance placement whose members render through its definition. Kept separate from
+  /// <see cref="ColorByGeometry"/> because the two source namespaces overlap numerically; the edge's <c>ord</c> is
+  /// the namespace tag (pre-tag bundles wrote 0, so they all land in ColorByGeometry as before) [ENG-8822].</summary>
+  public Dictionary<int, int> ColorByObject { get; } = new();
   public Dictionary<int, List<int>> DefinesByDefinition { get; } = new();
 
   /// <summary>DEFINES ordinals, index-aligned with <see cref="DefinesByDefinition"/>. The ordinal is the member index
@@ -511,7 +518,15 @@ public static class ArtefactBundleReader
           sets.MaterialByGeometry[src[i]] = dst[i];
           break;
         case RelKind.HasColor:
-          sets.ColorByGeometry[src[i]] = dst[i];
+          // ord tags the src namespace: 1 = object (instance placement), 0/absent = geometry [ENG-8822].
+          if (ord[i] == 1)
+          {
+            sets.ColorByObject[src[i]] = dst[i];
+          }
+          else
+          {
+            sets.ColorByGeometry[src[i]] = dst[i];
+          }
           break;
         case RelKind.Defines:
           sets.Add(sets.DefinesByDefinition, src[i], dst[i]);


### PR DESCRIPTION
HAS_COLOR's `src` is `geometry|object` per the spec, but the two dense K-spaces overlap numerically — a consumer reading an edge cannot tell an object-sourced instance colour from a geometry-sourced one, so it either drops instance colours (what AutoCAD receive did) or paints an unrelated mesh.

Tag the namespace in the edge's `ord` column: **0 = geometry** (what every pre-tag bundle wrote), **1 = object**. `HasColor` gains an optional `srcIsObject` flag; the reader splits `ColorByObject` out of `ColorByGeometry`.

Fully backward compatible — old bundles read exactly as before. Consumed by the AutoCAD receive fix in speckle-sharp-connectors (ENG-8822).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/specklesystems/codesmith/speckle-sharp-sdk/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787439359&installation_model_id=3962&pr_number=514&repository=specklesystems%2Fspeckle-sharp-sdk&return_to=https%3A%2F%2Fgithub.com%2Fspecklesystems%2Fspeckle-sharp-sdk%2Fpull%2F514&signature=a245d0cf376df36b0292b97bfe1c6d1ebadde869eb1d7528dd76dce4ac56d709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->