### PR TITLE
fix(ci): unbreak postgres startup in server integration tests

### DIFF
--- a/.github/workflows/integration-test-callable-from-server-repo.yml
+++ b/.github/workflows/integration-test-callable-from-server-repo.yml
@@ -48,6 +48,15 @@ jobs:
         env:
           SPECKLE_SERVER_IMAGE: ${{ env.SPECKLE_SERVER_IMAGE }}
 
+      # `up --wait` only reports that a container is unhealthy, never its output, so a
+      # dependency that dies on startup is otherwise undiagnosable from the run log.
+      - name: 🐛 Dump container state
+        if: failure()
+        run: |
+          docker compose --file "../${{ env.CLIENT_DIR }}/docker-compose-internal.yml" ps -a
+          docker compose --file "../${{ env.CLIENT_DIR }}/docker-compose-internal.yml" logs --no-color --tail=200
+        working-directory: ${{ env.SERVER_DIR }}
+
       - name: 📦 Restore .NET Solution
         run: dotnet restore ${{ env.SOLUTION }} --locked-mode
         working-directory: ${{ env.CLIENT_DIR }}

--- a/docker-compose-internal.yml
+++ b/docker-compose-internal.yml
@@ -13,8 +13,6 @@ services:
       POSTGRES_PASSWORD: speckle
     volumes:
       - ./.volumes/postgres-data:/var/lib/postgresql
-      - ./setup/db/10-docker_postgres_init.sql:/docker-entrypoint-initdb.d/10-docker_postgres_init.sql
-      - ./setup/db/11-docker_postgres_authentik_init.sql:/docker-entrypoint-initdb.d/11-docker_postgres_authentik_init.sql
     command: postgres -c max_prepared_transactions=150
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U speckle -d speckle"]


### PR DESCRIPTION
# fix(ci): unbreak postgres startup in server integration tests

## TL;DR

The `postgres` service in `docker-compose-internal.yml` bind-mounts two SQL init files that do not exist in this repo, which makes the container exit during initialisation and fails the integration test job before any test runs. This removes the bogus mounts and adds a failure-only container log dump so the next startup failure is diagnosable from the run log.

## Context

`docker-compose-internal.yml` brings up the server and its dependencies via `docker compose up --wait`, for both the `integration-test-internal` job in this repo's `pr.yml` and the reusable workflow the `speckle-server-internal` repo calls. Its `postgres` service declared bind mounts for `./setup/db/10-docker_postgres_init.sql` and `./setup/db/11-docker_postgres_authentik_init.sql` — paths carried over from the server repo's own compose file, but this repo has no `setup/` directory at all.

Docker creates missing bind sources as empty directories. The postgres entrypoint globs `/docker-entrypoint-initdb.d/*.sql`, runs `psql -f` against each match, and dies on `could not read from input file: Is a directory`, exiting 1. `restart: always` then restarts the container, and the second boot finds an already-initialised `PGDATA` and skips `initdb.d` entirely — so whether the job passes comes down to whether compose observes the exit before the restart lands. That race is why both jobs pass intermittently and otherwise fail as `dependency failed to start: container speckle-server-postgres-1 is unhealthy`.

Neither script is needed here, and the passing runs prove it: because the files have never existed in this repo, every green run to date was produced with them never executing once — no `wal_level = logical`, no `speckle2_test` database, no `authentik` database. That matches what the compose file wires up. The server gets a single `POSTGRES_URL` pointing at the `speckle` database, with no multi-region configuration and no authentik service, whereas `wal_level = logical` exists for the server's multi-region logical replication, `speckle2_test` is the database `packages/server`'s own test suite connects to, and `authentik` backs its SSO dev stack. Copying the files in would add two fixtures nothing in this stack reads, which would then silently drift from the server repo's copies.

## Summary

- Drop the two nonexistent `setup/db/*.sql` bind mounts from the `postgres` service — it now initialises and reports healthy on first boot instead of crash-restarting, removing the flake from both integration test workflows.
- Add an `if: failure()` step dumping `docker compose ps -a` and `logs --tail=200`, since `up --wait` reports only that a container is unhealthy and never its output, leaving startup failures invisible in the run log.
- The compose fix takes effect as soon as it is on `main` (the server repo's job checks this repo out at `ref: main`), but the workflow change does not: the caller in `speckle-server-internal` pins this reusable workflow by commit SHA and needs a pin bump on that side.
