### PR TITLE
fix(artifacts): fail fast on row/schema arity drift in ParquetTableWriter

### DIFF
--- a/.github/workflows/integration-test-callable-from-server-repo.yml
+++ b/.github/workflows/integration-test-callable-from-server-repo.yml
@@ -6,6 +6,12 @@ on:
       speckle-sharp-sdk-ref:
         required: true
         type: string
+    secrets:
+      # Token with Contents:Read on specklesystems/speckle-bundle-spec (private) — needed to check out
+      # the sibling spec repo Speckle.Sdk.Parquet compiles from. The server repo's CONNECTORS_GH_TOKEN
+      # (already scoped to speckle-bundle-spec) qualifies.
+      BUNDLE_SPEC_TOKEN:
+        required: true
 
 jobs:
   integration-test:
@@ -30,6 +36,19 @@ jobs:
         with:
           repository: ${{ env.SERVER_REPO }}
           path: ${{ env.SERVER_DIR }}
+
+      # Speckle.Sdk.Parquet compiles the spec's generated C# from a sibling speckle-bundle-spec checkout
+      # one level up from the SDK checkout — with the SDK at ./client that is the workspace root.
+      - name: Checkout speckle-bundle-spec
+        uses: actions/checkout@v7
+        with:
+          repository: specklesystems/speckle-bundle-spec
+          # Pin: speckle-bundle-spec main as of 2026-08-04 (merge of spec PR #12 — BundleCols.cs codegen).
+          # Keep aligned with the pin in pr.yml.
+          ref: ecbbd270fae06b00ee08e1b1022a08dd3f170c8f
+          token: ${{ secrets.BUNDLE_SPEC_TOKEN }}
+          path: speckle-bundle-spec
+          persist-credentials: false
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,6 +12,10 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: true
+      # Fine-grained PAT with Contents:Read on specklesystems/speckle-bundle-spec (private) —
+      # needed to check out the sibling spec repo Speckle.Sdk.Parquet compiles from.
+      BUNDLE_SPEC_TOKEN:
+        required: true
 jobs:
   integration-test:
     env:
@@ -20,6 +24,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      # Speckle.Sdk.Parquet compiles the spec's generated C# from a sibling speckle-bundle-spec
+      # checkout one level up ($(MSBuildThisFileDirectory)../../../speckle-bundle-spec).
+      - name: Checkout speckle-bundle-spec
+        uses: actions/checkout@v7
+        with:
+          repository: specklesystems/speckle-bundle-spec
+          # Pin: speckle-bundle-spec main as of 2026-08-04 (merge of spec PR #12 — BundleCols.cs codegen).
+          # Keep aligned with the pin in pr.yml.
+          ref: ecbbd270fae06b00ee08e1b1022a08dd3f170c8f
+          token: ${{ secrets.BUNDLE_SPEC_TOKEN }}
+          path: speckle-bundle-spec
+          persist-credentials: false
+
+      # actions/checkout cannot write outside $GITHUB_WORKSPACE; the csproj expects the spec one level up.
+      - name: Move speckle-bundle-spec to sibling location
+        run: mv speckle-bundle-spec "$GITHUB_WORKSPACE/../speckle-bundle-spec"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # Speckle.Sdk.Parquet compiles the spec's generated C# (BundleSpec.cs / BundleSchemas.cs / BundleCols.cs)
+      # from a sibling speckle-bundle-spec checkout one level up ($(MSBuildThisFileDirectory)../../../speckle-bundle-spec).
+      # BUNDLE_SPEC_TOKEN: fine-grained PAT with Contents:Read on specklesystems/speckle-bundle-spec —
+      # the default GITHUB_TOKEN cannot clone a second private repo.
+      - name: Checkout speckle-bundle-spec
+        uses: actions/checkout@v7
+        with:
+          repository: specklesystems/speckle-bundle-spec
+          # Pin: speckle-bundle-spec main as of 2026-08-04 (merge of spec PR #12 — BundleCols.cs codegen).
+          # Bump deliberately, together with SDK code that supports the new catalog.
+          ref: ecbbd270fae06b00ee08e1b1022a08dd3f170c8f
+          token: ${{ secrets.BUNDLE_SPEC_TOKEN }}
+          path: speckle-bundle-spec
+          persist-credentials: false
+
+      # actions/checkout cannot write outside $GITHUB_WORKSPACE, but the csproj expects the spec one
+      # level up from the SDK checkout — move it there (also keeps it out of `csharpier check .`).
+      - name: Move speckle-bundle-spec to sibling location
+        run: mv speckle-bundle-spec "$GITHUB_WORKSPACE/../speckle-bundle-spec"
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -54,12 +74,14 @@ jobs:
     with:
       docker-compose-file: "docker-compose-internal.yml"
       use-internal-image: true
