### PR TITLE
docs(adr): pointer stub for atlas ADR-0004 — generated constants, fail-loud writes

### DIFF
--- a/docs/adr/0004-bundle-writers-use-generated-spec-constants-and-fail-loud.md
+++ b/docs/adr/0004-bundle-writers-use-generated-spec-constants-and-fail-loud.md
@@ -1,0 +1,25 @@
+# ADR-0004: Bundle writers address columns via generated spec constants; any dropped row fails the job
+
+- **Status**: pointer — the canonical text lives in the speckle-atlas layer:
+  [`atlas/adr/0004`](../../../atlas/adr/0004-bundle-writers-use-generated-spec-constants-and-fail-loud.md)
+  (standing stack ADR, no owning spec)
+- **Date**: 2026-08-04
+
+Summary: after the 2026-08 empty-`envelope.nodes` incident (a bundle-spec
+column insert drifted from the C++ writers' hand-written ordinals; six days
+of green jobs shipping viewer-blank versions — this repo's writer was safe
+by construction but hardened anyway), the stack rule is: bundle writers
+address columns **only** via the spec's generated column-index constants —
+a hand-written ordinal is a defect; writes are type-checked and any dropped
+row fails the job loudly; relations referencing missing/empty nodes are a
+hard error in the spec validator; and CI round-trips each writer against
+its pinned spec on every PR.
+
+## What this binds in this repo
+
+- **`src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/`**
+  (`ParquetTableWriter`, `EavWriter`, `EnvelopeWriter`,
+  `StructuralResultsWriter`): row/schema arity guards fail fast, and
+  columns are addressed via the generated `BundleCols` constants (#525).
+- **CI**: the bundle-spec sibling checkout is provisioned so the writer
+  round-trip runs against the pinned spec on every PR (#525).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,9 @@
+# Architecture decision records
+
+Repo-local ADRs and pointer stubs to stack-level decisions share one number
+sequence (pointer stubs keep their atlas number and title; local ADRs
+continue numbering after adopted stubs — see the speckle-atlas layer's
+ADR-0003 for the pointer-stub convention).
+
+- [0004 — Bundle writers address columns via generated spec constants; any dropped row fails the job](0004-bundle-writers-use-generated-spec-constants-and-fail-loud.md)
+  (pointer — canonical text in the atlas layer)


### PR DESCRIPTION
Repo-side pointer ADR (per the atlas ADR-0003 amendment) for the standing stack rule recorded after the 2026-08 empty-`envelope.nodes` incident: columns via generated `BundleCols` constants only, arity drift fails fast, per-PR writer round-trip against the pinned spec.

Seeds `docs/adr/` (this repo had no ADR home) with a README establishing the shared number sequence. Thin stub only — the canonical text is atlas ADR-0004 (speckle-atlas PR #20, relative link resolves in an atlas-layer checkout once that merges); the binding code already landed here via #525. Based on `big-truck` because that's where #525 lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)