### PR TITLE
feat(harness): read v3 group proxies, and v2 `displayStyle` colours

### DIFF
--- a/src/Speckle.Sdk.Artifacts.Harness/Migration/ArtifactHelper.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Migration/ArtifactHelper.cs
@@ -8,6 +8,7 @@ using Speckle.Objects.Other;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
 using Speckle.Sdk.Models.Instances;
+using Speckle.Sdk.Models.Proxies;
 
 namespace Speckle.Sdk.Artifacts.Harness.Migration;
 
@@ -57,6 +58,8 @@ internal sealed class ArtifactHelper
     rmp.applicationId ?? rmp.value.applicationId ?? "mat:" + rmp.value.diffuse.ToString(CultureInfo.InvariantCulture);
 
   public string LevelKey(Base lvl, string? name) => lvl.applicationId ?? "lvl:" + (name ?? lvl.id);
+
+  public string GroupKey(GroupProxy gp) => gp.applicationId ?? "grp:" + gp.id;
 
   public string CollectionSubtype(Collection col)
   {

--- a/src/Speckle.Sdk.Artifacts.Harness/Migration/ArtifactHelper.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Migration/ArtifactHelper.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Diagnostics.Contracts;
 using System.Globalization;
 using Speckle.DoubleNumerics;
 using Speckle.Objects.Data;
@@ -118,12 +119,11 @@ internal sealed class ArtifactHelper
   public RenderMaterial? ReadEmbeddedMaterial(Base host) =>
     (host["renderMaterial"] ?? host["@renderMaterial"]) as RenderMaterial;
 
-  /// <summary>The level attached to a v2 buildElement. <c>level</c> was also used for unrelated data, so a
-  /// non-<see cref="Base"/> value reads as null and the caller skips it.</summary>
   public Base? ReadV2Level(Base host) => (host["level"] ?? host["@level"]) as Base;
 
-  /// <summary>Reads an untyped numeric member (level elevation, material ior). The deserializer only ever
-  /// yields double or long, so anything else — including null — means the value is absent or unusable.</summary>
+  public Base? ReadV2DisplayStyle(Base host) => (host["displayStyle"] ?? host["@displayStyle"]) as Base;
+
+  /// <summary>Reads a dynamic (untyped) JSON number from the given <paramref name="host"/></summary>
   public double? ReadDouble(Base host, string key) =>
     host[key] switch
     {
@@ -131,6 +131,19 @@ internal sealed class ArtifactHelper
       long l => l,
       _ => null,
     };
+
+  /// <summary>Reads a packed ARGB colour off an untyped member. The deserializer only yields integral JSON
+  /// as long, so anything else — including null — means no colour was authored.</summary>
+  public int? ReadArgb(Base host, string key)
+  {
+    // Accept both spellings of a 32-bit ARGB: the signed int form Color.ToArgb() produces, and the unsigned
+    // form a producer may have written instead. Anything outside that range is not a colour.
+    if (host[key] is not long l || l < int.MinValue || l > uint.MaxValue)
+    {
+      return null;
+    }
+    return unchecked((int)l); // the wrap reinterprets an unsigned ARGB as the signed int the bundle stores
+  }
 
   /// <summary>A detached list may sit under the typed key or the `@`-prefixed dynamic key; takes the first
   /// non-empty one.</summary>
@@ -168,24 +181,7 @@ internal sealed class ArtifactHelper
       _ => null,
     };
 
+  [Pure]
   public double[] Flatten(Matrix4x4 m) =>
-    new[]
-    {
-      m.M11,
-      m.M12,
-      m.M13,
-      m.M14,
-      m.M21,
-      m.M22,
-      m.M23,
-      m.M24,
-      m.M31,
-      m.M32,
-      m.M33,
-      m.M34,
-      m.M41,
-      m.M42,
-      m.M43,
-      m.M44,
-    };
+    [m.M11, m.M12, m.M13, m.M14, m.M21, m.M22, m.M23, m.M24, m.M31, m.M32, m.M33, m.M34, m.M41, m.M42, m.M43, m.M44];
 }

--- a/src/Speckle.Sdk.Artifacts.Harness/Migration/Stats.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Migration/Stats.cs
@@ -17,6 +17,8 @@ internal sealed class Stats
   public int OnLevelEdges;
   public int Collections;
   public int InCollectionEdges;
+  public int Groups;
+  public int InGroupEdges;
   public int DefinitionGeometries;
   public int DefinitionInstances;
   public int DefinesInstanceEdges;
@@ -35,15 +37,16 @@ internal sealed class Stats
   public int SkippedMaterial;
   public int SkippedColor;
   public int SkippedLevel;
