### PR TITLE
SPIKE (do not merge): crafted-referencedObject dispatch in Operations.Receive2

### DIFF
--- a/spikes/RealFixtureParity/Program.cs
+++ b/spikes/RealFixtureParity/Program.cs
@@ -1,0 +1,375 @@
+// SPIKE(wayfinder ticket 17) — THROWAWAY.
+// Real-source fixture pair: receives the SAME real Revit version down both rails and dumps a
+// comparable walk of each tree as JSON:
+//   legacy <serverUrl> <projectId> <rootId> <outJson>
+//       — the SDK's legacy server receive (real /objects API, no stub) via Operations.Receive2.
+//   bundle <bundleDir> <projectId> <modelId> <versionId> <outJson>
+//       — serves <bundleDir> through the ticket-07 in-process /v2 artifacts stub, then receives via
+//         the crafted-referencedObject dispatch (Receive2 → ArtifactDownloader → ObjectsArtifactReader).
+// The two JSON dumps are diffed outside (python) into the parity/loss report.
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Speckle.Objects.Data;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Utils;
+using Speckle.Sdk;
+using Speckle.Sdk.Api;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Models.Collections;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+if (args.Length < 1)
+{
+  Console.Error.WriteLine("usage: legacy <serverUrl> <projectId> <rootId> <outJson> | bundle <bundleDir> <projectId> <modelId> <versionId> <outJson>");
+  return 2;
+}
+
+var services = new ServiceCollection();
+services.AddSpeckleSdk(new Speckle.Sdk.Application("Parity17", "parity17"), "0.0.1", typeof(DataObject).Assembly);
+services.AddSingleton<IArtifactGraphMaterializer, SpikeArtifactGraphMaterializer>();
+var provider = services.BuildServiceProvider();
+var operations = provider.GetRequiredService<IOperations>();
+
+var sw = Stopwatch.StartNew();
+Base root;
+string leg = args[0];
+string source;
+long receiveMs;
+
+if (leg == "legacy")
+{
+  var (serverUrl, projectId, rootId, outJson) = (args[1], args[2], args[3], args[4]);
+  source = $"{serverUrl}/projects/{projectId} rootId={rootId}";
+  Console.WriteLine($"[legacy] Receive2({rootId}) from {serverUrl} …");
+  root = await operations.Receive2(new Uri(serverUrl), projectId, rootId, null, null, CancellationToken.None);
+  receiveMs = sw.ElapsedMilliseconds;
+  Console.WriteLine($"[legacy] received in {receiveMs} ms");
+  Dump(root, "legacy", source, outJson, receiveMs);
+  return 0;
+}
+
+if (leg == "bundle")
+{
+  var (bundleDir, projectId, modelId, versionId, outJson) = (args[1], args[2], args[3], args[4], args[5]);
+  const string Token = "parity-token";
+  string craftedId = $"{projectId};{modelId};{versionId}";
+  source = $"bundleDir={bundleDir} craftedId={craftedId}";
+
+  int port = 18177;
+  var listener = new HttpListener();
+  listener.Prefixes.Add($"http://localhost:{port}/");
+  listener.Start();
+  var cts = new CancellationTokenSource();
+  _ = Task.Run(async () =>
+  {
+    while (!cts.IsCancellationRequested)
+    {
+      HttpListenerContext ctx;
+      try
+      {
+        ctx = await listener.GetContextAsync();
+      }
+      catch (Exception) when (cts.IsCancellationRequested)
+      {
+        break;
+      }
+      string path = ctx.Request.Url!.AbsolutePath;
+      if (path == $"/api/v2/projects/{projectId}/models/{modelId}/versions/{versionId}/artifacts")
+      {
+        if (ctx.Request.Headers["Authorization"] != $"Bearer {Token}")
+        {
+          ctx.Response.StatusCode = 401;
+          ctx.Response.Close();
+          continue;
+        }
+        var files = Directory
+          .GetFiles(bundleDir)
+          .Select(Path.GetFileName)
+          .Select(n => $"{{\"name\":\"{n}\",\"url\":\"http://localhost:{port}/fake-s3/{n}?sig=presigned\"}}");
+        byte[] body = Encoding.UTF8.GetBytes($"{{\"files\":[{string.Join(",", files)}]}}");
+        ctx.Response.ContentType = "application/json";
+        await ctx.Response.OutputStream.WriteAsync(body);
+        ctx.Response.Close();
+      }
+      else if (path.StartsWith("/fake-s3/"))
+      {
+        string file = Path.Combine(bundleDir, Path.GetFileName(path));
+        if (!File.Exists(file))
+        {
+          ctx.Response.StatusCode = 404;
+          ctx.Response.Close();
+          continue;
+        }
+        byte[] bytes = await File.ReadAllBytesAsync(file);
+        await ctx.Response.OutputStream.WriteAsync(bytes);
+        ctx.Response.Close();
+      }
+      else
+      {
+        ctx.Response.StatusCode = 404;
+        ctx.Response.Close();
+      }
+    }
+  });
+
+  Console.WriteLine($"[bundle] Receive2({craftedId}) via stub :{port} over {bundleDir} …");
+  sw.Restart();
+  root = await operations.Receive2(new Uri($"http://localhost:{port}"), projectId, craftedId, Token, null, CancellationToken.None);
+  receiveMs = sw.ElapsedMilliseconds;
+  Console.WriteLine($"[bundle] received in {receiveMs} ms");
+  cts.Cancel();
+  listener.Stop();
+  Dump(root, "bundle", source, outJson, receiveMs);
+  return 0;
+}
+
+Console.Error.WriteLine($"unknown leg '{leg}'");
+return 2;
+
+// ── walker/dump ──────────────────────────────────────────────────────────────────────────────────────────
+
+static void Dump(Base root, string leg, string source, string outJson, long receiveMs)
+{
+  long gcBytes = GC.GetTotalMemory(forceFullCollection: true);
+  long workingSet = Environment.WorkingSet;
+
+  var elements = new List<Dictionary<string, object?>>();
+  var typeCounts = new SortedDictionary<string, int>();
+  var clrCounts = new SortedDictionary<string, int>();
+  int collections = 0;
+  long totalProps = 0;
+  int sampled = 0;
+
+  // root-level proxies / views (v3 graph inventory on the legacy side; whatever the reader emits on the bundle side)
+  var rootExtras = new SortedDictionary<string, object?>();
+  foreach (var m in root.GetMembers(DynamicBaseMemberType.Dynamic))
+  {
+    rootExtras[m.Key] = m.Value switch
+    {
+      System.Collections.ICollection c => $"count={c.Count}",
+      null => null,
+      _ => m.Value.GetType().Name,
+    };
+  }
+
+  void Walk(Base b, string colPath, int depth)
+  {
+    string sType = b.speckle_type ?? "<null>";
+    typeCounts[sType] = typeCounts.GetValueOrDefault(sType) + 1;
+    string clr = b.GetType().FullName ?? "?";
+    clrCounts[clr] = clrCounts.GetValueOrDefault(clr) + 1;
+
+    if (b is Collection col)
+    {
+      collections++;
+      string here = colPath.Length == 0 ? (col.name ?? "<root>") : $"{colPath}/{col.name}";
+      foreach (var child in col.elements)
+      {
+        Walk(child, here, depth + 1);
+      }
+      return;
+    }
+
+    // element node
+    var flat = new SortedDictionary<string, string?>(StringComparer.Ordinal);
+    if (b is DataObject dobj)
+    {
+      FlattenDict(dobj.properties, "", flat, 0);
+    }
+    else
+    {
+      // typed/legacy element: flatten its dynamic members (covers v2-era `parameters` etc.)
+      foreach (var m in b.GetMembers(DynamicBaseMemberType.Dynamic))
+      {
+        FlattenValue(m.Value, m.Key, flat, 0);
+      }
+    }
+    totalProps += flat.Count;
+
+    int dvMesh = 0;
+    long dvVerts = 0;
+    long dvFaceLen = 0;
+    var dvOther = new SortedDictionary<string, int>();
+    var dv = (b as DataObject)?.displayValue?.Cast<Base?>().ToList() ?? TryGetDisplay(b);
+    foreach (var d in dv ?? new List<Base?>())
+    {
+      if (d is Mesh m2)
+      {
+        dvMesh++;
+        dvVerts += m2.vertices.Count / 3;
+        dvFaceLen += m2.faces.Count;
+      }
+      else if (d is not null)
+      {
+        dvOther[d.speckle_type] = dvOther.GetValueOrDefault(d.speckle_type) + 1;
+      }
+    }
+
+    var rec = new Dictionary<string, object?>
+    {
+      ["a"] = b.applicationId,
+      ["i"] = b.id,
+      ["t"] = sType,
+      ["n"] = (b as DataObject)?.name ?? (b["name"] as string),
+      ["p"] = colPath,
+      ["np"] = flat.Count,
+      ["ph"] = HashProps(flat),
+      ["pp"] = flat.Keys.ToArray(),
+      ["dv"] = new object?[] { dvMesh, dvVerts, dvFaceLen, dvOther.Count == 0 ? null : dvOther },
+    };
+    // full values on a deterministic appId-keyed sample so BOTH legs sample the same elements
+    if (sampled < 400 && b.applicationId is { } aid && (StableHash(aid) % 23) == 0)
+    {
+      rec["v"] = flat;
+      sampled++;
+    }
+    elements.Add(rec);
+  }
+
+  Walk(root, "", 0);
+
+  var payload = new Dictionary<string, object?>
+  {
+    ["leg"] = leg,
+    ["source"] = source,
+    ["receiveMs"] = receiveMs,
+    ["workingSetMB"] = workingSet / (1024 * 1024),
+    ["gcHeapMB"] = gcBytes / (1024 * 1024),
+    ["rootType"] = root.speckle_type,
+    ["rootName"] = (root as Collection)?.name,
+    ["rootExtras"] = rootExtras,
+    ["collections"] = collections,
+    ["elementCount"] = elements.Count,
+    ["totalFlattenedProps"] = totalProps,
+    ["typeCounts"] = typeCounts,
+    ["clrCounts"] = clrCounts,
+    ["elements"] = elements,
+  };
+  File.WriteAllText(outJson, JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = false }));
+  Console.WriteLine(
+    $"[{leg}] dumped {elements.Count} elements, {collections} collections, {totalProps} props "
+      + $"→ {outJson} (ws {workingSet / (1024 * 1024)} MB, gc {gcBytes / (1024 * 1024)} MB)"
+  );
+}
+
+static List<Base?>? TryGetDisplay(Base b)
+{
+  var raw = b["displayValue"] ?? b["@displayValue"];
+  return raw switch
+  {
+    Base single => new List<Base?> { single },
+    IEnumerable<Base?> many => many.ToList(),
+    IEnumerable<object?> objs => objs.OfType<Base>().Cast<Base?>().ToList(),
+    _ => null,
+  };
+}
+
+static void FlattenDict(IReadOnlyDictionary<string, object?> d, string prefix, SortedDictionary<string, string?> into, int depth)
+{
+  foreach (var kv in d)
+  {
+    FlattenValue(kv.Value, prefix.Length == 0 ? kv.Key : $"{prefix}.{kv.Key}", into, depth);
+  }
+}
+
+static void FlattenValue(object? v, string path, SortedDictionary<string, string?> into, int depth)
+{
+  if (depth > 14)
+  {
+    into[path] = "<depth-capped>";
+    return;
+  }
+  switch (v)
+  {
+    case null:
+      into[path] = null;
+      break;
+    case Dictionary<string, object?> dd:
+      FlattenDict(dd, path, into, depth + 1);
+      break;
+    case IReadOnlyDictionary<string, object?> rd:
+      FlattenDict(rd, path, into, depth + 1);
+      break;
+    case Base bb when path.EndsWith("displayValue"):
+      into[path] = $"<{bb.speckle_type}>";
+      break;
+    case Base bb:
+      into[path] = $"<{bb.speckle_type}>";
+      break;
+    case string s:
+      into[path] = s;
+      break;
+    case bool bo:
+      into[path] = bo ? "true" : "false";
+      break;
+    case sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal:
+      into[path] = Canon(Convert.ToDouble(v, CultureInfo.InvariantCulture));
+      break;
+    case System.Collections.IEnumerable list:
+      {
+        int i = 0;
+        int scalarish = 0;
+        foreach (var item in list)
+        {
+          if (item is Dictionary<string, object?> or IReadOnlyDictionary<string, object?> or Base)
+          {
+            FlattenValue(item, $"{path}[{i}]", into, depth + 1);
+          }
+          else
+          {
+            scalarish++;
+          }
+          i++;
+        }
+        if (scalarish > 0)
+        {
+          into[path] = $"<list:{i} items>";
+        }
+        break;
+      }
+    default:
+      into[path] = v.ToString();
+      break;
+  }
+}
+
+static string Canon(double d)
+{
+  // canonical numeric form so int-vs-double round-trips hash identically across rails
+  if (double.IsNaN(d) || double.IsInfinity(d))
+  {
+    return d.ToString(CultureInfo.InvariantCulture);
+  }
+  double r = Math.Round(d, 9);
+  return r == Math.Floor(r) && Math.Abs(r) < 1e15
+    ? ((long)r).ToString(CultureInfo.InvariantCulture)
+    : r.ToString("G15", CultureInfo.InvariantCulture);
+}
+
+static int StableHash(string s)
+{
+  unchecked
+  {
+    int h = 23;
+    foreach (char c in s)
+    {
+      h = h * 31 + c;
+    }
+    return h & 0x7fffffff;
+  }
+}
+
+static string HashProps(SortedDictionary<string, string?> flat)
+{
+  var sb = new StringBuilder();
+  foreach (var kv in flat)
+  {
+    sb.Append(kv.Key).Append('=').Append(kv.Value ?? "\0null").Append('\n');
+  }
+  return Convert.ToHexString(SHA1.HashData(Encoding.UTF8.GetBytes(sb.ToString())))[..16];
+}