-    secrets: 
+    secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      
+      BUNDLE_SPEC_TOKEN: ${{ secrets.BUNDLE_SPEC_TOKEN }}
+
   integration-test-public:
     uses: "./.github/workflows/integration-test.yml"
     with:
       docker-compose-file: "docker-compose.yml"
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      BUNDLE_SPEC_TOKEN: ${{ secrets.BUNDLE_SPEC_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # Speckle.Sdk.Parquet compiles the spec's generated C# from a sibling speckle-bundle-spec
+      # checkout one level up — build.sh pack builds the full solution, so release needs it too.
+      - name: Checkout speckle-bundle-spec
+        uses: actions/checkout@v7
+        with:
+          repository: specklesystems/speckle-bundle-spec
+          # Pin: speckle-bundle-spec main as of 2026-08-04 (merge of spec PR #12 — BundleCols.cs codegen).
+          # Keep aligned with the pin in pr.yml.
+          ref: ecbbd270fae06b00ee08e1b1022a08dd3f170c8f
+          token: ${{ secrets.BUNDLE_SPEC_TOKEN }}
+          path: speckle-bundle-spec
+          persist-credentials: false
+
+      # actions/checkout cannot write outside $GITHUB_WORKSPACE; the csproj expects the spec one level up.
+      - name: Move speckle-bundle-spec to sibling location
+        run: mv speckle-bundle-spec "$GITHUB_WORKSPACE/../speckle-bundle-spec"
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:

--- a/src/Speckle.Objects/Utils/ObjectsArtifactReader.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactReader.cs
@@ -365,7 +365,9 @@ public sealed class ObjectsArtifactReader
           id = "def-" + defNodeK,
           name = kv.Value.Name ?? ("Definition " + defNodeK),
           objects = members,
-          maxDepth = depthByDefNode.GetValueOrDefault(defNodeK, 0),
+          // TryGetValue rather than GetValueOrDefault: this project also targets netstandard2.0,
+          // which has no Dictionary.GetValueOrDefault.
+          maxDepth = depthByDefNode.TryGetValue(defNodeK, out int defDepth) ? defDepth : 0,
         }
       );
     }

--- a/src/Speckle.Sdk.Artifacts.Harness/RemoteSource.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/RemoteSource.cs
@@ -138,7 +138,12 @@ internal sealed class RemoteSource(IDeserializeProcessFactory deserializeProcess
       }
       else
       {
-        logger.LogInformation("Progress {ProgressEvent} {Count}/{Total}", value.ProgressEvent, value.Count, value.Total);
+        logger.LogInformation(
+          "Progress {ProgressEvent} {Count}/{Total}",
+          value.ProgressEvent,
+          value.Count,
+          value.Total
+        );
       }
     }
   }

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
@@ -1,9 +1,8 @@
 using System.Globalization;
 using Parquet.Schema;
-using SpecArrow = Speckle.Bundle.Spec.ArrowType;
 using SpecBundle = Speckle.Bundle.Spec.BundleSpec;
 using SpecCatalog = Speckle.Bundle.Spec.Catalog;
-using SpecColumn = Speckle.Bundle.Spec.ColumnSpec;
+using SpecCols = Speckle.Bundle.Spec.BundleCols;
 using SpecSchemas = Speckle.Bundle.Spec.BundleSchemas;
 
 namespace Speckle.Sdk.Pipelines.Send.Artifacts;
