### PR TITLE
feat(envelope): bundle vocab additions — rels 24–27, model + property_set_definitions writers, gh_topology

### DIFF
--- a/.github/actions/checkout-bundle-spec/action.yml
+++ b/.github/actions/checkout-bundle-spec/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/checkout@v7
       with:
         repository: specklesystems/speckle-bundle-spec
-        ref: 8edf478a412e7a049973c87bbc608ca4ea70aae0
+        ref: 0bc4769c9f475b8bce94ea5d76c1f1a91c56bee8
         token: ${{ inputs.token }}
         path: speckle-bundle-spec
         persist-credentials: false

--- a/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
@@ -608,18 +608,22 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   /// <summary>Appends one field row of an AEC/Civil3D property-set DEFINITION to the optional
   /// <c>{base}.eav.property_set_definitions.parquet</c> (see <see cref="PropertySetDefinitionsWriter"/>) —
   /// the schema only; values stay per-object in eav under <c>properties.Property Sets.{set}.{field}</c> and
-  /// attachment is derived from those value paths. <paramref name="setKey"/> is the definition's content hash;
-  /// <paramref name="fieldId"/> joins <c>eav.internal_definition_name</c>.</summary>
+  /// attachment is derived from those value paths. <paramref name="setKey"/> is the definition's content hash
+  /// (SET-level identity); <paramref name="fieldBucketId"/> is THE rebind join key — the same string the value
+  /// rows ship in <c>eav.internal_definition_name</c> (null ⇒ consumers match <paramref name="fieldName"/>
+  /// against the value path leaf). Call once per field, in authored field order (row order is field order).</summary>
   public void AddPropertySetDefinition(
     string setName,
     string setKey,
     string fieldName,
-    int? fieldId,
+    string? fieldBucketId,
     string? dataType,
     string? defaultString = null,
     double? defaultDouble = null,
+    bool? defaultBoolean = null,
     string? unit = null,
     string? description = null,
+    string? setDescription = null,
     string? appliesTo = null
   )
   {
@@ -627,11 +631,13 @@ public sealed class ObjectsArtifactPipeline : IDisposable
     _propertySetDefinitionsWriter.AddRow(
       setName,
       setKey,
+      setDescription,
       fieldName,
-      fieldId,
+      fieldBucketId,
       dataType,
       defaultString,
       defaultDouble,
+      defaultBoolean,
       unit,
       description,
       appliesTo

--- a/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
@@ -35,6 +35,10 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   // polluting every non-structural connector's bundle catalog.
   private StructuralResultsWriter? _structuralResultsWriter;
 
+  // Same lazy-optional contract as structural_results: no rows → no file.
+  private ModelEavWriter? _modelEavWriter;
+  private PropertySetDefinitionsWriter? _propertySetDefinitionsWriter;
+
   // Per-namespace interners. The object namespace is owned by the eav writer (it writes the
   // dictionary), so it is not duplicated here.
   private readonly IdInterner _geometryInterner = new();
@@ -492,6 +496,34 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   public void Bounds(int boundingObjectK, int roomObjectK, int ord) =>
     _envelopeWriter.AddRelation(RelKind.Bounds, boundingObjectK, roomObjectK, ord);
 
+  /// <summary>object(definition member) → node(INSTANCE): the association-only object↔placement map (rel 24
+  /// PLACES). Ties a render-edge-less definition-member object to its nested placement so its properties and
+  /// <see cref="InCollection"/> membership stay reachable — replaces the <c>@speckle.instance_k</c> eav stamp.
+  /// NEVER a render root: that is <see cref="DisplayInstance"/>, whose every edge is drawn in world space.</summary>
+  public void Places(int memberObjectK, int instanceK) =>
+    _envelopeWriter.AddRelation(RelKind.Places, memberObjectK, instanceK, 0);
+
+  /// <summary>node(DEFINITION) → object(member): definition membership on the OBJECT plane, where nothing is
+  /// deduped (rel 25 DEFINES_MEMBER). <paramref name="memberOrd"/> is the MEMBER ordinal shared with the
+  /// member's <see cref="Defines"/> rows — joining (definition, ord) recovers each member's geometry even when
+  /// content-hash dedup collapses identical meshes across definitions. Replaces the <c>@speckle.geometry_k</c>
+  /// eav stamp; instance-members join via <see cref="Places"/> instead.</summary>
+  public void DefinesMember(int definitionK, int memberObjectK, int memberOrd) =>
+    _envelopeWriter.AddRelation(RelKind.DefinesMember, definitionK, memberObjectK, memberOrd);
+
+  /// <summary>object → node(MATERIAL): placement paint on the object plane (rel 26, successor of
+  /// <see cref="HasMaterial"/> with <c>srcIsInstance</c>). FILL semantics: geometry-level HAS_MATERIAL always
+  /// wins; the object's material fills definition geometry with no material of its own, resolved down the
+  /// placement chain (a nested member object reaches its placement via <see cref="Places"/>).</summary>
+  public void ObjectHasMaterial(int objectK, int materialK) =>
+    _envelopeWriter.AddRelation(RelKind.ObjectHasMaterial, objectK, materialK, 0);
+
+  /// <summary>object → node(COLOR): object-plane colour (rel 27, successor of <see cref="HasColor"/> with
+  /// <c>srcIsObject</c>). FILL semantics matching <see cref="ObjectHasMaterial"/>: geometry-level HAS_COLOR
+  /// wins; the object colour applies where the geometry carries none (CAD ByBlock-style inheritance).</summary>
+  public void ObjectHasColor(int objectK, int colorK) =>
+    _envelopeWriter.AddRelation(RelKind.ObjectHasColor, objectK, colorK, 0);
+
   // ── structural results ─────────────────────────────────────────────────────────────────
 
   /// <summary>
@@ -527,6 +559,82 @@ public sealed class ObjectsArtifactPipeline : IDisposable
       step,
       value,
       valueText
+    );
+  }
+
+  // ── model / property-set definitions (optional purpose files) ──────────────────────────
+
+  /// <summary>Appends one MODEL/document-scoped attribute to the optional <c>{base}.eav.model.parquet</c>
+  /// (see <see cref="ModelEavWriter"/>) — facts of the model itself (project information, the full
+  /// reference-point transform, document settings) that have no owning object. <paramref name="value"/> is
+  /// coalesced into exactly one typed column (bool / numeric / string); null values write no row. A bundle
+  /// where this is never called ships no file.</summary>
+  public void AddModelProperty(string path, object? value, string? unit = null)
+  {
+    if (string.IsNullOrEmpty(path) || value is null)
+    {
+      return;
+    }
+    string? s = null;
+    double? d = null;
+    bool? b = null;
+    switch (value)
+    {
+      case bool bv:
+        b = bv;
+        break;
+      case string sv:
+        s = sv;
+        break;
+      case sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal:
+        d = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+        break;
+      default:
+        s = Convert.ToString(value, CultureInfo.InvariantCulture);
+        break;
+    }
+    if (d is { } dv && (double.IsNaN(dv) || double.IsInfinity(dv)))
+    {
+      return; // eav convention: finite numerics only
+    }
+    if (s is null && d is null && b is null)
+    {
+      return;
+    }
+    _modelEavWriter ??= new ModelEavWriter(_outputDir, _baseName, _scheduler);
+    _modelEavWriter.AddRow(path, s, d, b, unit);
+  }
+
+  /// <summary>Appends one field row of an AEC/Civil3D property-set DEFINITION to the optional
+  /// <c>{base}.eav.property_set_definitions.parquet</c> (see <see cref="PropertySetDefinitionsWriter"/>) —
+  /// the schema only; values stay per-object in eav under <c>properties.Property Sets.{set}.{field}</c> and
+  /// attachment is derived from those value paths. <paramref name="setKey"/> is the definition's content hash;
+  /// <paramref name="fieldId"/> joins <c>eav.internal_definition_name</c>.</summary>
+  public void AddPropertySetDefinition(
+    string setName,
+    string setKey,
+    string fieldName,
+    int? fieldId,
+    string? dataType,
+    string? defaultString = null,
+    double? defaultDouble = null,
+    string? unit = null,
+    string? description = null,
+    string? appliesTo = null
+  )
+  {
+    _propertySetDefinitionsWriter ??= new PropertySetDefinitionsWriter(_outputDir, _baseName, _scheduler);
+    _propertySetDefinitionsWriter.AddRow(
+      setName,
+      setKey,
+      fieldName,
+      fieldId,
+      dataType,
+      defaultString,
+      defaultDouble,
+      unit,
+      description,
+      appliesTo
     );
   }
 
