### PR TITLE
feat: model relationship 

### DIFF
--- a/.github/actions/checkout-bundle-spec/action.yml
+++ b/.github/actions/checkout-bundle-spec/action.yml
@@ -1,0 +1,19 @@
+name: Checkout speckle-bundle-spec
+description: Checkout speckle-bundle-spec
+
+inputs: 
+   token:
+     required: true
+     description: "GitHub Auth Token"
+     
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout speckle-bundle-spec
+      uses: actions/checkout@v7
+      with:
+        repository: specklesystems/speckle-bundle-spec
+        ref: 8edf478a412e7a049973c87bbc608ca4ea70aae0
+        token: ${{ inputs.token }}
+        path: speckle-bundle-spec
+        persist-credentials: false

--- a/.github/workflows/integration-test-callable-from-server-repo.yml
+++ b/.github/workflows/integration-test-callable-from-server-repo.yml
@@ -7,9 +7,6 @@ on:
         required: true
         type: string
     secrets:
-      # Token with Contents:Read on specklesystems/speckle-bundle-spec (private) — needed to check out
-      # the sibling spec repo Speckle.Sdk.Parquet compiles from. The server repo's CONNECTORS_GH_TOKEN
-      # (already scoped to speckle-bundle-spec) qualifies.
       BUNDLE_SPEC_TOKEN:
         required: true
 
@@ -37,18 +34,10 @@ jobs:
           repository: ${{ env.SERVER_REPO }}
           path: ${{ env.SERVER_DIR }}
 
-      # Speckle.Sdk.Parquet compiles the spec's generated C# from a sibling speckle-bundle-spec checkout
-      # one level up from the SDK checkout — with the SDK at ./client that is the workspace root.
-      - name: Checkout speckle-bundle-spec
-        uses: actions/checkout@v7
+      - name: Checkout Bundle Spec Repo
+        uses: ./.github/actions/checkout-bundle-spec
         with:
-          repository: specklesystems/speckle-bundle-spec
-          # Pin: speckle-bundle-spec main as of 2026-08-04 (merge of spec PR #12 — BundleCols.cs codegen).
-          # Keep aligned with the pin in pr.yml.
-          ref: ecbbd270fae06b00ee08e1b1022a08dd3f170c8f
           token: ${{ secrets.BUNDLE_SPEC_TOKEN }}
-          path: speckle-bundle-spec
-          persist-credentials: false
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,8 +12,6 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: true
-      # Fine-grained PAT with Contents:Read on specklesystems/speckle-bundle-spec (private) —
-      # needed to check out the sibling spec repo Speckle.Sdk.Parquet compiles from.
       BUNDLE_SPEC_TOKEN:
         required: true
 jobs:
@@ -28,7 +26,7 @@ jobs:
       - name: Checkout Bundle Spec Repo
         uses: ./.github/actions/checkout-bundle-spec
         with:
-          token: ${{ secrets.CONNECTORS_GH_TOKEN }}
+          token: ${{ secrets.BUNDLE_SPEC_TOKEN }}
 
       # actions/checkout cannot write outside $GITHUB_WORKSPACE; the csproj expects the spec one level up.
       - name: Move speckle-bundle-spec to sibling location

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -25,18 +25,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      # Speckle.Sdk.Parquet compiles the spec's generated C# from a sibling speckle-bundle-spec
-      # checkout one level up ($(MSBuildThisFileDirectory)../../../speckle-bundle-spec).
-      - name: Checkout speckle-bundle-spec
-        uses: actions/checkout@v7
+      - name: Checkout Bundle Spec Repo
+        uses: ./.github/actions/checkout-bundle-spec
         with:
-          repository: specklesystems/speckle-bundle-spec
-          # Pin: speckle-bundle-spec main as of 2026-08-04 (merge of spec PR #12 — BundleCols.cs codegen).
-          # Keep aligned with the pin in pr.yml.
-          ref: ecbbd270fae06b00ee08e1b1022a08dd3f170c8f
-          token: ${{ secrets.BUNDLE_SPEC_TOKEN }}
-          path: speckle-bundle-spec
-          persist-credentials: false
+          token: ${{ secrets.CONNECTORS_GH_TOKEN }}
 
       # actions/checkout cannot write outside $GITHUB_WORKSPACE; the csproj expects the spec one level up.
       - name: Move speckle-bundle-spec to sibling location

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,7 @@ jobs:
       use-internal-image: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      BUNDLE_SPEC_TOKEN: ${{ secrets.BUNDLE_SPEC_TOKEN }}