--- a/spikes/RealFixtureParity/RealFixtureParity.csproj
+++ b/spikes/RealFixtureParity/RealFixtureParity.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- SPIKE(wayfinder ticket 17) — THROWAWAY console runner: real-source fixture pair, bundle
+       fidelity vs legacy /objects receive parity. Not in the solution; `dotnet run` from here. -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <AnalysisMode>None</AnalysisMode>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <RunAnalyzers>false</RunAnalyzers>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Speckle.Objects/Speckle.Objects.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+</Project>

--- a/spikes/RealFixtureParity/packages.lock.json
+++ b/spikes/RealFixtureParity/packages.lock.json
@@ -1,0 +1,220 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net8.0": {
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "poUvwtf92bEs8uBH3aRRs/ZgiAw+Z485EU7TtVPBt//MmD0uMPERe7+v3Ur7lpD8XgIEDL9sDoTBcW1LMG97CQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+        }
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
+      "Speckle.InterfaceGenerator": {
+        "type": "Direct",
+        "requested": "[0.9.6, )",
+        "resolved": "0.9.6",
+        "contentHash": "HKH7tYrYYlCK1ct483hgxERAdVdMtl7gUKW9ijWXxA1UsYR4Z+TrRHYmzZ9qmpu1NnTycSrp005NYM78GDKV1w=="
+      },
+      "GraphQL.Client.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "h7uzWFORHZ+CCjwr/ThAyXMr0DPpzEANDa4Uo54wqCQ+j7qUKwqYTgOrb1W40sqbvNaZm9v/X7It31SUw0maHA==",
+        "dependencies": {
+          "GraphQL.Primitives": "6.0.0"
+        }
+      },
+      "GraphQL.Client.Abstractions.Websocket": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Nr9bPf8gIOvLuXpqEpqr9z9jslYFJOvd0feHth3/kPqeR3uMbjF5pjiwh4jxyMcxHdr8Pb6QiXkV3hsSyt0v7A==",
+        "dependencies": {
+          "GraphQL.Client.Abstractions": "6.0.0"
+        }
+      },
+      "GraphQL.Primitives": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "yg72rrYDapfsIUrul7aF6wwNnTJBOFvuA9VdDTQpPa8AlAriHbufeXYLBcodKjfUdkCnaiggX1U/nEP08Zb5GA=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "7.0.5",
+        "contentHash": "FTerRmQPqHrCrnoUzhBu+E+1DNGwyrAMLqHkAqOOOu5pGfyMOj8qQUBxI/gDtWtG11p49UxSfWmBzRNlwZqfUg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.4"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "arDBqTgFCyS0EvRV7O3MZturChstm50OJ0y9bDJvAcmEPJm0FFpFyjU/JLYyStNGGey081DvnQYlncNX5SJJGA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "JOVOfqpnqlVLUzINQ2fox8evY2SKLYJ3BV8QDe/Jyp21u1T7r45x/R/5QdteURMR5r01GxeJSBBUOCOyaNXA3g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.4",
+        "contentHash": "EWI1olKDjFEBMJu0+3wuxwziIAdWDVMYLhuZ3Qs84rrz+DHwD00RzWPZCa+bLnHCf3oJwuFZIRsHT5p236QXww==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.4",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.4"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.4",
+        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.4",
+        "contentHash": "2C9Q9eX7CPLveJA0rIhf9RXAvu+7nWZu1A2MdG6SD/NOu26TakGgL1nsbc0JAspGijFOo3HoN79xrx8a368fBg=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.4",
+        "contentHash": "CSlb5dUp1FMIkez9Iv5EXzpeq7rHryVNqwJMWnpq87j9zWZexaEMdisDktMsnnrzKM6ahNrsTkjqNodTBPBxtQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.4"
+        }
+      },
+      "System.Reactive": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "erBZjkQHWL9jpasCE/0qKAryzVBJFxGHVBAvgRN1bzM0q2s1S4oYREEEL0Vb+1kA/6BKb5FjUZMp5VXmy+gzkQ=="
+      },
+      "speckle.objects": {
+        "type": "Project",
+        "dependencies": {
+          "Speckle.Sdk": "[1.0.0, )"
+        }
+      },
+      "speckle.sdk": {
+        "type": "Project",
+        "dependencies": {
+          "GraphQL.Client": "[6.0.0, )",
+          "Microsoft.Data.Sqlite": "[7.0.5, )",
+          "Microsoft.Extensions.Logging": "[8.0.0, )",
+          "Microsoft.Extensions.ObjectPool": "[8.0.0, )",
+          "Speckle.DoubleNumerics": "[4.1.0, )",
+          "Speckle.Newtonsoft.Json": "[13.0.2, )",
+          "Speckle.Sdk.Dependencies": "[1.0.0, )",
+          "Speckle.Sdk.Parquet": "[1.0.0, )"
+        }
+      },
+      "speckle.sdk.dependencies": {
+        "type": "Project"
+      },
+      "speckle.sdk.parquet": {
+        "type": "Project"
+      },
+      "GraphQL.Client": {
+        "type": "CentralTransitive",
+        "requested": "[6.1.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "8yPNBbuVBpTptivyAlak4GZvbwbUcjeQTL4vN1HKHRuOykZ4r7l5fcLS6vpyPyLn0x8FsL31xbOIKyxbmR9rbA==",
+        "dependencies": {
+          "GraphQL.Client.Abstractions": "6.0.0",
+          "GraphQL.Client.Abstractions.Websocket": "6.0.0",
+          "System.Reactive": "5.0.0"
+        }
+      },
+      "Microsoft.Data.Sqlite": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.5, )",
+        "resolved": "7.0.5",
+        "contentHash": "KGxbPeWsQMnmQy43DSBxAFtHz3l2JX8EWBSGUCvT3CuZ8KsuzbkqMIJMDOxWtG8eZSoCDI04aiVQjWuuV8HmSw==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "7.0.5",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.4"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.6, )",
+        "resolved": "8.0.0",
+        "contentHash": "tvRkov9tAJ3xP51LCv3FJ2zINmv1P8Hi8lhhtcKGqM+ImiTCC84uOPEI4z8Cdq2C3o9e+Aa0Gw0rmrsJD77W+w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Options": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "8.0.0",
+        "contentHash": "4pm+XgxSukskwjzDDfSjG4KNUIOdFF2VaqZZDtTzoyQMOVSnlV6ZM8a9aVu5dg9LVZTB//utzSc8fOi0b0Mb2Q=="
+      },
+      "Speckle.DoubleNumerics": {
+        "type": "CentralTransitive",
+        "requested": "[4.1.0, )",
+        "resolved": "4.1.0",
+        "contentHash": "20DtS+FsDRsOD9+AU3TwNFZ0qrKo5f6f7B5ZR9wStsIHHHC9k7DpjbCvuNtmnSjx54MD+TJC7wV2f5iyGVPj1A=="
+      },
+      "Speckle.Newtonsoft.Json": {
+        "type": "CentralTransitive",
+        "requested": "[13.0.2, )",
+        "resolved": "13.0.2",
+        "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
+      },
+      "System.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[4.5.5, )",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
+      }
+    }
+  }
+}

