### PR TITLE
feat(api): mark ModelIngestionResource.Complete obsolete (ENG-9221)

### DIFF
--- a/src/Speckle.Sdk/Api/GraphQL/Resources/ModelIngestionResource.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Resources/ModelIngestionResource.cs
@@ -301,6 +301,9 @@ public sealed class ModelIngestionResource
   /// <param name="cancellationToken"></param>
   /// <returns>The version id</returns>
   /// <inheritdoc cref="ISpeckleGraphQLClient.ExecuteGraphQLRequest{T}"/>
+  [Obsolete(
+    "The completeWithVersion mutation bypasses the v2 REST uploads/complete seam, so the resulting version is not viewer-consumable in the bundle era (ENG-9221). Complete ingestions via the v2 REST uploads/complete flow (Speckle.Sdk.Pipelines.Send.Artifacts.ArtifactPipeline) instead."
+  )]
   public async Task<string> Complete(ModelIngestionSuccessInput input, CancellationToken cancellationToken = default)
   {
     //language=graphql

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ModelIngestionResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ModelIngestionResourceTests.cs
@@ -147,7 +147,9 @@ public sealed class ModelIngestionResourceTests : IAsyncLifetime
     );
 
     ModelIngestionSuccessInput finish = new(ingest.id, _project.id, sendResult.RootId, "yay!");
+#pragma warning disable CS0618 // deliberately exercising the obsolete completeWithVersion path (ENG-9221)
     string versionId = await Sut.Complete(finish);
+#pragma warning restore CS0618
     Version version = await _testUser.Version.Get(versionId, _project.id);
     ModelIngestion finalIngestion = await _testUser.Ingestion.Get(ingest.id, _project.id);
     Assert.Equal(version.id, versionId);


### PR DESCRIPTION
## What

Marks `ModelIngestionResource.Complete` — the SDK wrapper of the `completeWithVersion` GraphQL mutation — `[Obsolete]` (warning-only), mirroring the server-side `@deprecated` from ENG-8970. The message points at the v2 REST `uploads/complete` flow (`ArtifactPipeline`) as the replacement.

- Non-error `[Obsolete]`, so deployed packfile-era connectors keep compiling (warning only); the method body is untouched.
- The one in-repo caller (integration test deliberately exercising the mutation) is wrapped in `#pragma warning disable CS0618`.

## Why

`completeWithVersion` bypasses the v2 REST `uploads/complete` seam where the server dispatches viewer `.dat` generation, so versions created through it are not viewer-consumable in the bundle era. The SDK must mirror the deprecation so new connector builds stop adopting the mutation.

## Verification

- Full solution builds with 0 warnings under `TreatWarningsAsErrors` against the CI-pinned `speckle-bundle-spec` ref.
- Unit suites green: 945 SDK + 224 Objects + 79 Serialization tests. Integration tests not run (need a live server).

Linear: [ENG-9221](https://linear.app/speckle/issue/ENG-9221/mark-modelingestionresourcecompletewithversion-obsolete-in-speckle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)