@@ -580,6 +688,8 @@ public sealed class ObjectsArtifactPipeline : IDisposable
     _envelopeWriter.Complete();
     _eavWriter.Complete();
     _structuralResultsWriter?.Complete(); // absent unless a producer added structural rows
+    _modelEavWriter?.Complete(); // absent unless a producer added model-scoped rows
+    _propertySetDefinitionsWriter?.Complete(); // absent unless a producer shipped set schemas
     _scheduler.CompleteAndWait();
   }
 
@@ -593,6 +703,14 @@ public sealed class ObjectsArtifactPipeline : IDisposable
     if (_structuralResultsWriter is not null)
     {
       SafeDispose(_structuralResultsWriter);
+    }
+    if (_modelEavWriter is not null)
+    {
+      SafeDispose(_modelEavWriter);
+    }
+    if (_propertySetDefinitionsWriter is not null)
+    {
+      SafeDispose(_propertySetDefinitionsWriter);
     }
     SafeDispose(_scheduler);
   }

--- a/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
@@ -519,8 +519,9 @@ public sealed class ObjectsArtifactPipeline : IDisposable
     _envelopeWriter.AddRelation(RelKind.ObjectHasMaterial, objectK, materialK, 0);
 
   /// <summary>object → node(COLOR): object-plane colour (rel 27, successor of <see cref="HasColor"/> with
-  /// <c>srcIsObject</c>). FILL semantics matching <see cref="ObjectHasMaterial"/>: geometry-level HAS_COLOR
-  /// wins; the object colour applies where the geometry carries none (CAD ByBlock-style inheritance).</summary>
+  /// <c>srcIsObject</c>). OVERRIDE semantics — deliberately the INVERSE of <see cref="ObjectHasMaterial"/>:
+  /// material is intrinsic (geometry owns, object fills), colour is presentational (object OVERRIDES,
+  /// geometry-level HAS_COLOR is the default) [spec #16].</summary>
   public void ObjectHasColor(int objectK, int colorK) =>
     _envelopeWriter.AddRelation(RelKind.ObjectHasColor, objectK, colorK, 0);
 

--- a/src/Speckle.Sdk.Parquet/Pipelines/Nodes.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Nodes.cs
@@ -28,6 +28,10 @@ public static class RelKind
   public const byte ConnectsTo = (byte)SpecRel.CONNECTS_TO;
   public const byte HostedOn = (byte)SpecRel.HOSTED_ON;
   public const byte Bounds = (byte)SpecRel.BOUNDS;
+  public const byte Places = (byte)SpecRel.PLACES;
+  public const byte DefinesMember = (byte)SpecRel.DEFINES_MEMBER;
+  public const byte ObjectHasMaterial = (byte)SpecRel.OBJECT_HAS_MATERIAL;
+  public const byte ObjectHasColor = (byte)SpecRel.OBJECT_HAS_COLOR;
 }
 
 /// <summary>Value-node kinds in the envelope <c>nodes</c> table — a thin facade over the generated

--- a/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
@@ -124,6 +124,27 @@ public sealed class ArtefactRelations
   public Dictionary<int, List<int>> DefinesOrdByDefinition { get; } = new();
   public Dictionary<int, List<int>> DefinesInstanceByDefinition { get; } = new();
 
+  /// <summary>PLACES (24): definition-member object → its INSTANCE node. Association ONLY — never a render
+  /// root (that is DISPLAY_INSTANCE). Ties a render-edge-less member object to its nested placement so its
+  /// properties/IN_COLLECTION stay reachable; successor of the <c>@speckle.instance_k</c> eav stamp.</summary>
+  public Dictionary<int, int> PlacesByObject { get; } = new();
+
+  /// <summary>DEFINES_MEMBER (25): DEFINITION node → member objects, on the object plane where nothing is
+  /// deduped. Ordinals (index-aligned in <see cref="MemberOrdByDefinition"/>) are MEMBER ordinals shared with
+  /// <see cref="DefinesOrdByDefinition"/> — join (definition, ord) to recover a member's geometry unambiguously
+  /// even when content-hash dedup shares one geometry K across definitions; successor of the
+  /// <c>@speckle.geometry_k</c> eav stamp.</summary>
+  public Dictionary<int, List<int>> MemberObjectsByDefinition { get; } = new();
+
+  /// <summary>DEFINES_MEMBER ordinals, index-aligned with <see cref="MemberObjectsByDefinition"/>.</summary>
+  public Dictionary<int, List<int>> MemberOrdByDefinition { get; } = new();
+
+  /// <summary>OBJECT_HAS_MATERIAL (26): object → MATERIAL node — placement paint on the object plane
+  /// (successor of the ord=1-tagged HAS_MATERIAL instance src). FILL semantics: geometry-level
+  /// <see cref="MaterialByGeometry"/> always wins; this fills definition geometry with no material of its own,
+  /// resolved down the placement chain (member object → placement via <see cref="PlacesByObject"/>).</summary>
+  public Dictionary<int, int> MaterialByObject { get; } = new();
+
   private Dictionary<int, List<ArtefactEdge>>? _displayByObject;
 
   /// <summary>The DISPLAY edges (object → mesh geometry) for one object, or null. Lazily indexed.</summary>