--- a/spikes/ReceiveDispatchSpike/Program.cs
+++ b/spikes/ReceiveDispatchSpike/Program.cs
@@ -1,0 +1,324 @@
+// SPIKE(wayfinder ticket 07) — THROWAWAY.
+// Proves/kills the crafted-referencedObject dispatch end-to-end on .NET:
+//   1. PRODUCE  a Revit-ish artefact bundle locally (ObjectsArtifactPipeline) — stands in for the server's
+//               stored bundle; the real server side of the crafted id does not exist yet (ticket 01).
+//   2. SERVE    the /v2 artifacts contract from an in-process HTTP stub: the list endpoint (auth required,
+//               presigned urls in the response) + the "S3" blob urls (no auth) — same shapes as production.
+//   3. RECEIVE  via Operations.Receive2(url, projectId, "projectId;modelId;versionId", token) — the real
+//               SDK path: dispatch → ArtifactDownloader → ArtefactBundleReader → ObjectsArtifactReader.
+//   4. TRAVERSE the result the way a v3-era script would (nested parameters, displayValue meshes) and
+//               print exactly where fidelity falls short of the legacy graph.
+//   5. FAIL     the legacy transport Receive on the crafted id (loud, pointed error).
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Speckle.Objects.Data;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Utils;
+using Speckle.Sdk;
+using Speckle.Sdk.Api;
+using Speckle.Sdk.Host;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Models.Collections;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using Speckle.Sdk.Transports;
+
+const string ProjectId = "spikeproj01";
+const string ModelId = "spikemodel1";
+const string VersionId = "spikever001";
+const string Token = "spike-token-abc";
+string craftedId = $"{ProjectId};{ModelId};{VersionId}";
+
+var bundleSourceDir = Path.Combine(Path.GetTempPath(), "SpeckleSpike07-producer", Guid.NewGuid().ToString("N"));
+Directory.CreateDirectory(bundleSourceDir);
+
+// ── 1. PRODUCE ────────────────────────────────────────────────────────────────────────────────────────────
+var producer = new SpeckleApplication
+{
+  HostApplication = "Spike07",
+  HostApplicationVersion = "0.0.1",
+  Slug = "spike07",
+  SpeckleVersion = "999.0.0-spike",
+};
+
+using (var pipeline = new ObjectsArtifactPipeline(bundleSourceDir, VersionId, producer))
+{
+  int levelK = pipeline.AddLevel("level-1", "Level 1", 0.0);
+  int layerK = pipeline.AddCollection("walls-cat", "Walls", null, "Category");
+
+  // A Revit-ish wall: nested instance parameters + type parameters (type-scoped rows go to the type tables).
+  int wallK = pipeline.InternObject("wall-1");
+  pipeline.AddProperties(
+    "wall-1",
+    new Dictionary<string, object?>
+    {
+      ["Parameters"] = new Dictionary<string, object?>
+      {
+        ["Dimensions"] = new Dictionary<string, object?> { ["Area"] = 24.5, ["Volume"] = 7.35 },
+        ["Type Parameters"] = new Dictionary<string, object?> { ["Width"] = 0.3, ["Fire Rating"] = "2hr" },
+      },
+    },
+    new[]
+    {
+      new KeyValuePair<string, object?>("name", "Basic Wall"),
+      new KeyValuePair<string, object?>("units", "m"),
+      new KeyValuePair<string, object?>("speckle_type", "Objects.BuiltElements.Wall"),
+    },
+    typeKey: "walltype-200mm"
+  );
+  var wallMesh = new Mesh
+  {
+    vertices = new List<double> { 0, 0, 0, 5, 0, 0, 5, 0, 3, 0, 0, 3 },
+    faces = new List<int> { 4, 0, 1, 2, 3 },
+    units = "m",
+  };
+  int gK = pipeline.AddGeometry("wall-1:g0", wallMesh);
+  pipeline.Display(wallK, gK, 0);
+  pipeline.InCollection(wallK, layerK, 0);
+  pipeline.OnLevel(wallK, levelK);
+
+  // A property-only element (a Room): no geometry, no DISPLAY edge — the reader's known skip case.
+  int roomK = pipeline.InternObject("room-1");
+  pipeline.AddProperties(
+    "room-1",
+    new Dictionary<string, object?>
+    {
+      ["Parameters"] = new Dictionary<string, object?> { ["Number"] = "101", ["Occupancy"] = "Office" },
+    },
+    new[]
+    {
+      new KeyValuePair<string, object?>("name", "Room 101"),
+      new KeyValuePair<string, object?>("units", "m"),
+    }
+  );
+  pipeline.InCollection(roomK, layerK, 1);
+
+  pipeline.Complete();
+}
+
+var producedFiles = Directory.GetFiles(bundleSourceDir).Select(Path.GetFileName).OrderBy(n => n).ToList();
+Console.WriteLine($"[produce] bundle written: {producedFiles.Count} files");
+foreach (var f in producedFiles)
+{
+  Console.WriteLine($"[produce]   {f}");
+}
+
+// ── 2. SERVE ──────────────────────────────────────────────────────────────────────────────────────────────
+int port = 18077;
+var listener = new HttpListener();
+listener.Prefixes.Add($"http://localhost:{port}/");
+listener.Start();
+var serverLog = new List<string>();
+var serverCts = new CancellationTokenSource();
+var serverTask = Task.Run(async () =>
+{
+  while (!serverCts.IsCancellationRequested)
+  {
+    HttpListenerContext ctx;
+    try
+    {
+      ctx = await listener.GetContextAsync();
+    }
+    catch (Exception) when (serverCts.IsCancellationRequested)
+    {
+      break;
+    }
+    string path = ctx.Request.Url!.AbsolutePath;
+    string? auth = ctx.Request.Headers["Authorization"];
+    if (path == $"/api/v2/projects/{ProjectId}/models/{ModelId}/versions/{VersionId}/artifacts")
+    {
+      serverLog.Add($"LIST   {path} auth={(auth is null ? "NONE" : auth.StartsWith("Bearer ") ? "Bearer …" : auth)}");
+      if (auth != $"Bearer {Token}")
+      {
+        ctx.Response.StatusCode = 401;
+        ctx.Response.Close();
+        continue;
+      }
+      var files = Directory
+        .GetFiles(bundleSourceDir)
+        .Select(Path.GetFileName)
+        .Select(n => $"{{\"name\":\"{n}\",\"url\":\"http://localhost:{port}/fake-s3/{n}?sig=presigned-opaque\"}}");
+      byte[] body = Encoding.UTF8.GetBytes($"{{\"files\":[{string.Join(",", files)}]}}");
+      ctx.Response.ContentType = "application/json";
+      await ctx.Response.OutputStream.WriteAsync(body);
+      ctx.Response.Close();
+    }
+    else if (path.StartsWith("/fake-s3/"))
+    {
+      serverLog.Add($"BLOB   {Path.GetFileName(path)} auth={(auth is null ? "none (presigned)" : "UNEXPECTED " + auth)}");
+      string file = Path.Combine(bundleSourceDir, Path.GetFileName(path));
+      if (!File.Exists(file))
+      {
+        ctx.Response.StatusCode = 404;
+        ctx.Response.Close();
+        continue;
+      }
+      byte[] bytes = await File.ReadAllBytesAsync(file);
+      await ctx.Response.OutputStream.WriteAsync(bytes);
+      ctx.Response.Close();
+    }
+    else
+    {
+      serverLog.Add($"404    {path}");
+      ctx.Response.StatusCode = 404;
+      ctx.Response.Close();
+    }
+  }
+});
+Console.WriteLine($"[serve] /v2 artifacts stub on http://localhost:{port}");
+
+// ── 3. RECEIVE ────────────────────────────────────────────────────────────────────────────────────────────
+var services = new ServiceCollection();
+services.AddSpeckleSdk(new Speckle.Sdk.Application("Spike07", "spike07"), "0.0.1", typeof(DataObject).Assembly);
+services.AddSingleton<IArtifactGraphMaterializer, SpikeArtifactGraphMaterializer>();
+var provider = services.BuildServiceProvider();
+var operations = provider.GetRequiredService<IOperations>();
+
+Console.WriteLine($"[receive] Operations.Receive2(referencedObject: \"{craftedId}\")");
+var root = await operations.Receive2(
+  new Uri($"http://localhost:{port}"),
+  ProjectId,
+  craftedId,
+  Token,
+  onProgressAction: null,
+  cancellationToken: CancellationToken.None
+);
+
+foreach (var line in serverLog)
+{
+  Console.WriteLine($"[serve]   {line}");
+}
+
+// ── 4. TRAVERSE like a v3 script ─────────────────────────────────────────────────────────────────────────
+Console.WriteLine();
+Console.WriteLine("=== received tree ===");
+PrintTree(root, 0);
+
+static void PrintTree(Base b, int depth)
+{
+  string pad = new(' ', depth * 2);
+  string label = b switch
+  {
+    Collection c => $"Collection(name={c.name})",
+    DataObject d => $"DataObject(name={d.name}, displayValue={d.displayValue.Count})",
+    _ => b.speckle_type,
+  };
+  Console.WriteLine($"{pad}{label}  [speckle_type={b.speckle_type}, id={b.id ?? "<null>"}, applicationId={b.applicationId ?? "<null>"}]");
+  if (b is Collection col)
+  {
+    foreach (var child in col.elements)
+    {
+      PrintTree(child, depth + 1);
+    }
+  }
+}
+
+Console.WriteLine();
+Console.WriteLine("=== v3-script-style access ===");
+var wall = FindByAppId(root, "wall-1") as DataObject ?? throw new InvalidOperationException("wall-1 not found");
+
+// the properties dict exactly as the reader hands it back:
+Console.WriteLine("wall.properties =");
+DumpDict(wall.properties, 1);
+
+static void DumpDict(IReadOnlyDictionary<string, object?> d, int depth)
+{
+  string pad = new(' ', depth * 2);
+  foreach (var kv in d)
+  {
+    if (kv.Value is Dictionary<string, object?> nested)
+    {
+      Console.WriteLine($"{pad}{kv.Key}:");
+      DumpDict(nested, depth + 1);
+    }
+    else
+    {
+      Console.WriteLine($"{pad}{kv.Key} = {kv.Value ?? "<null>"} ({kv.Value?.GetType().Name ?? "-"})");
+    }
+  }
+}
+
+// nested parameter access, the `obj.parameters["Area"]` analog (path shape verified by the dump above):
+object? Walk(IReadOnlyDictionary<string, object?> d, params string[] path)
+{
+  object? cur = d;
+  foreach (var seg in path)
+  {
+    if (cur is not Dictionary<string, object?> dd && (cur = (cur as IReadOnlyDictionary<string, object?>)) is null)
+    {
+      return $"<no such path: {string.Join(".", path)}>";
+    }
+    dd = (Dictionary<string, object?>)cur!;
+    if (!dd.TryGetValue(seg, out cur))
+    {
+      return $"<no such path: {string.Join(".", path)} (stuck at {seg})>";
+    }
+  }
+  return cur;
+}
+
+Console.WriteLine($"Parameters.Dimensions.Area   = {Walk(wall.properties, "Parameters", "Dimensions", "Area")}");
+Console.WriteLine($"Parameters.Dimensions.Volume = {Walk(wall.properties, "Parameters", "Dimensions", "Volume")}");
+Console.WriteLine($"properties.Parameters.Dimensions.Area (prefixed shape) = {Walk(wall.properties, "properties", "Parameters", "Dimensions", "Area")}");
+Console.WriteLine($"Type Parameters came back somewhere? = {FindKey(wall.properties, "Type Parameters") ?? "NO (were sent: Width=0.3, Fire Rating=2hr)"}");
+
+static string? FindKey(IReadOnlyDictionary<string, object?> d, string key, string prefix = "")
+{
+  foreach (var kv in d)
+  {
+    string here = prefix.Length == 0 ? kv.Key : $"{prefix}.{kv.Key}";
+    if (kv.Key == key)
+    {
+      return here;
+    }
+    if (kv.Value is Dictionary<string, object?> nested && FindKey(nested, key, here) is { } hit)
+    {
+      return hit;
+    }
+  }
+  return null;
+}
+
+var mesh0 = wall.displayValue.OfType<Mesh>().First();
+Console.WriteLine($"wall.displayValue[0]: Mesh vertices={mesh0.vertices.Count / 3} faces(list len)={mesh0.faces.Count} units={mesh0.units}");
+Console.WriteLine($"wall speckle_type sent='Objects.BuiltElements.Wall' received='{wall.speckle_type}'");
+Console.WriteLine($"wall id (content hash in legacy)                          = '{wall.id ?? "<null>"}' vs applicationId='{wall.applicationId}'");
+Console.WriteLine($"room-1 (property-only element) present in tree?           = {FindByAppId(root, "room-1") is not null}");
+
+static Base? FindByAppId(Base b, string appId)
+{
+  if (b.applicationId == appId)
+  {
+    return b;
+  }
+  if (b is Collection c)
+  {
+    foreach (var child in c.elements)
+    {
+      if (FindByAppId(child, appId) is { } hit)
+      {
+        return hit;
+      }
+    }
+  }
+  return null;
+}
+
+// ── 5. LEGACY TRANSPORT PATH must fail loud ──────────────────────────────────────────────────────────────
+Console.WriteLine();
+Console.WriteLine("=== legacy Receive(objectId, ITransport) with crafted id ===");
+try
+{
+  await operations.Receive(craftedId, remoteTransport: null, localTransport: new MemoryTransport());
+  Console.WriteLine("UNEXPECTED: legacy Receive accepted the crafted id");
+}
+catch (NotSupportedException ex)
+{
+  Console.WriteLine($"OK, failed loud: {ex.Message}");
+}
+
+serverCts.Cancel();
+listener.Stop();
+Directory.Delete(bundleSourceDir, true);
+Console.WriteLine();
+Console.WriteLine("spike complete");

