### PR TITLE
fix(artifacts): write the host-app slug to meta.produced_by

### DIFF
--- a/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
@@ -39,10 +39,17 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   private readonly IdInterner _geometryInterner = new();
   private readonly IdInterner _nodeInterner = new();
 
-  public ObjectsArtifactPipeline(string outputDir, string baseName, ISet<string>? excludedTopLevelProperties = null)
+  // producedBy: the producing host-app slug (e.g. "rhino") written to meta.produced_by — connectors pass
+  // ISpeckleApplication.Slug; null falls back to a generic writer label for un-migrated producers.
+  public ObjectsArtifactPipeline(
+    string outputDir,
+    string baseName,
+    ISet<string>? excludedTopLevelProperties = null,
+    string? producedBy = null
+  )
   {
     _geometriesWriter = new GeometriesParquetWriter(outputDir, baseName, _scheduler);
-    _envelopeWriter = new EnvelopeWriter(outputDir, baseName, _scheduler);
+    _envelopeWriter = new EnvelopeWriter(outputDir, baseName, _scheduler, producedBy);
     _eavWriter = new EavWriter(outputDir, baseName, _scheduler);
     _outputDir = outputDir;
     _baseName = baseName;

--- a/src/Speckle.Objects/Utils/ObjectsArtifactReader.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactReader.cs
@@ -365,7 +365,8 @@ public sealed class ObjectsArtifactReader
           id = "def-" + defNodeK,
           name = kv.Value.Name ?? ("Definition " + defNodeK),
           objects = members,
-          maxDepth = depthByDefNode.GetValueOrDefault(defNodeK, 0),
+          // TryGetValue, not GetValueOrDefault: the latter is unavailable on netstandard2.0 (the net48 plugin build).
+          maxDepth = depthByDefNode.TryGetValue(defNodeK, out int defDepth) ? defDepth : 0,
         }
       );
     }

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
@@ -103,12 +103,17 @@ public sealed class EnvelopeWriter : IDisposable
   private string? _referencePointKind;
   private string? _referencePointOffset;
 
-  public EnvelopeWriter(string outputDir, string baseName, ParquetWriteScheduler scheduler)
+  // meta.produced_by: the producing host-app slug (e.g. "rhino", "revit") — NOT a writer class name; consumers
+  // (e.g. the SketchUp receiver) branch on it to detect same-app round-trips. Null = un-migrated producer fallback.
+  private readonly string? _producedBy;
+
+  public EnvelopeWriter(string outputDir, string baseName, ParquetWriteScheduler scheduler, string? producedBy = null)
   {
     Directory.CreateDirectory(outputDir);
     OutputDir = outputDir;
     BaseName = baseName;
     _scheduler = scheduler;
+    _producedBy = producedBy;
 
     _relations = new ParquetTableWriter(P("relations.parquet"), SchemaOf(SpecSchemas.Relations), scheduler);
     _nodes = new ParquetTableWriter(P("nodes.parquet"), SchemaOf(SpecSchemas.Nodes), scheduler);
@@ -227,7 +232,12 @@ public sealed class EnvelopeWriter : IDisposable
       new ParquetSchema(I("schema_version"), S("produced_by"), S("reference_point_kind"), S("reference_point_offset")),
       _scheduler
     );
-    meta.AddRow(SpecBundle.SchemaVersion, "Speckle.Sdk EnvelopeWriter", _referencePointKind, _referencePointOffset);
+    meta.AddRow(
+      SpecBundle.SchemaVersion,
+      _producedBy ?? "Speckle.Sdk EnvelopeWriter",
+      _referencePointKind,
+      _referencePointOffset
+    );
   }
 
   // Self-describing catalog (SOT §6): the rel/kind vocabulary, written once from the


### PR DESCRIPTION
The envelope meta table recorded the writer class name ('Speckle.Sdk EnvelopeWriter') in produced_by, but the column is meant to carry the producing host app's slug (e.g. 'rhino', 'revit') so consumers can detect same-app round-trips. EnvelopeWriter/ObjectsArtifactPipeline now take an optional producedBy (connectors pass ISpeckleApplication.Slug); null keeps the old generic label for un-migrated producers.

Drive-by: replace Dictionary.GetValueOrDefault in ObjectsArtifactReader with TryGetValue — unavailable on netstandard2.0, it broke the net48 plugin (Local) builds.