@@ -155,6 +176,24 @@ public sealed class ArtefactRelations
     list.Add(value);
   }
 }
+
+/// <summary>One field row of an AEC/Civil3D property-set DEFINITION from the optional
+/// <c>eav.property_set_definitions.parquet</c> — the set's SCHEMA only; values live per-object in eav under
+/// <c>properties.Property Sets.{set}.{field}</c> and attachment is derived from those value paths.
+/// <see cref="FieldId"/> joins <c>eav.internal_definition_name</c>; <see cref="SetKey"/> is the definition's
+/// content hash (identity under same-name collisions).</summary>
+public sealed record ArtefactPropertySetField(
+  string SetName,
+  string SetKey,
+  string FieldName,
+  int? FieldId,
+  string? DataType,
+  string? DefaultString,
+  double? DefaultDouble,
+  string? Unit,
+  string? Description,
+  string? AppliesTo
+);
 
 /// <summary>
 /// The neutral, host-agnostic parse of a Speckle 4.0 artefact bundle (the directory of
@@ -188,6 +227,17 @@ public sealed class ArtefactBundle
   /// <c>view</c>; empty if the bundle ships none. Native bakers recreate them as host named views.</summary>
   public required IReadOnlyList<ArtefactCameraView> CameraViews { get; init; }
 
+  /// <summary>MODEL/document-scoped attributes from the optional <c>eav.model.parquet</c> (object-less eav:
+  /// project information, the full reference-point transform, document settings), nested by dotted path like
+  /// <see cref="Properties"/>. Empty when the bundle ships no model file.</summary>
+  public IReadOnlyDictionary<string, object?> ModelProperties { get; init; } = new Dictionary<string, object?>();
+
+  /// <summary>AEC property-set definitions from the optional <c>eav.property_set_definitions.parquet</c>, one
+  /// row per (set, field); empty when absent. Receivers recreate host set definitions from these, falling back
+  /// to synthesizing minimal ones from the value rows when the file is missing.</summary>
+  public IReadOnlyList<ArtefactPropertySetField> PropertySetDefinitions { get; init; } =
+    Array.Empty<ArtefactPropertySetField>();
+
   /// <summary>Type-scoped properties (Revit Type Parameters / System Type Parameters, deduped once per type by
   /// <c>ObjectsArtifactPipeline.TrySplitTypeParameters</c>) resolved to each instance object that references a
   /// type via <c>eav.object_type</c> [ENG-9136]. Every object of the same type shares the SAME dictionary
@@ -218,6 +268,10 @@ public static class ArtefactBundleReader
     var typeEavT = await TryReadTableAsync(bundleDir, ".eav.type_eav.parquet", cancellationToken).ConfigureAwait(false);
     var objectTypeT = await TryReadTableAsync(bundleDir, ".eav.object_type.parquet", cancellationToken)
       .ConfigureAwait(false);
+    // Optional purpose files — absent from bundles predating them (feature-detect by presence).
+    var modelT = await TryReadTableAsync(bundleDir, ".eav.model.parquet", cancellationToken).ConfigureAwait(false);
+    var psetDefsT = await TryReadTableAsync(bundleDir, ".eav.property_set_definitions.parquet", cancellationToken)
+      .ConfigureAwait(false);
 
     var objIdToApp = BuildObjectIds(objectsT);
     var pathById = BuildPaths(pathsT);
@@ -240,6 +294,8 @@ public static class ArtefactBundleReader
       ReferencePointKind = refPointKind,
       ReferencePointOffset = refPointOffset,
       TypePropertiesByObject = LoadTypeProperties(typeEavT, objectTypeT, pathById),
+      ModelProperties = LoadModelProperties(modelT),
+      PropertySetDefinitions = LoadPropertySetDefinitions(psetDefsT),
     };
   }
 
@@ -299,6 +355,70 @@ public static class ArtefactBundleReader
       relations.ColorByObject[k] = relations.ColorByGeometry[k];
       relations.ColorByGeometry.Remove(k);
     }
+  }
+
+  // Model-scoped attributes (object-less eav): same coalesce as BuildProperties, path inlined per row.
+  private static Dictionary<string, object?> LoadModelProperties(ParquetTable? t)
+  {
+    var dict = new Dictionary<string, object?>();
+    if (t is null || !t.Has("path"))
+    {
+      return dict;
+    }
+    var path = t.Strings("path");
+    var vStr = t.Strings("value_string");
+    var vDbl = t.NullableDoubles("value_double");
+    var vBool = t.NullableBools("value_boolean");
+    for (int i = 0; i < path.Length; i++)
+    {
+      object? value =
+        vBool[i].HasValue ? vBool[i]
+        : vDbl[i].HasValue ? vDbl[i]
+        : vStr[i];
+      if (value is null || path[i] is not { Length: > 0 } p)
+      {
+        continue;
+      }
+      SetNested(dict, p, value);
+    }
+    return dict;
+  }
+
+  private static IReadOnlyList<ArtefactPropertySetField> LoadPropertySetDefinitions(ParquetTable? t)
+  {
+    if (t is null || !t.Has("set_name"))
+    {
+      return Array.Empty<ArtefactPropertySetField>();
+    }
+    var setName = t.Strings("set_name");
+    var setKey = t.Strings("set_key");
+    var fieldName = t.Strings("field_name");
+    var fieldId = t.NullableInts("field_id");
+    var dataType = t.Strings("data_type");
+    var defStr = t.Strings("default_string");
+    var defDbl = t.NullableDoubles("default_double");
+    var unit = t.Strings("unit");
+    var description = t.Strings("description");
+    var appliesTo = t.Strings("applies_to");
+    var rows = new List<ArtefactPropertySetField>(setName.Length);
+    for (int i = 0; i < setName.Length; i++)
+    {
+      rows.Add(
+        new ArtefactPropertySetField(
+          setName[i] ?? "",
+          setKey[i] ?? "",
+          fieldName[i] ?? "",
+          fieldId[i],
+          dataType[i],
+          defStr[i],
+          defDbl[i],
+          unit[i],
+          description[i],
+          appliesTo[i]
+        )
+      );
+    }
+    return rows;
   }
 
   // ENG-8947: the reference-point provision from meta (single row). Columns are nullable + additive — older
@@ -633,6 +753,20 @@ public static class ArtefactBundleReader
           break;
         case RelKind.DefinesInstance:
           sets.Add(sets.DefinesInstanceByDefinition, src[i], dst[i]);
+          break;
+        case RelKind.Places:
+          sets.PlacesByObject[src[i]] = dst[i];
+          break;
+        case RelKind.DefinesMember:
+          sets.Add(sets.MemberObjectsByDefinition, src[i], dst[i]);
+          sets.Add(sets.MemberOrdByDefinition, src[i], ord[i]);
+          break;
+        case RelKind.ObjectHasMaterial:
+          sets.MaterialByObject[src[i]] = dst[i];
+          break;
+        case RelKind.ObjectHasColor:
+          // Same consumer home as the legacy ord=1-tagged HAS_COLOR object src — one map, two vintages.
+          sets.ColorByObject[src[i]] = dst[i];
           break;
         default:
           break;