-  public int SkippedDangling => SkippedDefines + SkippedMaterial + SkippedColor + SkippedLevel;
+  public int SkippedGroup;
+  public int SkippedDangling => SkippedDefines + SkippedMaterial + SkippedColor + SkippedLevel + SkippedGroup;
   public readonly List<string> Notes = new();
 
   public override string ToString() =>
     $"""
       objects={Objects} (meshAtomic={MeshAtomics} instAtomic={InstanceAtomics})  geometries={Geometries} (defGeom={DefinitionGeometries})
       edges: DISPLAY={DisplayEdges} DISPLAY_INSTANCE={DisplayInstanceEdges} SUBELEMENT={SubelementEdges} SOLID={Solids} (defSolid={DefinitionSolids})
-             DEFINES={DefinesEdges} DEFINES_INSTANCE={DefinesInstanceEdges} HAS_MATERIAL={HasMaterialEdges} HAS_COLOR={HasColorEdges} ON_LEVEL={OnLevelEdges} IN_COLLECTION={InCollectionEdges}
-      nodes: DEFINITION={Definitions} INSTANCE(def)={DefinitionInstances} MATERIAL={Materials} COLOR={Colors} LEVEL={Levels} COLLECTION={Collections} CAMERA_VIEW={CameraViews}
-      skipped (ref not in graph): {SkippedDangling}  (DEFINES={SkippedDefines} HAS_MATERIAL={SkippedMaterial} HAS_COLOR={SkippedColor} ON_LEVEL={SkippedLevel})
+             DEFINES={DefinesEdges} DEFINES_INSTANCE={DefinesInstanceEdges} HAS_MATERIAL={HasMaterialEdges} HAS_COLOR={HasColorEdges} ON_LEVEL={OnLevelEdges} IN_COLLECTION={InCollectionEdges} IN_GROUP={InGroupEdges}
+      nodes: DEFINITION={Definitions} INSTANCE(def)={DefinitionInstances} MATERIAL={Materials} COLOR={Colors} LEVEL={Levels} COLLECTION={Collections} GROUP={Groups} CAMERA_VIEW={CameraViews}
+      skipped (ref not in graph): {SkippedDangling}  (DEFINES={SkippedDefines} HAS_MATERIAL={SkippedMaterial} HAS_COLOR={SkippedColor} ON_LEVEL={SkippedLevel} IN_GROUP={SkippedGroup})
       """;
 }

--- a/src/Speckle.Sdk.Artifacts.Harness/Migration/V2GraphArtifactProducer.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Migration/V2GraphArtifactProducer.cs
@@ -39,6 +39,9 @@ internal sealed class V2GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
   // geometry appId → material embedded on the mesh. The only source of materials on a v2 graph.
   private readonly Dictionary<string, RenderMaterial> _embeddedMaterialByGeom = new(StringComparer.Ordinal);
 
+  // distinct argb seen — AddColor interns, so this only keeps _stats.Colors honest.
+  private readonly HashSet<int> _seenColorArgb = new();
+
   // synthetic collection K by cumulative property path ("Level 1/Walls") — dedup + parent-chain building.
   private readonly Dictionary<string, int> _v2CollByPath = new(StringComparer.Ordinal);
 
@@ -197,6 +200,7 @@ internal sealed class V2GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
           {
             _embeddedMaterialByGeom.TryAdd(gAppId, rm);
           }
+          EmitDisplayStyleColor(item, gAppId);
         }
       }
 
@@ -217,6 +221,7 @@ internal sealed class V2GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
         {
           _embeddedMaterialByGeom.TryAdd(appId, rm);
         }
+        EmitDisplayStyleColor(obj, appId);
       }
     }
 
@@ -322,6 +327,27 @@ internal sealed class V2GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
     );
     _stats.CameraViews++;
     return true;
+  }
+
+  // ── colours ─────────────────────────────────────────────────────────────────────────
+
+  // v2 attached a DisplayStyle to the geometry itself; its colour is the closest v4 equivalent (HAS_COLOR).
+  // linetype / lineweight / name have no v4 equivalent and are dropped. An absent colour emits nothing —
+  // the deleted class's LightGray field default cannot apply to the LegacyV2 the style now deserializes into.
+  private void EmitDisplayStyleColor(Base geometry, string geomAppId)
+  {
+    if (helper.ReadV2DisplayStyle(geometry) is not { } style || helper.ReadArgb(style, "color") is not { } argb)
+    {
+      return;
+    }
+
+    var colK = pipeline.AddColor(argb); // interned by argb, so repeats are free
+    if (_seenColorArgb.Add(argb))
+    {
+      _stats.Colors++;
+    }
+    pipeline.HasColor(pipeline.InternGeometryId(geomAppId), colK);
+    _stats.HasColorEdges++;
   }
 
   // ── materials ───────────────────────────────────────────────────────────────────────

--- a/src/Speckle.Sdk.Artifacts.Harness/Migration/V3GraphArtifactProducer.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Migration/V3GraphArtifactProducer.cs
@@ -526,6 +526,46 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
         _stats.OnLevelEdges++;
       }
     }