+      BUNDLE_SPEC_TOKEN: ${{ secrets.CONNECTORS_GH_TOKEN }}
 
   integration-test-public:
     uses: "./.github/workflows/integration-test.yml"
@@ -74,4 +74,4 @@ jobs:
       docker-compose-file: "docker-compose.yml"
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      BUNDLE_SPEC_TOKEN: ${{ secrets.BUNDLE_SPEC_TOKEN }}
+      BUNDLE_SPEC_TOKEN: ${{ secrets.CONNECTORS_GH_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,20 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      # Speckle.Sdk.Parquet compiles the spec's generated C# (BundleSpec.cs / BundleSchemas.cs / BundleCols.cs)
-      # from a sibling speckle-bundle-spec checkout one level up ($(MSBuildThisFileDirectory)../../../speckle-bundle-spec).
-      # BUNDLE_SPEC_TOKEN: fine-grained PAT with Contents:Read on specklesystems/speckle-bundle-spec —
-      # the default GITHUB_TOKEN cannot clone a second private repo.
-      - name: Checkout speckle-bundle-spec
-        uses: actions/checkout@v7
+      - name: Checkout Bundle Spec Repo
+        uses: ./.github/actions/checkout-bundle-spec
         with:
-          repository: specklesystems/speckle-bundle-spec
-          # Pin: speckle-bundle-spec main as of 2026-08-04 (merge of spec PR #12 — BundleCols.cs codegen).
-          # Bump deliberately, together with SDK code that supports the new catalog.
-          ref: ecbbd270fae06b00ee08e1b1022a08dd3f170c8f
-          token: ${{ secrets.BUNDLE_SPEC_TOKEN }}
-          path: speckle-bundle-spec
-          persist-credentials: false
+          token: ${{ secrets.CONNECTORS_GH_TOKEN }}
 
       # actions/checkout cannot write outside $GITHUB_WORKSPACE, but the csproj expects the spec one
       # level up from the SDK checkout — move it there (also keeps it out of `csharpier check .`).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      # Speckle.Sdk.Parquet compiles the spec's generated C# from a sibling speckle-bundle-spec
-      # checkout one level up — build.sh pack builds the full solution, so release needs it too.
-      - name: Checkout speckle-bundle-spec
-        uses: actions/checkout@v7
+      - name: Checkout Bundle Spec Repo
+        uses: ./.github/actions/checkout-bundle-spec
         with:
-          repository: specklesystems/speckle-bundle-spec
-          # Pin: speckle-bundle-spec main as of 2026-08-04 (merge of spec PR #12 — BundleCols.cs codegen).
-          # Keep aligned with the pin in pr.yml.
-          ref: ecbbd270fae06b00ee08e1b1022a08dd3f170c8f
-          token: ${{ secrets.BUNDLE_SPEC_TOKEN }}
-          path: speckle-bundle-spec
-          persist-credentials: false
+          token: ${{ secrets.CONNECTORS_GH_TOKEN }}
 
       # actions/checkout cannot write outside $GITHUB_WORKSPACE; the csproj expects the spec one level up.
       - name: Move speckle-bundle-spec to sibling location

--- a/Speckle.Sdk.slnx
+++ b/Speckle.Sdk.slnx
@@ -24,6 +24,9 @@
     <File Path=".github/workflows/pr.yml" />
     <File Path=".github/workflows/release.yml" />
   </Folder>
+  <Folder Name="/config/workflows/checkout-bundle-spec/">
+    <File Path=".github/actions/checkout-bundle-spec/action.yml" />
+  </Folder>
   <Folder Name="/performance/">
     <Project Path="tests/Speckle.Sdk.Serialization.Testing/Speckle.Sdk.Serialization.Testing.csproj" />
     <Project Path="tests/Speckle.Sdk.Tests.Performance/Speckle.Sdk.Tests.Performance.csproj" />

--- a/src/Speckle.Sdk.Artifacts.Harness/Migration/Stats.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Migration/Stats.cs
@@ -30,6 +30,10 @@ internal sealed class Stats
   public int ConnectsToEdges;
   public int HostSubelementEdges;
 
+  // Federation tier: linked-model collections retagged as CONTAINER(subtype=Model).
+  public int Models;
+  public int InModelEdges;
+
   // Raw (non-SGEO) native solid blobs: SOLID edges on atomic objects, DEFINES-linked solids on def members.
   public int Solids;
   public int DefinitionSolids;
@@ -62,8 +66,8 @@ internal sealed class Stats
       objects={Objects} (meshAtomic={MeshAtomics} instAtomic={InstanceAtomics})  geometries={Geometries} (defGeom={DefinitionGeometries})
       edges: DISPLAY={DisplayEdges} DISPLAY_INSTANCE={DisplayInstanceEdges} SUBELEMENT={SubelementEdges} SOLID={Solids} (defSolid={DefinitionSolids})
              DEFINES={DefinesEdges} DEFINES_INSTANCE={DefinesInstanceEdges} HAS_MATERIAL={HasMaterialEdges} HAS_COLOR={HasColorEdges} ON_LEVEL={OnLevelEdges} IN_COLLECTION={InCollectionEdges} IN_GROUP={InGroupEdges}
-             IN_ROOM={InRoomEdges} CONNECTS_TO={ConnectsToEdges} SUBELEMENT(host)={HostSubelementEdges}
-      nodes: DEFINITION={Definitions} INSTANCE(def)={DefinitionInstances} MATERIAL={Materials} COLOR={Colors} LEVEL={Levels} COLLECTION={Collections} GROUP={Groups} CAMERA_VIEW={CameraViews}
+             IN_ROOM={InRoomEdges} CONNECTS_TO={ConnectsToEdges} SUBELEMENT(host)={HostSubelementEdges} IN_MODEL={InModelEdges}
+      nodes: DEFINITION={Definitions} INSTANCE(def)={DefinitionInstances} MATERIAL={Materials} COLOR={Colors} LEVEL={Levels} COLLECTION={Collections} GROUP={Groups} CAMERA_VIEW={CameraViews} MODEL={Models}
       skipped (ref not in graph): {SkippedDangling}  (DEFINES={SkippedDefines} HAS_MATERIAL={SkippedMaterial} HAS_COLOR={SkippedColor} ON_LEVEL={SkippedLevel} IN_GROUP={SkippedGroup} IN_ROOM={SkippedRoom} CONNECTS_TO={SkippedConnects} SUBELEMENT(host)={SkippedHostParent})
       """;
 }

--- a/src/Speckle.Sdk.Artifacts.Harness/Migration/Stats.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Migration/Stats.cs
@@ -25,6 +25,11 @@ internal sealed class Stats
   public int MeshAtomics;
   public int InstanceAtomics;
 
+  // Revit topology edges derived from the flat v3 property keys (room/space/fromRoom/toRoom/parent).
+  public int InRoomEdges;
+  public int ConnectsToEdges;
+  public int HostSubelementEdges;
+
   // Raw (non-SGEO) native solid blobs: SOLID edges on atomic objects, DEFINES-linked solids on def members.
   public int Solids;
   public int DefinitionSolids;
@@ -38,7 +43,18 @@ internal sealed class Stats
   public int SkippedColor;
   public int SkippedLevel;
   public int SkippedGroup;
-  public int SkippedDangling => SkippedDefines + SkippedMaterial + SkippedColor + SkippedLevel + SkippedGroup;
+  public int SkippedRoom;
+  public int SkippedConnects;
+  public int SkippedHostParent;
+  public int SkippedDangling =>
+    SkippedDefines
+    + SkippedMaterial
+    + SkippedColor
+    + SkippedLevel
+    + SkippedGroup
+    + SkippedRoom
+    + SkippedConnects
+    + SkippedHostParent;
   public readonly List<string> Notes = new();
 
   public override string ToString() =>
@@ -46,7 +62,8 @@ internal sealed class Stats
       objects={Objects} (meshAtomic={MeshAtomics} instAtomic={InstanceAtomics})  geometries={Geometries} (defGeom={DefinitionGeometries})
       edges: DISPLAY={DisplayEdges} DISPLAY_INSTANCE={DisplayInstanceEdges} SUBELEMENT={SubelementEdges} SOLID={Solids} (defSolid={DefinitionSolids})
              DEFINES={DefinesEdges} DEFINES_INSTANCE={DefinesInstanceEdges} HAS_MATERIAL={HasMaterialEdges} HAS_COLOR={HasColorEdges} ON_LEVEL={OnLevelEdges} IN_COLLECTION={InCollectionEdges} IN_GROUP={InGroupEdges}
+             IN_ROOM={InRoomEdges} CONNECTS_TO={ConnectsToEdges} SUBELEMENT(host)={HostSubelementEdges}
       nodes: DEFINITION={Definitions} INSTANCE(def)={DefinitionInstances} MATERIAL={Materials} COLOR={Colors} LEVEL={Levels} COLLECTION={Collections} GROUP={Groups} CAMERA_VIEW={CameraViews}
-      skipped (ref not in graph): {SkippedDangling}  (DEFINES={SkippedDefines} HAS_MATERIAL={SkippedMaterial} HAS_COLOR={SkippedColor} ON_LEVEL={SkippedLevel} IN_GROUP={SkippedGroup})
+      skipped (ref not in graph): {SkippedDangling}  (DEFINES={SkippedDefines} HAS_MATERIAL={SkippedMaterial} HAS_COLOR={SkippedColor} ON_LEVEL={SkippedLevel} IN_GROUP={SkippedGroup} IN_ROOM={SkippedRoom} CONNECTS_TO={SkippedConnects} SUBELEMENT(host)={SkippedHostParent})
       """;
 }

--- a/src/Speckle.Sdk.Artifacts.Harness/Migration/V3GraphArtifactProducer.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Migration/V3GraphArtifactProducer.cs
@@ -37,6 +37,10 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
   private readonly HashSet<string> _seenObjectAppIds = new(StringComparer.Ordinal);
   private readonly HashSet<string> _seenGeometryAppIds = new(StringComparer.Ordinal);
 
+  // Supports Revit linked models: the v3 connector suffixed every linked element's appId with a per-placement
+  // hash, while proxies and properties kept referencing the bare UniqueId (see TryGetLinkedModelSuffix).
+  private readonly HashSet<string> _linkedModelSuffixes = new(StringComparer.Ordinal);
+
   // Revit room/host refs stashed during traversal, resolved after it when _seenObjectAppIds is complete.
   private readonly record struct TopologyRefs(
     string ElementAppId,
@@ -178,6 +182,11 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
     }
 
     _stats.Objects++;
+
+    if (TryGetLinkedModelSuffix(appId, out var suffix))
+    {
+      _linkedModelSuffixes.Add(suffix);
+    }
 
     var (props, rootScalars, typeKey) = helper.ExtractProperties(obj);
     pipeline.AddProperties(appId, props, rootScalars, typeKey);
@@ -562,13 +571,17 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
       _stats.Levels++;
       foreach (var objAppId in lp.objects)
       {
-        if (!_seenObjectAppIds.Contains(objAppId))
+        var resolvedAny = false;
+        foreach (var resolved in ResolveMemberRefs(objAppId))
+        {
+          pipeline.OnLevel(pipeline.InternObject(resolved), lvlK);
+          _stats.OnLevelEdges++;
+          resolvedAny = true;
+        }
+        if (!resolvedAny)
         {
           _stats.SkippedLevel++;
-          continue;
         }
-        pipeline.OnLevel(pipeline.InternObject(objAppId), lvlK);
-        _stats.OnLevelEdges++;
       }
     }
 