@@ -110,8 +109,16 @@ public sealed class EnvelopeWriter : IDisposable
     BaseName = baseName;
     _scheduler = scheduler;
 
-    _relations = new ParquetTableWriter(P("relations.parquet"), SchemaOf(SpecSchemas.Relations), scheduler);
-    _nodes = new ParquetTableWriter(P("nodes.parquet"), SchemaOf(SpecSchemas.Nodes), scheduler);
+    // Spec-schema'd tables carry their generated BundleCols ColumnCount so a spec bump that outruns
+    // this writer (or a stale sibling spec checkout) fails at construction / first AddRow — never by
+    // silently writing misaligned rows (the Jul 29 empty-nodes incident mode).
+    _relations = new ParquetTableWriter(
+      P("relations.parquet"),
+      SpecSchemas.Relations,
+      SpecCols.Relations.ColumnCount,
+      scheduler
+    );
+    _nodes = new ParquetTableWriter(P("nodes.parquet"), SpecSchemas.Nodes, SpecCols.Nodes.ColumnCount, scheduler);
 
     WriteCatalog();
   }
@@ -285,7 +292,12 @@ public sealed class EnvelopeWriter : IDisposable
     {
       return;
     }
-    using var cv = new ParquetTableWriter(P("camera_views.parquet"), SchemaOf(SpecSchemas.CameraViews), _scheduler);
+    using var cv = new ParquetTableWriter(
+      P("camera_views.parquet"),
+      SpecSchemas.CameraViews,
+      SpecCols.CameraViews.ColumnCount,
+      _scheduler
+    );
     foreach (var v in _cameraViews)
     {
       cv.AddRow(
@@ -326,30 +338,6 @@ public sealed class EnvelopeWriter : IDisposable
       throw new InvalidOperationException("Writer already completed.");
     }
   }
-
-  // Build a Parquet.Net schema from the generated spec column descriptors (the single source of truth
-  // for table shapes). DDL nullability → DataField<T> (required) vs DataField<T?> (nullable).
-  private static ParquetSchema SchemaOf(SpecColumn[] cols)
-  {
-    var fields = new Field[cols.Length];
-    for (var i = 0; i < cols.Length; i++)
-    {
-      fields[i] = ToField(cols[i]);
-    }
-    return new ParquetSchema(fields);
-  }
-
-  private static DataField ToField(SpecColumn c) =>
-    c.Type switch
-    {
-      SpecArrow.Int32 => c.Nullable ? new DataField<int?>(c.Name) : new DataField<int>(c.Name),
-      SpecArrow.Int64 => c.Nullable ? new DataField<long?>(c.Name) : new DataField<long>(c.Name),
-      SpecArrow.Float64 => c.Nullable ? new DataField<double?>(c.Name) : new DataField<double>(c.Name),
-      SpecArrow.Boolean => c.Nullable ? new DataField<bool?>(c.Name) : new DataField<bool>(c.Name),
-      SpecArrow.Utf8 => new DataField<string>(c.Name),
-      SpecArrow.Binary => new DataField<byte[]>(c.Name),
-      _ => throw new NotSupportedException($"Unmapped ArrowType {c.Type} for column {c.Name}"),
-    };
 
   private static DataField I(string name) => new DataField<int>(name);
 

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/ParquetTableWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/ParquetTableWriter.cs
@@ -1,6 +1,8 @@
 using Parquet;
 using Parquet.Data;
 using Parquet.Schema;
+using SpecArrow = Speckle.Bundle.Spec.ArrowType;
+using SpecColumn = Speckle.Bundle.Spec.ColumnSpec;
 
 namespace Speckle.Sdk.Pipelines.Send.Artifacts;
 
@@ -32,6 +34,22 @@ public sealed class ParquetTableWriter : IDisposable
   private readonly ParquetWriteScheduler _scheduler;
   private int _buffered;
   private bool _completed;