--- a/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
@@ -180,16 +180,20 @@ public sealed class ArtefactRelations
 /// <summary>One field row of an AEC/Civil3D property-set DEFINITION from the optional
 /// <c>eav.property_set_definitions.parquet</c> — the set's SCHEMA only; values live per-object in eav under
 /// <c>properties.Property Sets.{set}.{field}</c> and attachment is derived from those value paths.
-/// <see cref="FieldId"/> joins <c>eav.internal_definition_name</c>; <see cref="SetKey"/> is the definition's
-/// content hash (identity under same-name collisions).</summary>
+/// <see cref="FieldBucketId"/> is THE rebind join key — the same string the value rows ship in
+/// <c>eav.internal_definition_name</c> (null ⇒ match <see cref="FieldName"/> against the value path leaf);
+/// <see cref="SetKey"/> is the definition's content hash (SET-level identity under same-name collisions).
+/// List order is authored field order (row order in the file).</summary>
 public sealed record ArtefactPropertySetField(
   string SetName,
   string SetKey,
+  string? SetDescription,
   string FieldName,
-  int? FieldId,
+  string? FieldBucketId,
   string? DataType,
   string? DefaultString,
   double? DefaultDouble,
+  bool? DefaultBoolean,
   string? Unit,
   string? Description,
   string? AppliesTo
@@ -392,11 +396,13 @@ public static class ArtefactBundleReader
     }
     var setName = t.Strings("set_name");
     var setKey = t.Strings("set_key");
+    var setDescription = t.Strings("set_description");
     var fieldName = t.Strings("field_name");
-    var fieldId = t.NullableInts("field_id");
+    var fieldBucketId = t.Strings("field_bucket_id");
     var dataType = t.Strings("data_type");
     var defStr = t.Strings("default_string");
     var defDbl = t.NullableDoubles("default_double");
+    var defBool = t.NullableBools("default_boolean");
     var unit = t.Strings("unit");
     var description = t.Strings("description");
     var appliesTo = t.Strings("applies_to");
@@ -407,11 +413,13 @@ public static class ArtefactBundleReader
         new ArtefactPropertySetField(
           setName[i] ?? "",
           setKey[i] ?? "",
+          setDescription[i],
           fieldName[i] ?? "",
-          fieldId[i],
+          fieldBucketId[i],
           dataType[i],
           defStr[i],
           defDbl[i],
+          defBool[i],
           unit[i],
           description[i],
           appliesTo[i]

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
@@ -158,7 +158,8 @@ public sealed class EnvelopeWriter : IDisposable
     double? roughness,
     int? emissive,
     double? ior,
-    double? elevation
+    double? elevation,
+    string? ghTopology = null
   )
   {
     EnsureNotCompleted();
@@ -176,7 +177,8 @@ public sealed class EnvelopeWriter : IDisposable
       roughness,
       emissive,
       ior,
-      elevation
+      elevation,
+      ghTopology
     );
   }
 

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/ModelEavWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/ModelEavWriter.cs
@@ -1,0 +1,71 @@
+using Speckle.Bundle.Spec;
+
+namespace Speckle.Sdk.Pipelines.Send.Artifacts;
+
+/// <summary>
+/// Writer for the OPTIONAL <c>{base}.eav.model.parquet</c> — MODEL/document-scoped attributes (Revit project
+/// information / reference-point transform, Civil3D drawing settings, Grasshopper document facts): facts with
+/// no owning object, so they cannot ride <c>eav.eav</c>. Object-less eav rows:
+/// <code>
+///   {base}.eav.model.parquet(path, value_string, value_double, value_boolean, unit)
+/// </code>
+/// Exactly one value column is set per row (consumer coalesces); <c>path</c> is inlined rather than interned
+/// via <c>eav.paths</c> — the table is tiny and stays self-contained. Lazily constructed by the pipeline so a
+/// bundle with no model rows ships NO file (feature-detected by presence). Not thread-safe: calls are sequential.
+/// </summary>
+public sealed class ModelEavWriter : IDisposable
+{
+  private readonly ParquetTableWriter _rows;
+  private bool _completed;
+
+  public ModelEavWriter(string outputDir, string baseName, ParquetWriteScheduler scheduler)
+  {
+    Directory.CreateDirectory(outputDir);
+    _rows = new ParquetTableWriter(
+      System.IO.Path.Combine(outputDir, $"{baseName}.eav.model.parquet"),
+      BundleSchemas.Model,
+      BundleCols.Model.ColumnCount,
+      scheduler
+    );
+  }
+
+  /// <summary>Appends one model-scoped attribute row. Exactly one of <paramref name="valueString"/> /
+  /// <paramref name="valueDouble"/> / <paramref name="valueBoolean"/> must be set.</summary>
+  public void AddRow(string path, string? valueString, double? valueDouble, bool? valueBoolean, string? unit)
+  {
+    if (_completed)
+    {
+      throw new InvalidOperationException("Writer already completed.");
+    }
+    _rows.AddRow(path, valueString, valueDouble, valueBoolean, unit);
+  }
+
+  public void Complete()
+  {
+    if (_completed)
+    {
+      return;
+    }
+    _completed = true;
+    _rows.Complete();
+  }
+
+  public void Dispose()
+  {
+    if (_completed)
+    {
+      return;
+    }
+    _completed = true;
+    try
+    {
+      _rows.Dispose();
+    }
+#pragma warning disable CA1031 // cleanup path: swallow so the original failure propagates unmasked
+    catch (Exception)
+#pragma warning restore CA1031
+    {
+      // Intentionally ignored.
+    }
+  }
+}

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/PropertySetDefinitionsWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/PropertySetDefinitionsWriter.cs
@@ -6,11 +6,13 @@ namespace Speckle.Sdk.Pipelines.Send.Artifacts;
 /// Writer for the OPTIONAL <c>{base}.eav.property_set_definitions.parquet</c> — the SCHEMAS of AEC/Civil3D
 /// property sets, one row per (set, field):
 /// <code>
-///   {base}.eav.property_set_definitions.parquet(set_name, set_key, field_name, field_id,
-///       data_type, default_string, default_double, unit, description, applies_to)
+///   {base}.eav.property_set_definitions.parquet(set_name, set_key, set_description, field_name,
+///       field_bucket_id, data_type, default_string, default_double, default_boolean, unit,
+///       description, applies_to)
 /// </code>