@@ -590,12 +603,16 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
         {
           continue; // unpack can visit a block sub-object twice
         }
-        if (!_seenObjectAppIds.Contains(objAppId))
+        var resolvedAny = false;
+        foreach (var resolved in ResolveMemberRefs(objAppId))
+        {
+          members.Add(pipeline.InternObject(resolved));
+          resolvedAny = true;
+        }
+        if (!resolvedAny)
         {
           _stats.SkippedGroup++;
-          continue;
         }
-        members.Add(pipeline.InternObject(objAppId));
       }
 
       if (members.Count == 0)
@@ -685,8 +702,8 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
 
   // v3 Revit federated sends (SendCollectionManager nested mode) put one collection per source model under
   // the root: the host model named exactly like the root, links named by file. The collections carry no
-  // marker, so require both signals — the host wrapper by name, and a sibling whose elements bear the
-  // _t{hash} appId suffix that only linked (transformed) documents produce. Non-federated sends stay untouched.
+  // marker, so require both signals — the host wrapper by name, and a sibling holding linked-model elements.
+  // Non-federated sends stay untouched.
   private HashSet<string> DetectRevitModelCollections(Base root)
   {
     var result = new HashSet<string>(StringComparer.Ordinal);
@@ -703,7 +720,7 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
     }
 
     var links = children