+
+  /// <summary>Creates a writer whose shape comes straight from the generated bundle-spec column descriptors
+  /// (e.g. <c>BundleSchemas.Nodes</c>) — the single source of truth for spec'd tables. Pass the matching
+  /// generated <c>BundleCols.*.ColumnCount</c> as <paramref name="specColumnCount"/>: both files are emitted
+  /// by the same spec codegen run, so a mismatch means a stale or partially-synced spec checkout and throws
+  /// here, at construction, before a single row can be written misaligned. NOTE this is also the only ctor
+  /// usable from OUTSIDE this assembly — the ILRepack internalizes Parquet.Net, so the
+  /// <see cref="ParquetSchema"/> overload's parameter type is renamed in the shipped assembly.</summary>
+  public ParquetTableWriter(
+    string path,
+    SpecColumn[] spec,
+    int specColumnCount,
+    ParquetWriteScheduler scheduler,
+    int flushRows = DEFAULT_ROWGROUP_ROWS
+  )
+    : this(path, SchemaOf(spec, specColumnCount, path), scheduler, flushRows) { }
 
   public ParquetTableWriter(
     string path,
@@ -66,12 +84,24 @@ public sealed class ParquetTableWriter : IDisposable
     });
   }
 
-  /// <summary>Appends one row; <paramref name="values"/> are in schema-column order.</summary>
+  /// <summary>Appends one row; <paramref name="values"/> are in schema-column order. The value count must
+  /// match the schema exactly — a mismatch means the schema (typically spec-generated) and this call site
+  /// have drifted (e.g. a spec bump inserted a column the caller doesn't supply yet), which would otherwise
+  /// silently misalign every row, so it throws instead.</summary>
   public void AddRow(params object?[] values)
   {
     if (_completed)
     {
       throw new InvalidOperationException("Writer already completed.");
+    }
+    if (values.Length != _cols.Length)
+    {
+      throw new ArgumentException(
+        $"Row arity mismatch for '{Path}': got {values.Length} value(s) for a {_cols.Length}-column schema "
+          + $"({string.Join(", ", _fields.Select(f => f.Name))}). The schema and this AddRow call site have "
+          + "drifted — update the caller to supply exactly one value per column, in schema order.",
+        nameof(values)
+      );
     }
     for (var i = 0; i < _cols.Length; i++)
     {
@@ -132,6 +162,38 @@ public sealed class ParquetTableWriter : IDisposable
       }
     });
   }