+
+    // v3 records no group nesting, so every group is top-level — an outer group already lists its inner
+    // groups' members.
+    foreach (var grp in helper.GetBaseList(root, "groupProxies"))
+    {
+      if (grp is not GroupProxy gp)
+      {
+        continue;
+      }
+
+      // Resolved up front so an all-dangling group leaves no edgeless CONTAINER behind.ons.
+      var members = new List<int>();
+      var seen = new HashSet<string>(StringComparer.Ordinal);
+      foreach (var objAppId in gp.objects)
+      {
+        if (!seen.Add(objAppId))
+        {
+          continue; // unpack can visit a block sub-object twice
+        }
+        if (!_seenObjectAppIds.Contains(objAppId))
+        {
+          _stats.SkippedGroup++;
+          continue;
+        }
+        members.Add(pipeline.InternObject(objAppId));
+      }
+
+      if (members.Count == 0)
+      {
+        continue;
+      }
+
+      var grpK = pipeline.AddContainer(helper.GroupKey(gp), gp.name, null, "Group");
+      _stats.Groups++;
+      foreach (var objK in members)
+      {
+        pipeline.InGroup(objK, grpK, 0);
+        _stats.InGroupEdges++;
+      }
+    }
   }
 
   // ── layer geometry resolution (ByLayer material/colour) ─────────────────────────────

--- a/src/Speckle.Sdk.Artifacts.Harness/Transports/AggregateTransport.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Transports/AggregateTransport.cs
@@ -28,7 +28,7 @@ internal sealed class AggregateTransport(
     set
     {
       _cancellationToken = value;
-      // Children read their own token, so storing it here alone would silently disable cancellation.
+      // Children read their own token; storing it here alone would silently disable cancellation.
       foreach (var t in readTransports.Concat(writeTransports).Distinct())
       {
         t.CancellationToken = value;

--- a/src/Speckle.Sdk.Artifacts.Harness/Transports/PackfileManager.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Transports/PackfileManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Data.Common;
 using System.Runtime.CompilerServices;
 using DuckDB.NET.Data;
@@ -90,7 +90,6 @@ internal sealed class PackFileManager(FileInfo file, ISdkActivityFactory activit
     using ISdkActivity? activity = activityFactory.Start();
     try
     {
-      //Default to false so every requested id gets an entry
       Dictionary<string, bool> results = new(objectIds.Count);
       foreach (string id in objectIds)
       {

--- a/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
@@ -123,6 +123,41 @@ public sealed class EnvelopeWriterTests : IDisposable
     File.Exists(Path.Combine(_dir, "model.envelope.camera_views.parquet")).Should().BeFalse();
   }
 
+  // Groups overlap (unlike single-valued IN_COLLECTION) and migrate flat — def_ref NULL is asserted so
+  // deriving a parent chain later has to be a deliberate change.
+  [Fact]
+  public void WritesGroupContainers_OverlappingMembership_RoundTrips()
+  {
+    using var scheduler = new ParquetWriteScheduler();
+    using (var w = new EnvelopeWriter(_dir, "model", scheduler))
+    {
+      w.AddNode(0, NodeKind.Container, "Group A", null, null, null, "Group", null, null, null, null, null, null, null);
+      // Unnamed Rhino group — a null name must not be back-filled.
+      w.AddNode(1, NodeKind.Container, null, null, null, null, "Group", null, null, null, null, null, null, null);
+
+      w.AddRelation(RelKind.InGroup, 100, 0, 0);
+      w.AddRelation(RelKind.InGroup, 101, 0, 0);
+      w.AddRelation(RelKind.InGroup, 101, 1, 0); // 101 is in both groups
+
+      w.Complete();
+    }
+    scheduler.CompleteAndWait();
+
+    using var db = new DuckDBConnection("Data Source=:memory:");
+    db.Open();
+    View(db, "relations");
+    View(db, "nodes");
+
+    Scalar(db, $"SELECT count(*) FROM nodes WHERE kind = {NodeKind.Container} AND subtype = 'Group'").Should().Be(2L);
+    Scalar(db, $"SELECT count(*) FROM nodes WHERE kind = {NodeKind.Container} AND def_ref IS NOT NULL").Should().Be(0L);
+    Scalar(db, "SELECT count(*) FROM nodes WHERE subtype = 'Group' AND name IS NULL").Should().Be(1L);
+
+    Scalar(db, $"SELECT count(*) FROM relations WHERE rel = {RelKind.InGroup}").Should().Be(3L);
+    Scalar(db, $"SELECT count(*) FROM relations WHERE rel = {RelKind.InGroup} AND src = 101").Should().Be(2L);
+    // ord carries nothing for IN_GROUP (rel_types.ord_semantics IS NULL)
+    Scalar(db, $"SELECT count(*) FROM relations WHERE rel = {RelKind.InGroup} AND ord <> 0").Should().Be(0L);
+  }
+
   [Fact]
   public void WritesCameraViews_RoundTrips()
   {


### PR DESCRIPTION
# v3 Groups (before and after)
<img width="1688" height="809" alt="image" src="https://github.com/user-attachments/assets/785c19ea-bb71-4f77-bdfb-7e779cbc77c7" />


# v2 displayStyles (before and after)
<img width="1658" height="635" alt="image" src="https://github.com/user-attachments/assets/e03aff4b-c37c-45d2-b4a0-19a878139030" />