-      .Where(c => !ReferenceEquals(c, main) && c.name != "definitionGeometry" && HasTransformSuffixedDescendant(c))
+      .Where(c => !ReferenceEquals(c, main) && c.name != "definitionGeometry" && HasLinkedModelElements(c))
       .ToList();
     if (links.Count == 0)
     {
@@ -718,15 +735,15 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
     return result;
   }
 
-  private static bool HasTransformSuffixedDescendant(Collection col)
+  private static bool HasLinkedModelElements(Collection col)
   {
     foreach (var el in col.elements)
     {
-      if (el.applicationId is { } aid && TryGetTransformSuffix(aid, out _))
+      if (el.applicationId is { } aid && TryGetLinkedModelSuffix(aid, out _))
       {
         return true;
       }
-      if (el is Collection sub && HasTransformSuffixedDescendant(sub))
+      if (el is Collection sub && HasLinkedModelElements(sub))
       {
         return true;
       }
@@ -734,9 +751,10 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
     return false;
   }
 
-  // Matches the v3 connector's linked-model appId suffix: {UniqueId}_t{8 lowercase hex}
+  // The v3 Revit connector kept one appId per placement of a linked model by suffixing the element's
+  // UniqueId with a hash of the link's placement transform: {UniqueId}_t{8 lowercase hex}
   // (LinkedModelHandler.GetTransformHash).
-  private static bool TryGetTransformSuffix(string appId, out string suffix)
+  private static bool TryGetLinkedModelSuffix(string appId, out string suffix)
   {
     suffix = "";
     if (appId.Length <= 10 || appId[^10] != '_' || appId[^9] != 't')
@@ -754,16 +772,34 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
     return true;
   }
 
-  // Bare refs resolve exact first, else within the referrer's transform scope — the connector wrote refs as
-  // bare UniqueIds while suffixing sent appIds, and referrer + target share a document, hence a suffix.
-  private bool TryResolveRef(string bareRef, string referrerAppId, out string resolved)
+  // An exact match covers everything except Revit linked models, whose objects were sent suffixed while
+  // proxies reference the bare UniqueId — there a bare ref matches once per placement of the link.
+  private IEnumerable<string> ResolveMemberRefs(string bareRef)
+  {
+    if (_seenObjectAppIds.Contains(bareRef))
+    {
+      yield return bareRef;
+      yield break;
+    }
+    foreach (var suffix in _linkedModelSuffixes)
+    {
+      if (_seenObjectAppIds.Contains(bareRef + suffix))
+      {
+        yield return bareRef + suffix;
+      }
+    }
+  }
+
+  // A Revit element and the room/host its properties reference live in the same document, so on a
+  // linked-model send both carry the same suffix — a missed bare ref is re-tried with the element's own.
+  private bool TryResolveRef(string bareRef, string elementAppId, out string resolved)
   {
     if (_seenObjectAppIds.Contains(bareRef))
     {
       resolved = bareRef;
       return true;
     }
-    if (TryGetTransformSuffix(referrerAppId, out var suffix) && _seenObjectAppIds.Contains(bareRef + suffix))
+    if (TryGetLinkedModelSuffix(elementAppId, out var suffix) && _seenObjectAppIds.Contains(bareRef + suffix))
     {
       resolved = bareRef + suffix;
       return true;

--- a/src/Speckle.Sdk.Artifacts.Harness/Migration/V3GraphArtifactProducer.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Migration/V3GraphArtifactProducer.cs
@@ -52,6 +52,11 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
   // objKs that already received a lineage SUBELEMENT — the host-derived pass must not duplicate them.
   private readonly HashSet<int> _lineageSubelementChildKs = new();
 
+  // Root-child collections detected as the federation tier, retagged CONTAINER(subtype=Model) instead of
+  // COLLECTION; their appId → container K.
+  private HashSet<string> _modelCollectionAppIds = new(StringComparer.Ordinal);
+  private readonly Dictionary<string, int> _modelContainerByAppId = new(StringComparer.Ordinal);
+
   // INSTANCE-node K by appId, shared between atomic instance leaves and nested-instance definition members.
   private readonly Dictionary<string, int> _instanceNodeByAppId = new(StringComparer.Ordinal);
 
@@ -64,6 +69,7 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
   public Stats Produce(Base root)
   {
     IReadOnlySet<string> defSourceAppIds = GetDefinitionAppIds(root);
+    _modelCollectionAppIds = DetectRevitModelCollections(root);
 
     var traversal = DefaultTraversal.CreateTraversalFunc();
     foreach (var tc in traversal.Traverse(root))
@@ -78,6 +84,16 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
 
       if (current is Collection col)
       {
+        if (_modelCollectionAppIds.Contains(helper.Aid(col)))
+        {
+          // Federation tier: a source model is a CONTAINER, not a collection — its child collections become
+          // top-level (flat containers, as the v4 Revit builder writes them).
+          var mk = pipeline.AddContainer(helper.CollectionKey(col), col.name, null, "Model");
+          _modelContainerByAppId[helper.Aid(col)] = mk;
+          _stats.Models++;
+          continue;
+        }
+
         // Parent is a Collection except at the root, which is skipped above and never mapped → top-level (null).
         int? parentK = _collectionMap.TryGetValue(helper.Aid(parent.Current), out var pk) ? pk : null;
         var k = pipeline.AddCollection(helper.CollectionKey(col), col.name, parentK, helper.CollectionSubtype(col));
@@ -115,19 +131,34 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
   private void EmitHierarchyEdge(TraversalContext tc, int objK)
   {
     var hostFound = false;
+    var collectionFound = false;
     for (var p = tc.Parent; p is not null; p = p.Parent)
     {
       var pc = p.Current;
       if (pc is Collection)
       {
-        if (_collectionMap.TryGetValue(helper.Aid(pc), out var ck))
+        if (_modelContainerByAppId.TryGetValue(helper.Aid(pc), out var mk))
         {
-          pipeline.InCollection(objK, ck, 0);
-          _stats.InCollectionEdges++;
+          pipeline.InModel(objK, mk, 0);
+          _stats.InModelEdges++;
+          return; // model containers sit directly under the root
         }
-        return; // nearest collection reached; membership resolved
+        if (!collectionFound)
+        {
+          collectionFound = true;
+          if (_collectionMap.TryGetValue(helper.Aid(pc), out var ck))
+          {
+            pipeline.InCollection(objK, ck, 0);
+            _stats.InCollectionEdges++;
+          }
+          if (_modelCollectionAppIds.Count == 0)
+          {
+            return; // no federation tier; nearest collection resolved membership
+          }
+        }
+        continue; // keep climbing to the model tier
       }
-      if (!hostFound && _objectKMap.TryGetValue(pc.id.NotNull(), out var hostK))
+      if (!hostFound && !collectionFound && _objectKMap.TryGetValue(pc.id.NotNull(), out var hostK))
       {
         pipeline.Subelement(hostK, objK, _stats.SubelementEdges++);
         _lineageSubelementChildKs.Add(objK);
@@ -652,6 +683,57 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
     }
   }
 
+  // v3 Revit federated sends (SendCollectionManager nested mode) put one collection per source model under
+  // the root: the host model named exactly like the root, links named by file. The collections carry no
+  // marker, so require both signals — the host wrapper by name, and a sibling whose elements bear the
+  // _t{hash} appId suffix that only linked (transformed) documents produce. Non-federated sends stay untouched.
+  private HashSet<string> DetectRevitModelCollections(Base root)
+  {
+    var result = new HashSet<string>(StringComparer.Ordinal);
+    if (root is not Collection rootCol || string.IsNullOrEmpty(rootCol.name))
+    {
+      return result;
+    }
+
+    var children = rootCol.elements.OfType<Collection>().ToList();
+    var main = children.FirstOrDefault(c => c.name == rootCol.name);
+    if (main is null)
+    {
+      return result;
+    }
+
+    var links = children
+      .Where(c => !ReferenceEquals(c, main) && c.name != "definitionGeometry" && HasTransformSuffixedDescendant(c))
+      .ToList();
+    if (links.Count == 0)
+    {
+      return result;
+    }
+
+    result.Add(helper.Aid(main));
+    foreach (var link in links)
+    {
+      result.Add(helper.Aid(link));
+    }
+    return result;
+  }
+
+  private static bool HasTransformSuffixedDescendant(Collection col)
+  {
+    foreach (var el in col.elements)
+    {
+      if (el.applicationId is { } aid && TryGetTransformSuffix(aid, out _))
+      {
+        return true;
+      }
+      if (el is Collection sub && HasTransformSuffixedDescendant(sub))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
   // Matches the v3 connector's linked-model appId suffix: {UniqueId}_t{8 lowercase hex}
   // (LinkedModelHandler.GetTransformHash).
   private static bool TryGetTransformSuffix(string appId, out string suffix)
@@ -781,6 +863,11 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
   private void EmitSceneView()
   {
     var keys = new List<SceneViewKey>();
+    // Model tier only when the send actually federates >1 source model (mirrors the v4 Revit builder).
+    if (_modelContainerByAppId.Count > 1)
+    {
+      keys.Add(SceneViewKey.Rel(RelKind.InModel));
+    }
     if (_stats.InCollectionEdges > 0)
     {
       keys.Add(SceneViewKey.Rel(RelKind.InCollection));

--- a/src/Speckle.Sdk.Artifacts.Harness/Migration/V3GraphArtifactProducer.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Migration/V3GraphArtifactProducer.cs
@@ -37,6 +37,21 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
   private readonly HashSet<string> _seenObjectAppIds = new(StringComparer.Ordinal);
   private readonly HashSet<string> _seenGeometryAppIds = new(StringComparer.Ordinal);
 
+  // Revit room/host refs stashed during traversal, resolved after it when _seenObjectAppIds is complete.
+  private readonly record struct TopologyRefs(
+    string ElementAppId,
+    string? Room,
+    string? Space,
+    string? FromRoom,
+    string? ToRoom,
+    string? Parent
+  );
+
+  private readonly List<TopologyRefs> _topologyRefs = new();
+
+  // objKs that already received a lineage SUBELEMENT — the host-derived pass must not duplicate them.
+  private readonly HashSet<int> _lineageSubelementChildKs = new();
+
   // INSTANCE-node K by appId, shared between atomic instance leaves and nested-instance definition members.
   private readonly Dictionary<string, int> _instanceNodeByAppId = new(StringComparer.Ordinal);
 
@@ -85,6 +100,7 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
     var layerGeomKeys = BuildLayerGeomKeys(root, out var layerDepth);
 
     EmitProxies(root, layerGeomKeys, layerDepth);
+    EmitRevitTopology();
     EmitCameraViews(root);
     EmitSceneView();
 
@@ -114,6 +130,7 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
       if (!hostFound && _objectKMap.TryGetValue(pc.id.NotNull(), out var hostK))
       {
         pipeline.Subelement(hostK, objK, _stats.SubelementEdges++);
+        _lineageSubelementChildKs.Add(objK);
         hostFound = true;
       }
       // keep walking up to reach the enclosing collection
@@ -133,6 +150,7 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
 
     var (props, rootScalars, typeKey) = helper.ExtractProperties(obj);
     pipeline.AddProperties(appId, props, rootScalars, typeKey);
+    StashTopologyRefs(appId, props);
 
     if (obj is InstanceProxy ip)
     {
@@ -562,6 +580,114 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
         _stats.InGroupEdges++;
       }
     }
+  }
+
+  // Revit v3 recorded room/host topology as flat property keys holding bare Element.UniqueIds
+  // (ClassPropertiesExtractor, FamilyInstance only). Stashed here, resolved post-traversal.
+  private void StashTopologyRefs(string appId, IReadOnlyDictionary<string, object?> props)
+  {
+    string? Str(string key) => props.TryGetValue(key, out var v) && v is string { Length: > 0 } s ? s : null;
+
+    var room = Str("roomApplicationId");
+    var space = Str("spaceApplicationId");
+    var fromRoom = Str("fromRoomApplicationId");
+    var toRoom = Str("toRoomApplicationId");
+    var parent = Str("parentApplicationId");
+    if (room is null && space is null && fromRoom is null && toRoom is null && parent is null)
+    {
+      return;
+    }
+    _topologyRefs.Add(new TopologyRefs(appId, room, space, fromRoom, toRoom, parent));
+  }
+
+  // Mirrors big-truck's EmitElementTopology: room ?? space → IN_ROOM, from/to rooms → one CONNECTS_TO scoped
+  // by the opening's K, host parent → SUBELEMENT unless the lineage already provided one.
+  private void EmitRevitTopology()
+  {
+    foreach (var t in _topologyRefs)
+    {
+      var elementK = pipeline.InternObject(t.ElementAppId);
+
+      if (t.Parent is not null && !_lineageSubelementChildKs.Contains(elementK))
+      {
+        if (TryResolveRef(t.Parent, t.ElementAppId, out var parent) && parent != t.ElementAppId)
+        {
+          pipeline.Subelement(pipeline.InternObject(parent), elementK, 0);
+          _stats.HostSubelementEdges++;
+        }
+        else
+        {
+          _stats.SkippedHostParent++;
+        }
+      }
+
+      var roomRef = t.Room ?? t.Space;
+      if (roomRef is not null)
+      {
+        if (TryResolveRef(roomRef, t.ElementAppId, out var room))
+        {
+          pipeline.InRoom(elementK, pipeline.InternObject(room), 0);
+          _stats.InRoomEdges++;
+        }
+        else
+        {
+          _stats.SkippedRoom++;
+        }
+      }
+
+      if (t.FromRoom is not null && t.ToRoom is not null)
+      {
+        if (
+          TryResolveRef(t.FromRoom, t.ElementAppId, out var from) && TryResolveRef(t.ToRoom, t.ElementAppId, out var to)
+        )
+        {
+          pipeline.ConnectsTo(pipeline.InternObject(from), pipeline.InternObject(to), elementK);
+          _stats.ConnectsToEdges++;
+        }
+        else
+        {
+          _stats.SkippedConnects++;
+        }
+      }
+    }
+  }
+
+  // Matches the v3 connector's linked-model appId suffix: {UniqueId}_t{8 lowercase hex}
+  // (LinkedModelHandler.GetTransformHash).
+  private static bool TryGetTransformSuffix(string appId, out string suffix)
+  {
+    suffix = "";
+    if (appId.Length <= 10 || appId[^10] != '_' || appId[^9] != 't')
+    {
+      return false;
+    }
+    for (var i = appId.Length - 8; i < appId.Length; i++)
+    {
+      if (appId[i] is not ((>= '0' and <= '9') or (>= 'a' and <= 'f')))
+      {
+        return false;
+      }
+    }
+    suffix = appId[^10..];
+    return true;
+  }
+
+  // Bare refs resolve exact first, else within the referrer's transform scope — the connector wrote refs as
+  // bare UniqueIds while suffixing sent appIds, and referrer + target share a document, hence a suffix.
+  private bool TryResolveRef(string bareRef, string referrerAppId, out string resolved)
+  {
+    if (_seenObjectAppIds.Contains(bareRef))
+    {
+      resolved = bareRef;
+      return true;
+    }
+    if (TryGetTransformSuffix(referrerAppId, out var suffix) && _seenObjectAppIds.Contains(bareRef + suffix))
+    {
+      resolved = bareRef + suffix;
+      return true;
+    }
+    resolved = "";
+    return false;
   }
 
   // collection appId → the display geometry of every object beneath it, with each collection's depth — so a


### PR DESCRIPTION
Fixes https://linear.app/speckle/issue/ENG-9077/migration-on-level-edges-are-skipped-for-all-linked-model-revit, https://linear.app/speckle/issue/ENG-9054/linked-model-federation-tier-not-mapped-to-in-model-container-subtype, and https://linear.app/speckle/issue/ENG-9050/revit-roomhost-topology-properties-are-not-converted-to-in-room