-/// VALUES stay per-object in <c>eav.eav</c> (path <c>properties.Property Sets.{set}.{field}</c>, with
-/// <c>unit</c> + <c>internal_definition_name</c> = field id) and attachment is DERIVED from those value
+/// ROW ORDER IS FIELD ORDER (the authored palette order — recreate preserves it). VALUES stay per-object in
+/// <c>eav.eav</c> (path <c>properties.Property Sets.{set}.{field}</c>, with <c>unit</c> +
+/// <c>internal_definition_name</c> = the FieldBucketId) and attachment is DERIVED from those value
 /// paths — an object implements a set iff it carries rows under it. Deliberately NOT <c>type_eav</c>
 /// (whose rows an object inherits as its own attributes — schema rows there would surface as fake
 /// properties in the eav ∪ type_eav read). Replaces the managed carrier pseudo-object. Lazily constructed
@@ -33,17 +35,21 @@ public sealed class PropertySetDefinitionsWriter : IDisposable
   }
 
   /// <summary>Appends one field row of one property-set definition. <paramref name="setKey"/> is the
-  /// definition's content hash (identity under same-name collisions); <paramref name="fieldId"/> is the
-  /// host's stable field id (joins <c>eav.internal_definition_name</c>). At most one of
-  /// <paramref name="defaultString"/> / <paramref name="defaultDouble"/> may be set.</summary>
+  /// definition's content hash (SET-level identity under same-name collisions);
+  /// <paramref name="fieldBucketId"/> is THE rebind join key — the same string the value rows ship in
+  /// <c>eav.internal_definition_name</c> (null ⇒ consumers fall back to matching <paramref name="fieldName"/>
+  /// against the value path leaf). At most one of <paramref name="defaultString"/> /
+  /// <paramref name="defaultDouble"/> / <paramref name="defaultBoolean"/> may be set.</summary>
   public void AddRow(
     string setName,
     string setKey,
+    string? setDescription,
     string fieldName,
-    int? fieldId,
+    string? fieldBucketId,
     string? dataType,
     string? defaultString,
     double? defaultDouble,
+    bool? defaultBoolean,
     string? unit,
     string? description,
     string? appliesTo
@@ -53,14 +59,28 @@ public sealed class PropertySetDefinitionsWriter : IDisposable
     {
       throw new InvalidOperationException("Writer already completed.");
     }
-    if (defaultString is not null && defaultDouble is not null)
+    int defaults = (defaultString is not null ? 1 : 0) + (defaultDouble is not null ? 1 : 0) + (defaultBoolean is not null ? 1 : 0);
+    if (defaults > 1)
     {
       throw new ArgumentException(
-        $"Property-set field '{setName}.{fieldName}': at most one of defaultString/defaultDouble may be set.",
+        $"Property-set field '{setName}.{fieldName}': at most one of defaultString/defaultDouble/defaultBoolean may be set.",
         nameof(defaultDouble)
       );
     }
-    _rows.AddRow(setName, setKey, fieldName, fieldId, dataType, defaultString, defaultDouble, unit, description, appliesTo);
+    _rows.AddRow(
+      setName,
+      setKey,
+      setDescription,
+      fieldName,
+      fieldBucketId,
+      dataType,
+      defaultString,
+      defaultDouble,
+      defaultBoolean,
+      unit,
+      description,
+      appliesTo
+    );
   }
 
   public void Complete()

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/PropertySetDefinitionsWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/PropertySetDefinitionsWriter.cs
@@ -59,7 +59,8 @@ public sealed class PropertySetDefinitionsWriter : IDisposable
     {
       throw new InvalidOperationException("Writer already completed.");
     }