--- a/spikes/ReceiveDispatchSpike/ReceiveDispatchSpike.csproj
+++ b/spikes/ReceiveDispatchSpike/ReceiveDispatchSpike.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- SPIKE(wayfinder ticket 07) — THROWAWAY console runner. Not in the solution; run `dotnet run`
+       from this directory. -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <!-- throwaway spike: repo analyzers off -->
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <AnalysisMode>None</AnalysisMode>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <RunAnalyzers>false</RunAnalyzers>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Speckle.Objects/Speckle.Objects.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+</Project>

--- a/spikes/ReceiveDispatchSpike/packages.lock.json
+++ b/spikes/ReceiveDispatchSpike/packages.lock.json
@@ -1,0 +1,220 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net8.0": {
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "poUvwtf92bEs8uBH3aRRs/ZgiAw+Z485EU7TtVPBt//MmD0uMPERe7+v3Ur7lpD8XgIEDL9sDoTBcW1LMG97CQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+        }
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
+      "Speckle.InterfaceGenerator": {
+        "type": "Direct",
+        "requested": "[0.9.6, )",
+        "resolved": "0.9.6",
+        "contentHash": "HKH7tYrYYlCK1ct483hgxERAdVdMtl7gUKW9ijWXxA1UsYR4Z+TrRHYmzZ9qmpu1NnTycSrp005NYM78GDKV1w=="
+      },
+      "GraphQL.Client.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "h7uzWFORHZ+CCjwr/ThAyXMr0DPpzEANDa4Uo54wqCQ+j7qUKwqYTgOrb1W40sqbvNaZm9v/X7It31SUw0maHA==",
+        "dependencies": {
+          "GraphQL.Primitives": "6.0.0"
+        }
+      },
+      "GraphQL.Client.Abstractions.Websocket": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Nr9bPf8gIOvLuXpqEpqr9z9jslYFJOvd0feHth3/kPqeR3uMbjF5pjiwh4jxyMcxHdr8Pb6QiXkV3hsSyt0v7A==",
+        "dependencies": {
+          "GraphQL.Client.Abstractions": "6.0.0"
+        }
+      },
+      "GraphQL.Primitives": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "yg72rrYDapfsIUrul7aF6wwNnTJBOFvuA9VdDTQpPa8AlAriHbufeXYLBcodKjfUdkCnaiggX1U/nEP08Zb5GA=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "7.0.5",
+        "contentHash": "FTerRmQPqHrCrnoUzhBu+E+1DNGwyrAMLqHkAqOOOu5pGfyMOj8qQUBxI/gDtWtG11p49UxSfWmBzRNlwZqfUg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.4"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "arDBqTgFCyS0EvRV7O3MZturChstm50OJ0y9bDJvAcmEPJm0FFpFyjU/JLYyStNGGey081DvnQYlncNX5SJJGA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "JOVOfqpnqlVLUzINQ2fox8evY2SKLYJ3BV8QDe/Jyp21u1T7r45x/R/5QdteURMR5r01GxeJSBBUOCOyaNXA3g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.4",
+        "contentHash": "EWI1olKDjFEBMJu0+3wuxwziIAdWDVMYLhuZ3Qs84rrz+DHwD00RzWPZCa+bLnHCf3oJwuFZIRsHT5p236QXww==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.4",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.4"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.4",
+        "contentHash": "inBjvSHo9UDKneGNzfUfDjK08JzlcIhn1+SP5Y3m6cgXpCxXKCJDy6Mka7LpgSV+UZmKSnC8rTwB0SQ0xKu5pA==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.4",
+        "contentHash": "2C9Q9eX7CPLveJA0rIhf9RXAvu+7nWZu1A2MdG6SD/NOu26TakGgL1nsbc0JAspGijFOo3HoN79xrx8a368fBg=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.4",
+        "contentHash": "CSlb5dUp1FMIkez9Iv5EXzpeq7rHryVNqwJMWnpq87j9zWZexaEMdisDktMsnnrzKM6ahNrsTkjqNodTBPBxtQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.4"
+        }
+      },
+      "System.Reactive": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "erBZjkQHWL9jpasCE/0qKAryzVBJFxGHVBAvgRN1bzM0q2s1S4oYREEEL0Vb+1kA/6BKb5FjUZMp5VXmy+gzkQ=="
+      },
+      "speckle.objects": {
+        "type": "Project",
+        "dependencies": {
+          "Speckle.Sdk": "[1.0.0, )"
+        }
+      },
+      "speckle.sdk": {
+        "type": "Project",
+        "dependencies": {
+          "GraphQL.Client": "[6.0.0, )",
+          "Microsoft.Data.Sqlite": "[7.0.5, )",
+          "Microsoft.Extensions.Logging": "[8.0.0, )",
+          "Microsoft.Extensions.ObjectPool": "[8.0.0, )",
+          "Speckle.DoubleNumerics": "[4.1.0, )",
+          "Speckle.Newtonsoft.Json": "[13.0.2, )",
+          "Speckle.Sdk.Dependencies": "[1.0.0, )",
+          "Speckle.Sdk.Parquet": "[1.0.0, )"
+        }
+      },
+      "speckle.sdk.dependencies": {
+        "type": "Project"
+      },
+      "speckle.sdk.parquet": {
+        "type": "Project"
+      },
+      "GraphQL.Client": {
+        "type": "CentralTransitive",
+        "requested": "[6.1.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "8yPNBbuVBpTptivyAlak4GZvbwbUcjeQTL4vN1HKHRuOykZ4r7l5fcLS6vpyPyLn0x8FsL31xbOIKyxbmR9rbA==",
+        "dependencies": {
+          "GraphQL.Client.Abstractions": "6.0.0",
+          "GraphQL.Client.Abstractions.Websocket": "6.0.0",
+          "System.Reactive": "5.0.0"
+        }
+      },
+      "Microsoft.Data.Sqlite": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.5, )",
+        "resolved": "7.0.5",
+        "contentHash": "KGxbPeWsQMnmQy43DSBxAFtHz3l2JX8EWBSGUCvT3CuZ8KsuzbkqMIJMDOxWtG8eZSoCDI04aiVQjWuuV8HmSw==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "7.0.5",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.4"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.6, )",
+        "resolved": "8.0.0",
+        "contentHash": "tvRkov9tAJ3xP51LCv3FJ2zINmv1P8Hi8lhhtcKGqM+ImiTCC84uOPEI4z8Cdq2C3o9e+Aa0Gw0rmrsJD77W+w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Options": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.4, )",
+        "resolved": "8.0.0",
+        "contentHash": "4pm+XgxSukskwjzDDfSjG4KNUIOdFF2VaqZZDtTzoyQMOVSnlV6ZM8a9aVu5dg9LVZTB//utzSc8fOi0b0Mb2Q=="
+      },
+      "Speckle.DoubleNumerics": {
+        "type": "CentralTransitive",
+        "requested": "[4.1.0, )",
+        "resolved": "4.1.0",
+        "contentHash": "20DtS+FsDRsOD9+AU3TwNFZ0qrKo5f6f7B5ZR9wStsIHHHC9k7DpjbCvuNtmnSjx54MD+TJC7wV2f5iyGVPj1A=="
+      },
+      "Speckle.Newtonsoft.Json": {
+        "type": "CentralTransitive",
+        "requested": "[13.0.2, )",
+        "resolved": "13.0.2",
+        "contentHash": "g1BejUZwax5PRfL6xHgLEK23sqHWOgOj9hE7RvfRRlN00AGt8GnPYt8HedSK7UB3HiRW8zCA9Pn0iiYxCK24BA=="
+      },
+      "System.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[4.5.5, )",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
+      }
+    }
+  }
+}