+
+  // Build a Parquet.Net schema from the generated spec column descriptors (the single source of truth
+  // for table shapes). DDL nullability → DataField<T> (required) vs DataField<T?> (nullable).
+  private static ParquetSchema SchemaOf(SpecColumn[] spec, int specColumnCount, string path)
+  {
+    if (spec.Length != specColumnCount)
+    {
+      throw new InvalidOperationException(
+        $"Generated spec drift for '{path}': BundleSchemas declares {spec.Length} column(s) but the "
+          + $"BundleCols ColumnCount passed is {specColumnCount}. The two generated files come from the "
+          + "same codegen run — regenerate speckle-bundle-spec (npm run generate) and re-sync the checkout."
+      );
+    }
+    var fields = new Field[spec.Length];
+    for (var i = 0; i < spec.Length; i++)
+    {
+      fields[i] = ToField(spec[i]);
+    }
+    return new ParquetSchema(fields);
+  }
+
+  private static DataField ToField(SpecColumn c) =>
+    c.Type switch
+    {
+      SpecArrow.Int32 => c.Nullable ? new DataField<int?>(c.Name) : new DataField<int>(c.Name),
+      SpecArrow.Int64 => c.Nullable ? new DataField<long?>(c.Name) : new DataField<long>(c.Name),
+      SpecArrow.Float64 => c.Nullable ? new DataField<double?>(c.Name) : new DataField<double>(c.Name),
+      SpecArrow.Boolean => c.Nullable ? new DataField<bool?>(c.Name) : new DataField<bool>(c.Name),
+      SpecArrow.Utf8 => new DataField<string>(c.Name),
+      SpecArrow.Binary => new DataField<byte[]>(c.Name),
+      _ => throw new NotSupportedException($"Unmapped ArrowType {c.Type} for column {c.Name}"),
+    };
 
   private static Col MakeCol(DataField f)
   {

--- a/src/Speckle.Sdk.Parquet/Speckle.Sdk.Parquet.csproj
+++ b/src/Speckle.Sdk.Parquet/Speckle.Sdk.Parquet.csproj
@@ -46,5 +46,11 @@
       Include="$(MSBuildThisFileDirectory)../../../speckle-bundle-spec/generated/csharp/BundleSchemas.cs"
       Link="Generated/BundleSchemas.cs"
     />
+    <!-- Per-table column-index constants (BundleCols.Nodes.Argb, ….ColumnCount) — produced by the
+         speckle-bundle-spec codegen (PR in flight there); requires a sibling checkout that has it. -->
+    <Compile
+      Include="$(MSBuildThisFileDirectory)../../../speckle-bundle-spec/generated/csharp/BundleCols.cs"
+      Link="Generated/BundleCols.cs"
+    />
   </ItemGroup>
 </Project>

--- a/tests/Speckle.Objects.Tests.Unit/Utils/ArtifactRoundTripTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Utils/ArtifactRoundTripTests.cs
@@ -116,11 +116,13 @@ public class ArtifactRoundTripTests
       rhinoObj.rawEncoding!.format.Should().Be("3dm");
       Convert.FromBase64String(rhinoObj.rawEncoding.contents).Should().Equal(solidBytes);
 
-      // Revit (PreferSolids = false): no 3dm, rebuilt as a plain DataObject (meshes only).
+      // Revit (PreferSolids = false): the 3dm blob is not accepted and the object has no DISPLAY meshes — since
+      // #520 the reader skips such objects entirely rather than fabricating an empty-displayValue DataObject the
+      // v1 converter pipeline has no path for (see BuildGeometryObject's null return).
       var rootMeshes = (Collection)
         await reader.ReadAsync(dir, new ArtifactReceiveOptions(PreferSolids: false), default);
       Flatten(rootMeshes).OfType<RhinoObject>().Should().BeEmpty();
-      Flatten(rootMeshes).OfType<DataObject>().Should().ContainSingle(d => d.applicationId == "solid-1");
+      Flatten(rootMeshes).Where(b => b.applicationId == "solid-1").Should().BeEmpty();
     }
     finally
     {

--- a/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
@@ -96,7 +96,8 @@ public sealed class EnvelopeWriterTests : IDisposable
     // DEFINES (4) is now geometry-only; DEFINES_INSTANCE (9) carries node→node nesting. rel fixes dst namespace.
     Scalar(db, $"SELECT dst_ns FROM rel_types WHERE rel = {RelKind.Defines}").Should().Be("geometry");
     Scalar(db, $"SELECT dst_ns FROM rel_types WHERE rel = {RelKind.DefinesInstance}").Should().Be("node");
-    Scalar(db, $"SELECT src_ns FROM rel_types WHERE rel = {RelKind.HasMaterial}").Should().Be("geometry");
+    // ENG-8849 (spec d485e68): HAS_MATERIAL src broadened to geometry|instance — instances can carry material overrides.
+    Scalar(db, $"SELECT src_ns FROM rel_types WHERE rel = {RelKind.HasMaterial}").Should().Be("geometry|instance");
     // IN_MODEL (11) → CONTAINER node; the default-projection top key (SOT §8).
     Scalar(db, $"SELECT name FROM rel_types WHERE rel = {RelKind.InModel}").Should().Be("IN_MODEL");
     Scalar(db, $"SELECT dst_ns FROM rel_types WHERE rel = {RelKind.InModel}").Should().Be("node");

--- a/tests/Speckle.Sdk.Tests.Unit/Pipelines/Send/Artifacts/ParquetTableWriterTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Pipelines/Send/Artifacts/ParquetTableWriterTests.cs
@@ -1,0 +1,101 @@
+using AwesomeAssertions;
+using Parquet;
+using Speckle.Bundle.Spec;
+using Speckle.Sdk.Pipelines.Send.Artifacts;
+
+namespace Speckle.Sdk.Tests.Unit.Pipelines.Send.Artifacts;
+
+/// <summary>
+/// Guards the <see cref="ParquetTableWriter.AddRow"/> arity assert on a spec-schema'd table: a row whose
+/// value count doesn't match the schema must throw (naming the file and both counts) instead of silently
+/// misaligning — the failure mode behind the Jul 29 empty-nodes incident, where a spec column insertion
+/// (emissive/ior, 12 → 14) outran positional call sites and every row was dropped. Uses the generated
+/// <c>BundleSchemas.Nodes</c> + <c>BundleCols.Nodes.ColumnCount</c> pair, i.e. the exact construction path
+/// <see cref="EnvelopeWriter"/> uses (the repack internalizes Parquet.Net, so the spec-based ctor is also
+/// the only one visible out here).
+/// </summary>
+public class ParquetTableWriterTests : IDisposable
+{
+  private readonly string _dir = Path.Combine(Path.GetTempPath(), $"parquet-table-writer-{Guid.NewGuid():N}");
+
+  public ParquetTableWriterTests()
+  {
+    Directory.CreateDirectory(_dir);
+  }
+
+  public void Dispose()
+  {
+    if (Directory.Exists(_dir))
+    {
+      Directory.Delete(_dir, recursive: true);
+    }
+  }
+
+  // A full 14-value nodes row in BundleCols order — assembled by named ordinal, the adoption pattern
+  // the constants exist for (an inserted spec column re-numbers these at the next regen).
+  private static object?[] NodeRow(int id, string? name = null)
+  {
+    var row = new object?[BundleCols.Nodes.ColumnCount];
+    row[BundleCols.Nodes.Id] = id;
+    row[BundleCols.Nodes.Kind] = 1;
+    row[BundleCols.Nodes.Name] = name;
+    return row;
+  }
+
+  [Fact]
+  public void AddRow_TooFewValues_ThrowsNamingFileAndCounts()
+  {
+    var path = Path.Combine(_dir, "nodes.parquet");
+    using var scheduler = new ParquetWriteScheduler();
+    using var writer = new ParquetTableWriter(path, BundleSchemas.Nodes, BundleCols.Nodes.ColumnCount, scheduler);
+
+    // The incident shape: a pre-emissive/ior call site still supplying 12 values to the 14-column schema.
+    var act = () => writer.AddRow(0, 1, "wall", null, null, "mm", null, null, null, null, null, null);
+
+    act.Should()
+      .Throw<ArgumentException>()
+      .WithMessage($"*{path}*")
+      .WithMessage("*12 value(s)*")
+      .WithMessage("*14-column*")
+      .WithMessage("*emissive, ior*");
+  }
+
+  [Fact]
+  public void AddRow_TooManyValues_Throws()
+  {
+    var path = Path.Combine(_dir, "nodes.parquet");
+    using var scheduler = new ParquetWriteScheduler();
+    using var writer = new ParquetTableWriter(path, BundleSchemas.Nodes, BundleCols.Nodes.ColumnCount, scheduler);
+
+    var row = NodeRow(0);
+    var act = () => writer.AddRow([.. row, "surplus"]);
+
+    act.Should().Throw<ArgumentException>().WithMessage("*15 value(s)*").WithMessage("*14-column*");
+  }
+
+  [Fact]
+  public async Task AddRow_ExactArity_RoundTrips()
+  {
+    var path = Path.Combine(_dir, "nodes.parquet");
+    using (var scheduler = new ParquetWriteScheduler())
+    {
+      using (var writer = new ParquetTableWriter(path, BundleSchemas.Nodes, BundleCols.Nodes.ColumnCount, scheduler))
+      {
+        writer.AddRow(NodeRow(0, "wall-def"));
+        writer.AddRow(NodeRow(1));
+        writer.Complete();
+      }
+      scheduler.CompleteAndWait();
+    }
+
+    await using var fs = File.OpenRead(path);
+    using var reader = await ParquetReader.CreateAsync(fs);
+    reader.Schema.DataFields.Should().HaveCount(BundleCols.Nodes.ColumnCount);
+    reader.Schema.DataFields[BundleCols.Nodes.Emissive].Name.Should().Be("emissive");
+    using var rg = reader.OpenRowGroupReader(0);
+    var ids = await rg.ReadColumnAsync(reader.Schema.DataFields[BundleCols.Nodes.Id]);
+    ((int[])ids.Data).Should().Equal(0, 1);
+    var names = await rg.ReadColumnAsync(reader.Schema.DataFields[BundleCols.Nodes.Name]);
+    ((string?[])names.Data).Should().Equal("wall-def", null);
+  }
+}


### PR DESCRIPTION
## Why

Production incident (Jul 29): the bundle spec added `emissive`/`ior` to the `nodes` table before `elevation` (12 → 14 columns). In the native (C++) converters the table **schema** came from the spec's generated code (auto-updated) while rows were filled by hard-coded positional ordinals (not updated) — DuckDB silently dropped every row, so every native conversion uploaded an **empty** `envelope.nodes.parquet` and models rendered invisible in the viewer.

This SDK did **not** break that time (`EnvelopeWriter.AddNode` has one named parameter per column, so the spec bump forced a conscious signature update) — but it carries the same **latent bug class**: `ParquetTableWriter.AddRow` takes a positional `object?[]` validated against nothing, while its schema comes from the spec-generated `BundleSchemas` arrays. A future column insertion plus one missed call site would silently misalign rows.

## What

- **`ParquetTableWriter.AddRow` arity guard** — throws an `ArgumentException` naming the file, the value count, the schema column count, and the column list on any mismatch, instead of silently dropping/misaligning (or dying with a bare `IndexOutOfRangeException`).
- **Adopts the generated `BundleCols` column-index constants** (`generated/csharp/BundleCols.cs`, produced by the speckle-bundle-spec codegen — **PR in flight there**; see dependency note below):
  - new `ParquetTableWriter` ctor takes the generated `ColumnSpec[]` **plus** the matching `BundleCols.*.ColumnCount` and cross-checks the two generated files at construction, so a stale/partially-synced spec checkout fails before a single row is written;
  - `EnvelopeWriter` constructs all spec-schema'd tables (`nodes`, `relations`, `camera_views`) through it (the `SchemaOf`/`ToField` spec→Parquet.Net mapping moved from `EnvelopeWriter` into `ParquetTableWriter`);
  - hand-declared, locally-filled schemas (`meta`, catalog, `scene_views`, EAV tables) are unchanged — they can't drift the same way, and the generic `AddRow` guard now covers them too.
- **`Speckle.Sdk.Parquet.csproj`** — adds the third `<Compile Include>` for `BundleCols.cs` from the sibling `speckle-bundle-spec` checkout (same mechanism as `BundleSpec.cs`/`BundleSchemas.cs`).
- **Tests** — new `ParquetTableWriterTests` exercise the guard on the real generated 14-column `nodes` schema: the exact incident shape (12 values into 14 columns) throws with an informative message; too many values throws; exact arity round-trips via Parquet.Net. Side note: the spec-based ctor is also the only one usable from test code — ILRepack internalizes Parquet.Net, so the `ParquetSchema` overload's parameter type is renamed in the shipped assembly.

## Dependency

⚠️ Depends on the speckle-bundle-spec PR that adds `generated/csharp/BundleCols.cs` (column-index constants + `ColumnCount` per table). Until that lands and the sibling checkout is updated, `Speckle.Sdk.Parquet` won't compile — hence **draft**.

## Verification

- `dotnet build src/Speckle.Sdk.Parquet` — clean (0 warnings) on netstandard2.0 / net8.0 / net10.0.
- `dotnet test tests/Speckle.Sdk.Tests.Unit` — 942/942 passing on net8.0 and net10.0 (sibling spec pinned to `a37dd49`, the vintage matching this branch's catalog expectations; spec `main`'s later HAS_MATERIAL `src_ns` broadening trips a pre-existing `EnvelopeWriterTests` assertion unrelated to this change).
- `dotnet csharpier check` — clean.
- Pre-existing on `big-truck`, not touched here: `Speckle.Objects` fails its netstandard2.0 build (`ObjectsArtifactReader.cs` uses `Dictionary.GetValueOrDefault`), which is why branch CI is already red.