-    int defaults = (defaultString is not null ? 1 : 0) + (defaultDouble is not null ? 1 : 0) + (defaultBoolean is not null ? 1 : 0);
+    int defaults =
+      (defaultString is not null ? 1 : 0) + (defaultDouble is not null ? 1 : 0) + (defaultBoolean is not null ? 1 : 0);
     if (defaults > 1)
     {
       throw new ArgumentException(

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/PropertySetDefinitionsWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/PropertySetDefinitionsWriter.cs
@@ -1,0 +1,94 @@
+using Speckle.Bundle.Spec;
+
+namespace Speckle.Sdk.Pipelines.Send.Artifacts;
+
+/// <summary>
+/// Writer for the OPTIONAL <c>{base}.eav.property_set_definitions.parquet</c> — the SCHEMAS of AEC/Civil3D
+/// property sets, one row per (set, field):
+/// <code>
+///   {base}.eav.property_set_definitions.parquet(set_name, set_key, field_name, field_id,
+///       data_type, default_string, default_double, unit, description, applies_to)
+/// </code>
+/// VALUES stay per-object in <c>eav.eav</c> (path <c>properties.Property Sets.{set}.{field}</c>, with
+/// <c>unit</c> + <c>internal_definition_name</c> = field id) and attachment is DERIVED from those value
+/// paths — an object implements a set iff it carries rows under it. Deliberately NOT <c>type_eav</c>
+/// (whose rows an object inherits as its own attributes — schema rows there would surface as fake
+/// properties in the eav ∪ type_eav read). Replaces the managed carrier pseudo-object. Lazily constructed
+/// so a bundle with no definitions ships NO file. Not thread-safe: calls are sequential.
+/// </summary>
+public sealed class PropertySetDefinitionsWriter : IDisposable
+{
+  private readonly ParquetTableWriter _rows;
+  private bool _completed;
+
+  public PropertySetDefinitionsWriter(string outputDir, string baseName, ParquetWriteScheduler scheduler)
+  {
+    Directory.CreateDirectory(outputDir);
+    _rows = new ParquetTableWriter(
+      System.IO.Path.Combine(outputDir, $"{baseName}.eav.property_set_definitions.parquet"),
+      BundleSchemas.PropertySetDefinitions,
+      BundleCols.PropertySetDefinitions.ColumnCount,
+      scheduler
+    );
+  }
+
+  /// <summary>Appends one field row of one property-set definition. <paramref name="setKey"/> is the
+  /// definition's content hash (identity under same-name collisions); <paramref name="fieldId"/> is the
+  /// host's stable field id (joins <c>eav.internal_definition_name</c>). At most one of
+  /// <paramref name="defaultString"/> / <paramref name="defaultDouble"/> may be set.</summary>
+  public void AddRow(
+    string setName,
+    string setKey,
+    string fieldName,
+    int? fieldId,
+    string? dataType,
+    string? defaultString,
+    double? defaultDouble,
+    string? unit,
+    string? description,
+    string? appliesTo
+  )
+  {
+    if (_completed)
+    {
+      throw new InvalidOperationException("Writer already completed.");
+    }
+    if (defaultString is not null && defaultDouble is not null)
+    {
+      throw new ArgumentException(
+        $"Property-set field '{setName}.{fieldName}': at most one of defaultString/defaultDouble may be set.",
+        nameof(defaultDouble)
+      );
+    }
+    _rows.AddRow(setName, setKey, fieldName, fieldId, dataType, defaultString, defaultDouble, unit, description, appliesTo);
+  }
+
+  public void Complete()
+  {
+    if (_completed)
+    {
+      return;
+    }
+    _completed = true;
+    _rows.Complete();
+  }
+
+  public void Dispose()
+  {
+    if (_completed)
+    {
+      return;
+    }
+    _completed = true;
+    try
+    {
+      _rows.Dispose();
+    }
+#pragma warning disable CA1031 // cleanup path: swallow so the original failure propagates unmasked
+    catch (Exception)
+#pragma warning restore CA1031
+    {
+      // Intentionally ignored.
+    }
+  }
+}

--- a/tests/Speckle.Objects.Tests.Unit/Utils/BundleVocabAdditionsTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Utils/BundleVocabAdditionsTests.cs
@@ -82,9 +82,20 @@ public class BundleVocabAdditionsTests
         pipeline.AddModelProperty("projectInformation.buildingHeight", 42.5, "m");
         pipeline.AddModelProperty("projectInformation.isMetric", true);
 
-        // One property-set schema, two fields.
-        pipeline.AddPropertySetDefinition("Pipe Data", "ps_hash1", "Slope", 17, "Real", null, 0.0, "%", "Design slope");
-        pipeline.AddPropertySetDefinition("Pipe Data", "ps_hash1", "Service", 18, "Text", "Supply", null);
+        // One property-set schema, three fields in authored order (row order IS field order).
+        pipeline.AddPropertySetDefinition(
+          "Pipe Data",
+          "ps_hash1",
+          "Slope",
+          "SLOPE_BUCKET",
+          "Real",
+          defaultDouble: 0.0,
+          unit: "%",
+          description: "Design slope",
+          setDescription: "Hydraulic pipe data"
+        );
+        pipeline.AddPropertySetDefinition("Pipe Data", "ps_hash1", "Service", "SERVICE_BUCKET", "Text", "Supply");
+        pipeline.AddPropertySetDefinition("Pipe Data", "ps_hash1", "Insulated", null, "TrueFalse", defaultBoolean: false);
 
         pipeline.Complete();
       }
@@ -114,17 +125,23 @@ public class BundleVocabAdditionsTests
       projInfo["buildingHeight"].Should().Be(42.5);
       projInfo["isMetric"].Should().Be(true);
 
-      // Property-set schema rows.
-      bundle.PropertySetDefinitions.Should().HaveCount(2);
-      var slope = bundle.PropertySetDefinitions.Single(f => f.FieldName == "Slope");
+      // Property-set schema rows: field_bucket_id is the rebind join key; row order is authored field order.
+      bundle.PropertySetDefinitions.Should().HaveCount(3);
+      bundle.PropertySetDefinitions.Select(f => f.FieldName).Should().Equal("Slope", "Service", "Insulated");
+      var slope = bundle.PropertySetDefinitions[0];
       slope.SetName.Should().Be("Pipe Data");
       slope.SetKey.Should().Be("ps_hash1");
-      slope.FieldId.Should().Be(17);
+      slope.SetDescription.Should().Be("Hydraulic pipe data");
+      slope.FieldBucketId.Should().Be("SLOPE_BUCKET");
       slope.DataType.Should().Be("Real");
       slope.DefaultDouble.Should().Be(0.0);
       slope.Unit.Should().Be("%");
-      var service = bundle.PropertySetDefinitions.Single(f => f.FieldName == "Service");
+      var service = bundle.PropertySetDefinitions[1];
+      service.FieldBucketId.Should().Be("SERVICE_BUCKET");
       service.DefaultString.Should().Be("Supply");
+      var insulated = bundle.PropertySetDefinitions[2];
+      insulated.FieldBucketId.Should().BeNull();
+      insulated.DefaultBoolean.Should().Be(false);
     }
     finally
     {

--- a/tests/Speckle.Objects.Tests.Unit/Utils/BundleVocabAdditionsTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Utils/BundleVocabAdditionsTests.cs
@@ -1,0 +1,175 @@
+using AwesomeAssertions;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Utils;
+using Speckle.Sdk;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+namespace Speckle.Objects.Tests.Unit.Utils;
+
+/// <summary>
+/// Round-trips the post-v5 vocabulary additions: member rels PLACES(24)/DEFINES_MEMBER(25), object-plane
+/// appearance OBJECT_HAS_MATERIAL(26)/OBJECT_HAS_COLOR(27), and the optional purpose files
+/// <c>eav.model.parquet</c> / <c>eav.property_set_definitions.parquet</c>. Also guards the lazy-optional
+/// contract: a pipeline that never touches them ships NO file.
+/// </summary>
+public class BundleVocabAdditionsTests
+{
+  private static readonly SpeckleApplication TestProducer = new()
+  {
+    HostApplication = "Test",
+    HostApplicationVersion = "1.2.3",
+    Slug = "test-connector",
+    SpeckleVersion = "999.1.0-alpha.1",
+  };
+
+  private static Mesh UnitTriangle() =>
+    new()
+    {
+      vertices = new List<double> { 0, 0, 0, 1, 0, 0, 1, 1, 0 },
+      faces = new List<int> { 3, 0, 1, 2 },
+      units = "m",
+    };
+
+  [Fact]
+  public async Task MemberRels_ModelAndPropertySetFiles_RoundTrip()
+  {
+    var dir = Path.Combine(Path.GetTempPath(), "SpeckleVocabAdditions", Guid.NewGuid().ToString("N"));
+    try
+    {
+      using (var pipeline = new ObjectsArtifactPipeline(dir, "va", TestProducer))
+      {
+        // A definition with one geometry member (object 'member-1', member ord 0) and one nested
+        // placement member ('member-2' PLACES instance node) — the stamp-replacement shape.
+        int defK = pipeline.AddDefinition("chair", "Chair");
+        int gK = pipeline.AddGeometry("chair:g0", UnitTriangle());
+        pipeline.Defines(defK, gK, 0);
+        int memberObjK = pipeline.InternObject("member-1");
+        pipeline.AddProperties("member-1", new Dictionary<string, object?> { ["layer"] = "Details" });
+        pipeline.DefinesMember(defK, memberObjK, 0);
+
+        int nestedDefK = pipeline.AddDefinition("cushion", "Cushion");
+        int nestedInstK = pipeline.AddInstance(
+          "chair/cushion-0",
+          nestedDefK,
+          new double[] { 1, 0, 0, 0.5, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 },
+          "m"
+        );
+        pipeline.DefinesInstance(defK, nestedInstK, 1);
+        int nestedMemberK = pipeline.InternObject("member-2");
+        pipeline.Places(nestedMemberK, nestedInstK);
+        pipeline.DefinesMember(defK, nestedMemberK, 1);
+
+        // Object-plane appearance (fill semantics — successors of the ord-tag era).
+        int topObjK = pipeline.InternObject("chair-1");
+        int instK = pipeline.AddInstance(
+          "chair-1:placement",
+          defK,
+          new double[] { 1, 0, 0, 2, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1 },
+          "m"
+        );
+        pipeline.DisplayInstance(topObjK, instK, 0);
+        int matK = pipeline.AddMaterial("fabric", "Fabric, Blue", unchecked((int)0xFF2244CC), 1.0, 0.0, 0.8);
+        pipeline.ObjectHasMaterial(topObjK, matK);
+        int colK = pipeline.AddColor(unchecked((int)0xFFE03A2F));
+        pipeline.ObjectHasColor(topObjK, colK);
+
+        // Model-scoped attributes: the full reference-point transform + a document fact.
+        pipeline.AddModelProperty(
+          "referencePoint.transform",
+          "1,0,0,30.5,0,1,0,12.2,0,0,1,0,0,0,0,1"
+        );
+        pipeline.AddModelProperty("referencePoint.kind", "projectBasePoint");
+        pipeline.AddModelProperty("projectInformation.buildingHeight", 42.5, "m");
+        pipeline.AddModelProperty("projectInformation.isMetric", true);
+
+        // One property-set schema, two fields.
+        pipeline.AddPropertySetDefinition("Pipe Data", "ps_hash1", "Slope", 17, "Real", null, 0.0, "%", "Design slope");
+        pipeline.AddPropertySetDefinition("Pipe Data", "ps_hash1", "Service", 18, "Text", "Supply", null);
+
+        pipeline.Complete();
+      }
+
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+
+      // Member rels: (definition, ord) joins for the geometry member; PLACES for the nested one.
+      var rels = bundle.Relations;
+      int def = rels.MemberObjectsByDefinition.Keys.Single();
+      rels.MemberObjectsByDefinition[def].Should().HaveCount(2);
+      rels.MemberOrdByDefinition[def].Should().Equal(0, 1);
+      rels.PlacesByObject.Should().HaveCount(1);
+      rels.DefinesByDefinition[def].Should().HaveCount(1);
+      rels.DefinesOrdByDefinition[def].Should().Equal(0);
+
+      // Object-plane appearance landed in the object-keyed maps.
+      rels.MaterialByObject.Should().HaveCount(1);
+      rels.ColorByObject.Should().HaveCount(1);
+      rels.MaterialByGeometry.Should().BeEmpty();
+      rels.ColorByGeometry.Should().BeEmpty();
+
+      // Model file: nested by dotted path, values coalesced per type.
+      var refPoint = (Dictionary<string, object?>)bundle.ModelProperties["referencePoint"]!;
+      refPoint["transform"].Should().Be("1,0,0,30.5,0,1,0,12.2,0,0,1,0,0,0,0,1");
+      refPoint["kind"].Should().Be("projectBasePoint");
+      var projInfo = (Dictionary<string, object?>)bundle.ModelProperties["projectInformation"]!;
+      projInfo["buildingHeight"].Should().Be(42.5);
+      projInfo["isMetric"].Should().Be(true);
+
+      // Property-set schema rows.
+      bundle.PropertySetDefinitions.Should().HaveCount(2);
+      var slope = bundle.PropertySetDefinitions.Single(f => f.FieldName == "Slope");
+      slope.SetName.Should().Be("Pipe Data");
+      slope.SetKey.Should().Be("ps_hash1");
+      slope.FieldId.Should().Be(17);
+      slope.DataType.Should().Be("Real");
+      slope.DefaultDouble.Should().Be(0.0);
+      slope.Unit.Should().Be("%");
+      var service = bundle.PropertySetDefinitions.Single(f => f.FieldName == "Service");
+      service.DefaultString.Should().Be("Supply");
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+
+  [Fact]
+  public async Task OptionalFiles_AbsentWhenUnused()
+  {
+    var dir = Path.Combine(Path.GetTempPath(), "SpeckleVocabAdditions", Guid.NewGuid().ToString("N"));
+    try
+    {
+      using (var pipeline = new ObjectsArtifactPipeline(dir, "min", TestProducer))
+      {
+        int objK = pipeline.InternObject("obj-1");
+        pipeline.AddProperties(
+          "obj-1",
+          new Dictionary<string, object?>(),
+          new[] { new KeyValuePair<string, object?>("units", "m") }
+        );
+        int gK = pipeline.AddGeometry("obj-1:g0", UnitTriangle());
+        pipeline.Display(objK, gK, 0);
+        pipeline.Complete();
+      }
+
+      File.Exists(Path.Combine(dir, "min.eav.model.parquet")).Should().BeFalse();
+      File.Exists(Path.Combine(dir, "min.eav.property_set_definitions.parquet")).Should().BeFalse();
+
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+      bundle.ModelProperties.Should().BeEmpty();
+      bundle.PropertySetDefinitions.Should().BeEmpty();
+      bundle.Relations.PlacesByObject.Should().BeEmpty();
+      bundle.Relations.MemberObjectsByDefinition.Should().BeEmpty();
+      bundle.Relations.MaterialByObject.Should().BeEmpty();
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+}

--- a/tests/Speckle.Objects.Tests.Unit/Utils/BundleVocabAdditionsTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Utils/BundleVocabAdditionsTests.cs
@@ -74,10 +74,7 @@ public class BundleVocabAdditionsTests
         pipeline.ObjectHasColor(topObjK, colK);
 
         // Model-scoped attributes: the full reference-point transform + a document fact.
-        pipeline.AddModelProperty(
-          "referencePoint.transform",
-          "1,0,0,30.5,0,1,0,12.2,0,0,1,0,0,0,0,1"
-        );
+        pipeline.AddModelProperty("referencePoint.transform", "1,0,0,30.5,0,1,0,12.2,0,0,1,0,0,0,0,1");
         pipeline.AddModelProperty("referencePoint.kind", "projectBasePoint");
         pipeline.AddModelProperty("projectInformation.buildingHeight", 42.5, "m");
         pipeline.AddModelProperty("projectInformation.isMetric", true);
@@ -95,7 +92,14 @@ public class BundleVocabAdditionsTests
           setDescription: "Hydraulic pipe data"
         );
         pipeline.AddPropertySetDefinition("Pipe Data", "ps_hash1", "Service", "SERVICE_BUCKET", "Text", "Supply");
-        pipeline.AddPropertySetDefinition("Pipe Data", "ps_hash1", "Insulated", null, "TrueFalse", defaultBoolean: false);
+        pipeline.AddPropertySetDefinition(
+          "Pipe Data",
+          "ps_hash1",
+          "Insulated",
+          null,
+          "TrueFalse",
+          defaultBoolean: false
+        );
 
         pipeline.Complete();
       }

--- a/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
@@ -88,18 +88,25 @@ public sealed class EnvelopeWriterTests : IDisposable
       .Be(unchecked((int)0xFF112233u));
     Scalar(db, $"SELECT ior FROM nodes WHERE kind = {NodeKind.Material}").Should().Be(1.45);
 
-    // self-describing catalog (SOT §6) — sourced from speckle-bundle-spec (v5: live + reserved rows).
-    Scalar(db, "SELECT count(*) FROM rel_types").Should().Be(17L); // 16 live + SOLID (reserved); retired ids absent
+    // self-describing catalog (SOT §6) — sourced from speckle-bundle-spec (live + reserved rows; retired absent).
+    // Count derives from the generated catalog so a spec vocabulary change never dead-reckons here again.
+    Scalar(db, "SELECT count(*) FROM rel_types").Should().Be((long)Speckle.Bundle.Spec.Catalog.RelTypes.Length);
     Scalar(db, "SELECT count(*) FROM node_kinds").Should().Be(6L); // COLLECTION folded into CONTAINER
     Scalar(db, $"SELECT name FROM rel_types WHERE rel = {RelKind.DisplayInstance}").Should().Be("DISPLAY_INSTANCE");
     Scalar(db, $"SELECT name FROM rel_types WHERE rel = {RelKind.DefinesInstance}").Should().Be("DEFINES_INSTANCE");
     // DEFINES (4) is now geometry-only; DEFINES_INSTANCE (9) carries node→node nesting. rel fixes dst namespace.
     Scalar(db, $"SELECT dst_ns FROM rel_types WHERE rel = {RelKind.Defines}").Should().Be("geometry");
     Scalar(db, $"SELECT dst_ns FROM rel_types WHERE rel = {RelKind.DefinesInstance}").Should().Be("node");
-    // HAS_MATERIAL src broadened to geometry|instance (ENG-8849) — a material can hang off an instance too.
-    Scalar(db, $"SELECT src_ns FROM rel_types WHERE rel = {RelKind.HasMaterial}").Should().Be("geometry|instance");
-    // ENG-8849 (spec d485e68): HAS_MATERIAL src broadened to geometry|instance — instances can carry material overrides.
-    Scalar(db, $"SELECT src_ns FROM rel_types WHERE rel = {RelKind.HasMaterial}").Should().Be("geometry|instance");
+    // HAS_MATERIAL src is geometry-only again (union removed post-v5): placement paint moved to
+    // OBJECT_HAS_MATERIAL (26); the ord=1-tag era is a read-side fallback, not the vocabulary.
+    Scalar(db, $"SELECT src_ns FROM rel_types WHERE rel = {RelKind.HasMaterial}").Should().Be("geometry");
+    Scalar(db, $"SELECT name FROM rel_types WHERE rel = {RelKind.Places}").Should().Be("PLACES");
+    Scalar(db, $"SELECT src_ns FROM rel_types WHERE rel = {RelKind.DefinesMember}").Should().Be("node");
+    Scalar(db, $"SELECT dst_ns FROM rel_types WHERE rel = {RelKind.DefinesMember}").Should().Be("object");
+    Scalar(db, $"SELECT src_ns FROM rel_types WHERE rel = {RelKind.ObjectHasMaterial}").Should().Be("object");
+    Scalar(db, $"SELECT src_ns FROM rel_types WHERE rel = {RelKind.ObjectHasColor}").Should().Be("object");
+    // Post-v5 union removal: HAS_MATERIAL src is geometry-only; instance paint is OBJECT_HAS_MATERIAL (26).
+    Scalar(db, $"SELECT src_ns FROM rel_types WHERE rel = {RelKind.HasMaterial}").Should().Be("geometry");
     // IN_MODEL (11) → CONTAINER node; the default-projection top key (SOT §8).
     Scalar(db, $"SELECT name FROM rel_types WHERE rel = {RelKind.InModel}").Should().Be("IN_MODEL");
     Scalar(db, $"SELECT dst_ns FROM rel_types WHERE rel = {RelKind.InModel}").Should().Be("node");
@@ -118,7 +125,8 @@ public sealed class EnvelopeWriterTests : IDisposable
     Scalar(db, "SELECT name FROM rel_types WHERE rel = 22").Should().Be("HOSTED_ON");
     Scalar(db, "SELECT dst_ns FROM rel_types WHERE rel = 22").Should().Be("object");
     // retired ids (IN_NETWORK 15, IN_SPACE 13, …) are absent from the catalog.
-    Scalar(db, "SELECT count(*) FROM rel_types WHERE rel IN (13, 15, 16, 18, 19, 20)").Should().Be(0L);
+    // 18 (IN_ASSEMBLY) was un-retired upstream and ships again; the rest stay retired-in-place.
+    Scalar(db, "SELECT count(*) FROM rel_types WHERE rel IN (13, 15, 16, 19, 20)").Should().Be(0L);
     Scalar(db, "SELECT schema_version FROM meta").Should().Be(5);
 
     // No scene views / camera views authored ⇒ the tables are absent (consumer feature-detects by file presence).

--- a/tests/Speckle.Sdk.Tests.Unit/Pipelines/Send/Artifacts/ParquetTableWriterTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Pipelines/Send/Artifacts/ParquetTableWriterTests.cs
@@ -56,7 +56,7 @@ public class ParquetTableWriterTests : IDisposable
       .Throw<ArgumentException>()
       .WithMessage($"*{path}*")
       .WithMessage("*12 value(s)*")
-      .WithMessage("*14-column*")
+      .WithMessage($"*{BundleCols.Nodes.ColumnCount}-column*")
       .WithMessage("*emissive, ior*");
   }
 
@@ -70,7 +70,10 @@ public class ParquetTableWriterTests : IDisposable
     var row = NodeRow(0);
     var act = () => writer.AddRow([.. row, "surplus"]);
 
-    act.Should().Throw<ArgumentException>().WithMessage("*15 value(s)*").WithMessage("*14-column*");
+    act.Should()
+      .Throw<ArgumentException>()
+      .WithMessage($"*{BundleCols.Nodes.ColumnCount + 1} value(s)*")
+      .WithMessage($"*{BundleCols.Nodes.ColumnCount}-column*");
   }
 
   [Fact]


### PR DESCRIPTION
SDK side of spec`@oguzhan/bundle-vocab-additions` (rels 24 PLACES / 25 DEFINES_MEMBER / 26 OBJECT_HAS_MATERIAL / 27 OBJECT_HAS_COLOR + two new optional eav files + nodes.gh_topology).

- RelKind facade + typed pipeline helpers (`Places`/`DefinesMember`/`ObjectHasMaterial`/`ObjectHasColor`) with semantics doc-comments.
- New lazy writers: `{base}.eav.model.parquet` (`AddModelProperty`) and `{base}.eav.property_set_definitions.parquet` (`AddPropertySetDefinition`) — no rows ⇒ no file.
- Receive: `PlacesByObject`, `MemberObjectsByDefinition`/`MemberOrdByDefinition` ((definition, ord) join), `MaterialByObject`, optional `ModelProperties`/`PropertySetDefinitions` readers; legacy ord=1-stamp fallbacks untouched.
- `AddNode` gains optional `ghTopology`; arity-guard tests now derive counts from `BundleCols.Nodes.ColumnCount`.

Tests: 945/945 + 225/1-skip on net8+net10. **Builds against the sibling speckle-bundle-spec working tree — requires that repo's same-named branch.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)