--- a/src/Speckle.Objects/Utils/SpikeArtifactGraphMaterializer.cs
+++ b/src/Speckle.Objects/Utils/SpikeArtifactGraphMaterializer.cs
@@ -1,0 +1,14 @@
+// SPIKE(wayfinder ticket 07) — THROWAWAY. Objects-side implementation of the Sdk-declared materializer seam:
+// wraps the existing connector reader unchanged, so the spike measures ObjectsArtifactReader's fidelity as-is.
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+namespace Speckle.Objects.Utils;
+
+public sealed class SpikeArtifactGraphMaterializer : IArtifactGraphMaterializer
+{
+  public Task<Base> MaterializeAsync(string bundleDir, CancellationToken cancellationToken) =>
+    // PreferSolids: false = the Revit-shaped view (SGEO display meshes, no raw 3dm) — the closest analog to
+    // what an SDK data consumer traverses today.
+    new ObjectsArtifactReader().ReadAsync(bundleDir, new ArtifactReceiveOptions(PreferSolids: false), cancellationToken);
+}

--- a/src/Speckle.Sdk.Artifacts.Harness/Harness.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/Harness.cs
@@ -48,11 +48,10 @@ internal sealed class Harness(
     CancellationToken ct
   )
   {
+    // SPIKE(ticket-17, local-only): unset/empty token ⇒ anonymous — public-project reads work only
+    // with the Authorization header fully absent (server 403s empty/invalid bearers).
     var authToken =
-      Environment.GetEnvironmentVariable("SPECKLE_SRC_TOKEN")
-      ?? Environment
-        .GetEnvironmentVariable("SPECKLE_TOKEN")
-        .NotNull("Expected SPECKLE_TOKEN or SPECKLE_SRC_TOKEN to be set");
+      Environment.GetEnvironmentVariable("SPECKLE_SRC_TOKEN") ?? Environment.GetEnvironmentVariable("SPECKLE_TOKEN") ?? "";
 
     // No destination → migrate the source version in place. The CLI guarantees a version is supplied here.
     if (destServer is null && destProject is null && destModel is null)
@@ -68,7 +67,11 @@ internal sealed class Harness(
       return 1;
     }
 
-    string[] destination = [(destServer ?? server).AbsoluteUri, destProject ?? project, destModel ?? model];
+    // SPIKE(ticket-17, local-only): HARNESS_NO_UPLOAD=1 stops after Produce (fixture manufacture).
+    string[]? destination =
+      Environment.GetEnvironmentVariable("HARNESS_NO_UPLOAD") == "1"
+        ? null
+        : [(destServer ?? server).AbsoluteUri, destProject ?? project, destModel ?? model];
     return await ProduceAndUpload(graph, model, outDir, destination, ct).ConfigureAwait(false);
   }
 
