### PR TITLE
test(artifacts): pin the definition-member carrier shape (ENG-9110)

### DIFF
--- a/tests/Speckle.Objects.Tests.Unit/Utils/ArtifactRoundTripTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Utils/ArtifactRoundTripTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using AwesomeAssertions;
 using Speckle.Objects.Data;
 using Speckle.Objects.Geometry;
@@ -6,6 +7,9 @@ using Speckle.Objects.Utils;
 using Speckle.Sdk;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Models.Collections;
+using Speckle.Sdk.Pipelines;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using Speckle.Sdk.Pipelines.Send.Artifacts;
 
 namespace Speckle.Objects.Tests.Unit.Utils;
 
@@ -143,6 +147,99 @@ public class ArtifactRoundTripTests
       }
     }
   }
+
+  /// <summary>
+  /// ENG-9110 / ENG-8851: a block-definition MEMBER keeps an object row carrying the ordinary object-sourced
+  /// IN_COLLECTION (that is how its layer survives) plus an <c>@speckle.geometry_k</c> eav stamp joining that row
+  /// back to the geometry its definition owns via DEFINES. The member has no DISPLAY edge — it renders only through
+  /// a placed instance [ENG-8782] — and the whole scheme rests on two properties of that shape, both asserted here:
+  /// the stamp must survive the parquet round trip (it is the only route from a definition's geometry back to the
+  /// member), and a render-less carrier must NOT materialise as a scene object.
+  /// </summary>
+  [Fact]
+  public async Task RoundTrip_DefinitionMemberCarriesItsLayerWithoutBecomingASceneObject()
+  {
+    var dir = Path.Combine(Path.GetTempPath(), "SpeckleArtifactRoundTrip", Guid.NewGuid().ToString("N"));
+    int layerBK,
+      memberGeoK,
+      memberSolidK;
+    try
+    {
+      using (var pipeline = new ObjectsArtifactPipeline(dir, "rt", TestProducer))
+      {
+        int layerAK = pipeline.AddCollection("layer-a", "Layer A", null, "Layer");
+        layerBK = pipeline.AddCollection("layer-b", "Layer B", null, "Layer");
+
+        // the placement, on Layer A — a real scene object
+        int defK = pipeline.AddDefinition("def-1", "Frame");
+        int placementK = pipeline.InternObject("inst-1");
+        pipeline.AddProperties("inst-1", new Dictionary<string, object?>(), Units("m"));
+        pipeline.DisplayInstance(placementK, pipeline.AddInstance("inst-1", defK, Identity(), "m"), 0);
+        pipeline.InCollection(placementK, layerAK, 0);
+
+        // The member, on Layer B: object row + IN_COLLECTION + the geometry stamp, and NO display edge. A Rhino
+        // member owns TWO geometry Ks — the lossless 3dm solid and its display mesh, which receive chooses between
+        // per member — so the stamp is a comma-joined list and both Ks must lead back here.
+        memberSolidK = pipeline.AddRawGeometry("member-1:solid", [1, 2, 3], "3dm");
+        memberGeoK = pipeline.AddGeometry("member-1:g0", Triangle());
+        pipeline.Defines(defK, memberSolidK, 0);
+        pipeline.Defines(defK, memberGeoK, 0); // same member ordinal — solid + its display shadow
+        pipeline.InCollection(pipeline.InternObject("member-1"), layerBK, 0);
+        pipeline.AddProperties(
+          "member-1",
+          new Dictionary<string, object?>(),
+          [
+            new("units", "m"),
+            new("@speckle.geometry_k", string.Create(CultureInfo.InvariantCulture, $"{memberSolidK},{memberGeoK}")),
+          ]
+        );
+
+        pipeline.AddSceneView(new SceneView(0, "Default", true, new[] { SceneViewKey.Rel(RelKind.InCollection) }));
+        pipeline.Complete();
+      }
+
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+      int memberObjK = bundle.ObjectAppIds.Single(kv => kv.Value == "member-1").Key;
+
+      // 1. The stamp survives, and a dotted eav path comes back NESTED — the shape every reader of it must expect.
+      //    Note what eav does to the VALUE: a multi-K list isn't numeric under the invariant culture (NumberStyles
+      //    .Float admits no thousands separator) so it stays a string, but a SINGLE-K stamp is coerced to a number
+      //    and returns as a double. Any reader has to accept both — see DefinitionMemberStamps.ParseKs.
+      var stamps = bundle.Properties[memberObjK]["@speckle"].Should().BeOfType<Dictionary<string, object?>>().Subject;
+      stamps["geometry_k"].Should().Be(string.Create(CultureInfo.InvariantCulture, $"{memberSolidK},{memberGeoK}"));
+
+      // 2. the member's layer is readable through the ordinary scene-tree map, no new relation involved.
+      bundle.Relations.CollectionByObject[memberObjK].Should().Be(layerBK);
+      SceneViewResolver.Segments(bundle, memberObjK).Should().Equal("Layer B");
+
+      // 3. the carrier has no render edge, so the v1 reader drops it rather than emitting a phantom scene object.
+      //    This is the invariant the whole approach depends on (see DefinitionMemberStamps in the connectors repo).
+      bundle.Relations.DisplayByObject(memberObjK).Should().BeNull();
+      var reader = new ObjectsArtifactReader();
+      var root = (Collection)await reader.ReadAsync(dir, new ArtifactReceiveOptions(PreferSolids: true), default);
+      Flatten(root).Where(b => b.applicationId == "member-1").Should().BeEmpty();
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+
+  private static KeyValuePair<string, object?>[] Units(string units) =>
+    [new KeyValuePair<string, object?>("units", units)];
+
+  private static double[] Identity() => [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+  private static Mesh Triangle() =>
+    new()
+    {
+      vertices = new List<double> { 0, 0, 0, 1, 0, 0, 1, 1, 0 },
+      faces = new List<int> { 3, 0, 1, 2 },
+      units = "m",
+    };
 
   private static IEnumerable<Base> Flatten(Base b)
   {


### PR DESCRIPTION
**Test-only — nothing under `src/` is touched.**

Locks the two properties the Rhino/SketchUp definition-member layer scheme rests on, neither of which is enforced anywhere today.

### Context

A block-definition member is deliberately stripped of its top-level `DISPLAY` / `SOLID` / `DISPLAY_INSTANCE` (ENG-8782 — otherwise definition geometry draws untransformed at the model origin). It keeps an ordinary object row with the standard object-sourced `IN_COLLECTION`, which is how its layer travels, plus an `@speckle.geometry_k` eav stamp joining that row back to the geometry its definition owns via `DEFINES`. SketchUp established the pattern for tags in ENG-8851; Rhino reuses the same keys in specklesystems/speckle-sharp-connectors ENG-9110.

Because a member has no `DISPLAY` edge, `ArtefactRelations.ObjectByGeometry()` cannot invert it — the stamp is the **only** route from a definition's geometry back to the member. Nothing in the spec, the validator or the SDK checks that it survives, so this test does.

### What it asserts

1. **The stamp round-trips through parquet**, and a dotted eav path comes back **nested** (`["@speckle"]["geometry_k"]`) — the shape every reader of it must expect. If this breaks, every block member silently lands on the base layer with no error anywhere.
2. **A carrier object row does not materialise as a scene object.** Object-sourced `IN_COLLECTION`, no render edge → `ObjectsArtifactReader` must keep dropping it. The day it doesn't, members bake twice and show up in the scene explorer.

### Also documented

A surprise the writer has no say over: eav infers a type per value, so a multi-K stamp (`"7,8"`) stays a string while a single-K one is coerced to a number and reads back as a `double`. Any reader has to accept both — and SketchUp's bare-integer stamp arrives via the same numeric branch. Verified the coercion is `NumberStyles.Float` + `InvariantCulture`, so `"7,8"` can never be misparsed as `7.8`.

The fixture uses the real Rhino shape — a member owning a 3dm solid **and** its display mesh, which receive chooses between per member — so the list form is what gets asserted.

### Verification

`Speckle.Objects.Tests.Unit` 224 passed / 1 skipped (pre-existing); `Speckle.Sdk.Tests.Unit` 945 passed. csharpier clean.

### Merge order

Independent of the connectors PR — that one needs no SDK change, so these can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)