@@ -484,7 +487,12 @@ internal sealed class Harness(
   {
     // Reuse the latest-version resolver if no pin; otherwise query the single version.
     using var http = new System.Net.Http.HttpClient();
-    http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+    // SPIKE(ticket-17, local-only): anonymous when token empty; UA required through Cloudflare.
+    if (!string.IsNullOrEmpty(token))
+    {
+      http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+    }
+    http.DefaultRequestHeaders.UserAgent.ParseAdd("speckle-backfill-validation/1.0");
     const string QUERY = """
       query Version($projectId: String!, $modelId: String!, $versionId: String!) {
         project(id: $projectId) {

--- a/src/Speckle.Sdk.Artifacts.Harness/RemoteSource.cs
+++ b/src/Speckle.Sdk.Artifacts.Harness/RemoteSource.cs
@@ -44,7 +44,11 @@ internal sealed class RemoteSource(IDeserializeProcessFactory deserializeProcess
     var payload = new { query, variables = new { projectId, modelId } };
 
     using HttpClient http = new();
-    http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+    // SPIKE(ticket-17, local-only): anonymous when token empty (public-project reads).
+    if (!string.IsNullOrEmpty(token))
+    {
+      http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+    }
     // app.speckle.systems is behind Cloudflare, which 403s (code 1010) requests with no User-Agent.
     http.DefaultRequestHeaders.UserAgent.ParseAdd("speckle-backfill-validation/1.0");
 

--- a/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ParquetTableReader.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ParquetTableReader.cs
@@ -64,6 +64,10 @@ public static class ParquetTableReader
     {
       total += c.Length;
     }
+    // SPIKE(ticket-17, local-only): Parquet.NET hands back nullable-element arrays (double?[]) where
+    // f.ClrType is the bare type (double) — Array.Copy across that pair throws ArrayTypeMismatch on any
+    // bundle big enough for >1 row group. Allocate with the chunks' real element type instead.
+    elementType = chunks[0].GetType().GetElementType() ?? elementType;
     var result = Array.CreateInstance(elementType, total);
     int offset = 0;
     foreach (var c in chunks)

--- a/src/Speckle.Sdk/Api/Operations/Operations.Receive.cs
+++ b/src/Speckle.Sdk/Api/Operations/Operations.Receive.cs
@@ -28,6 +28,14 @@ public partial class Operations
     DeserializeProcessOptions? options = null
   )
   {
+    // SPIKE(wayfinder ticket 07) — THROWAWAY: front-door dispatch. A crafted resource id in place of an
+    // object hash routes to the artefact-bundle rail; everything below stays the legacy v1 path.
+    if (Pipelines.Receive.Artifacts.CraftedResourceId.TryParse(objectId, out var craftedId))
+    {
+      return await ReceiveViaArtifactsSpike(url, streamId, craftedId, authorizationToken, cancellationToken)
+        .ConfigureAwait(false);
+    }
+
     using var receiveActivity = activityFactory.Start("Operations.Receive");
     receiveActivity?.SetTag("speckle.url", url);
     receiveActivity?.SetTag("speckle.projectId", streamId);
@@ -93,6 +101,16 @@ public partial class Operations
     CancellationToken cancellationToken = default
   )
   {
+    // SPIKE(wayfinder ticket 07) — THROWAWAY: fail loud, don't 404 cryptically. Bundle-over-ITransport is
+    // deliberately unsupported (research 03 §3: the contract is per-hashed-object JSON; bundles have neither).
+    if (Pipelines.Receive.Artifacts.CraftedResourceId.TryParse(objectId, out _))
+    {
+      throw new NotSupportedException(
+        $"'{objectId}' is a bundle resource identifier, not an object id. This version has no legacy object "
+          + "graph; transport-based Receive cannot serve it. Use Receive2 (server receive) instead."
+      );
+    }
+
     using var receiveActivity = activityFactory.Start("Operations.Receive");
     metricsFactory.CreateCounter<long>("Receive").Add(1);
 

--- a/src/Speckle.Sdk/Api/Operations/Operations.ReceiveArtifacts.Spike.cs
+++ b/src/Speckle.Sdk/Api/Operations/Operations.ReceiveArtifacts.Spike.cs
@@ -1,0 +1,84 @@
+// SPIKE(wayfinder ticket 07) — THROWAWAY. The artefact-bundle rail behind Receive2's crafted-id dispatch.
+using Speckle.Sdk.Credentials;
+using Speckle.Sdk.Logging;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+namespace Speckle.Sdk.Api;
+
+public partial class Operations
+{
+  private async Task<Base> ReceiveViaArtifactsSpike(
+    Uri url,
+    string streamId,
+    CraftedResourceId craftedId,
+    string? authorizationToken,
+    CancellationToken cancellationToken
+  )
+  {
+    using var receiveActivity = activityFactory.Start("Operations.Receive.Artifacts");
+    receiveActivity?.SetTag("speckle.url", url);
+    receiveActivity?.SetTag("speckle.projectId", streamId);
+    receiveActivity?.SetTag("speckle.resourceId", craftedId.ToString());
+    metricsFactory.CreateCounter<long>("Receive").Add(1);
+    try
+    {
+      if (craftedId.ProjectId != streamId)
+      {
+        throw new SpeckleException(
+          $"Resource id project '{craftedId.ProjectId}' does not match the requested project '{streamId}'."
+        );
+      }
+      if (artifactDownloader is null || artifactGraphMaterializer is null)
+      {
+        throw new SpeckleException(
+          "This version is bundle-only and no artefact materializer is available. Reference Speckle.Objects "
+            + "and register IArtifactGraphMaterializer (or build Operations via AddSpeckleSdk DI)."
+        );
+      }
+
+      // ArtifactDownloader wants an Account but only reads token + serverInfo.url (research 03 §4).
+      var account = new Account
+      {
+        token = authorizationToken ?? "",
+        serverInfo = new() { url = url.ToString() },
+      };
+      string bundleDir = Path.Combine(Path.GetTempPath(), "SpeckleSpike07", Guid.NewGuid().ToString("N"));
+      try
+      {
+        var files = await artifactDownloader
+          .DownloadBundleAsync(account, craftedId.ProjectId, craftedId.ModelId, craftedId.VersionId, bundleDir, cancellationToken)
+          .ConfigureAwait(false);
+        if (files.Count == 0)
+        {
+          // The readiness question (ticket 09): a crafted id promises a bundle; an empty listing means the
+          // promise is broken (still building, or migration incomplete). Fail loud rather than fall back.
+          throw new SpeckleException(
+            $"Version '{craftedId.VersionId}' carries a bundle resource id but the server returned no artefact "
+              + "files — the bundle is not (yet) available."
+          );
+        }
+        var result = await artifactGraphMaterializer.MaterializeAsync(bundleDir, cancellationToken).ConfigureAwait(false);
+        receiveActivity?.SetStatus(SdkActivityStatusCode.Ok);
+        return result;
+      }
+      finally
+      {
+        if (Directory.Exists(bundleDir))
+        {
+          Directory.Delete(bundleDir, true);
+        }
+      }
+    }
+    catch (OperationCanceledException)
+    {
+      throw;
+    }
+    catch (Exception ex)
+    {
+      receiveActivity?.SetStatus(SdkActivityStatusCode.Error);
+      receiveActivity?.RecordException(ex);
+      throw;
+    }
+  }
+}

--- a/src/Speckle.Sdk/Api/Operations/Operations.cs
+++ b/src/Speckle.Sdk/Api/Operations/Operations.cs
@@ -16,5 +16,9 @@ public partial class Operations(
   ISdkActivityFactory activityFactory,
   ISdkMetricsFactory metricsFactory,
   ISerializeProcessFactory serializeProcessFactory,
-  IDeserializeProcessFactory deserializeProcessFactory
+  IDeserializeProcessFactory deserializeProcessFactory,
+  // SPIKE(wayfinder ticket 07) — THROWAWAY: bundle dispatch deps. Materializer is optional so pure-Sdk
+  // consumers (no Speckle.Objects) still resolve; they fail loud only when handed a crafted id.
+  Speckle.Sdk.Pipelines.Receive.Artifacts.IArtifactDownloader? artifactDownloader = null,
+  Speckle.Sdk.Pipelines.Receive.Artifacts.IArtifactGraphMaterializer? artifactGraphMaterializer = null
 ) : IOperations;

--- a/src/Speckle.Sdk/Pipelines/Receive/Artifacts/CraftedResourceId.cs
+++ b/src/Speckle.Sdk/Pipelines/Receive/Artifacts/CraftedResourceId.cs
@@ -1,0 +1,37 @@
+// SPIKE(wayfinder ticket 07) — THROWAWAY. Candidate format pinned for real by ticket 08.
+namespace Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+/// <summary>
+/// The crafted resource identifier a bundle-only version carries in <c>version.referencedObject</c> instead of a
+/// content hash: <c>projectId;modelId;versionId</c>. The <c>;</c> delimiter makes it non-hex-shaped (unambiguous
+/// vs legacy object ids) and it avoids <c>/ ? # %</c> (ticket 02's URL-interpolation constraint).
+/// </summary>
+public readonly record struct CraftedResourceId(string ProjectId, string ModelId, string VersionId)
+{
+  public static bool TryParse(string? id, out CraftedResourceId parsed)
+  {
+    parsed = default;
+    if (id is null || id.IndexOf(';') < 0)
+    {
+      return false;
+    }
+    var parts = id.Split(';');
+    if (parts.Length != 3)
+    {
+      return false;
+    }
+    foreach (var p in parts)
+    {
+      if (p.Length == 0 || p.IndexOfAny(s_forbidden) >= 0)
+      {
+        return false;
+      }
+    }
+    parsed = new CraftedResourceId(parts[0], parts[1], parts[2]);
+    return true;
+  }
+
+  private static readonly char[] s_forbidden = ['/', '?', '#', '%', ' '];
+
+  public override string ToString() => $"{ProjectId};{ModelId};{VersionId}";
+}

--- a/src/Speckle.Sdk/Pipelines/Receive/Artifacts/IArtifactGraphMaterializer.cs
+++ b/src/Speckle.Sdk/Pipelines/Receive/Artifacts/IArtifactGraphMaterializer.cs
@@ -1,0 +1,12 @@
+// SPIKE(wayfinder ticket 07) — THROWAWAY. The DI-inversion seam for the Sdk/Objects split (research 03 §2):
+// declared here in Speckle.Sdk (where Operations lives), implemented in Speckle.Objects (where the geometry
+// codecs and Base-shaping live), injected via the existing container.
+using Speckle.Sdk.Models;
+
+namespace Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+/// <summary>Turns a downloaded artefact bundle directory into a legacy-compatible <see cref="Base"/> tree.</summary>
+public interface IArtifactGraphMaterializer
+{
+  Task<Base> MaterializeAsync(string bundleDir, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
> [!WARNING]
> **Throwaway spike — not for merge.** Draft PR opened as a discussion surface for the big-truck developer-compat effort (Linear anchor: ENG-9154). Delete the branch once the spec lands.

## What this proves

The crafted-referencedObject dispatch trick works end-to-end on .NET. A bundle-only version plants a resource identifier (`projectId;modelId;versionId`) in `version.referencedObject` instead of an object hash, and `Operations.Receive2` serves it from the artefact bundle rail — while every legacy id keeps flowing down the v1 path untouched:

```
Operations.Receive2(url, projectId, "projectId;modelId;versionId", token)
  → crafted-id detected at the front door (CraftedResourceId.TryParse)
  → ArtifactDownloader — UNCHANGED (Bearer auth on the artifacts listing, bare presigned GETs)
  → ArtefactBundleReader → ObjectsArtifactReader behind a DI seam
  → a Base tree a v3-era script can traverse
```

- Nested instance parameters survive: `wall.properties["properties"]["Parameters"]["Dimensions"]["Area"]` → `24.5`; `displayValue` SGEO meshes come back intact.
- Legacy `Receive(craftedId, ITransport)` fails **loud** with a pointed `NotSupportedException` — bundle-over-ITransport is deliberately unsupported.
- ~135 new lines in Sdk+Objects; no existing receive code moved.

## The Sdk/Objects split did not bite

The dependency cycle (`Operations` in Sdk, geometry codecs + Base-shaping in Objects) is resolved by DI inversion, done in hours: `IArtifactGraphMaterializer` is declared in `Speckle.Sdk`, implemented in `Speckle.Objects` wrapping `ObjectsArtifactReader`, and injected as an optional `Operations` ctor param (pure-Sdk consumers resolve fine and only fail — loudly — when handed a crafted id). Dissolving the split is therefore a desirability/packaging question, not a feasibility blocker for the receive rail.

## What it deliberately does NOT solve

`ObjectsArtifactReader` output is a v1-connector bake, not an SDK-grade graph — the spike demonstrates the gaps live: type-scoped parameters lost, property-only elements absent, `speckle_type` collapsed to `DataObject` (the sent name survives only as a string property), `id` = applicationId. What `operations.receive` is *contracted* to return for bundle-only versions is an open decision in the effort's map (ticket 16), as is the final identifier format (ticket 08 — the embedded projectId is redundant with `Receive2`'s own argument, and there's no versioning prefix yet).

**Faked here, required for real:** the server planting the crafted id (today `referencedObject` holds the raw client rootId), the `/v2` artifacts endpoint (in-process stub copying the production shapes — the real `ArtifactDownloader` consumed it unmodified), and readiness (the spike assumes crafted id ⇒ bundle exists; an empty listing throws rather than falling back).

## Run it

```bash
# needs a sibling speckle-bundle-spec checkout at current origin/main (BundleCols.cs)
cd spikes/ReceiveDispatchSpike && dotnet run
```

The runner produces a Revit-ish bundle locally via `ObjectsArtifactPipeline`, serves it through an in-process `/v2`-shaped HTTP stub, receives it through the real `Operations.Receive2` path with a crafted id, prints the tree + fidelity report, and demonstrates the legacy-path fail-loud guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
