### PR TITLE
feat(envelope): rels 28/29 — container appearance (NODE_HAS_MATERIAL / NODE_HAS_COLOR)

### DIFF
--- a/.github/actions/checkout-bundle-spec/action.yml
+++ b/.github/actions/checkout-bundle-spec/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/checkout@v7
       with:
         repository: specklesystems/speckle-bundle-spec
-        ref: 0bc4769c9f475b8bce94ea5d76c1f1a91c56bee8
+        ref: a980a8eb0354307d9e1ff18fee4ed93b7558cc61
         token: ${{ inputs.token }}
         path: speckle-bundle-spec
         persist-credentials: false

--- a/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
@@ -525,6 +525,16 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   public void ObjectHasColor(int objectK, int colorK) =>
     _envelopeWriter.AddRelation(RelKind.ObjectHasColor, objectK, colorK, 0);
 
+  /// <summary>node → node(MATERIAL): container appearance (rel 28, NODE_HAS_MATERIAL) — e.g. a
+  /// CONTAINER's authored material.</summary>
+  public void NodeHasMaterial(int nodeK, int materialK) =>
+    _envelopeWriter.AddRelation(RelKind.NodeHasMaterial, nodeK, materialK, 0);
+
+  /// <summary>node → node(COLOR): container display colour (rel 29, NODE_HAS_COLOR) — e.g. a layer/tag
+  /// colour as a first-class COLOR node instead of the CONTAINER argb overload.</summary>
+  public void NodeHasColor(int nodeK, int colorK) =>
+    _envelopeWriter.AddRelation(RelKind.NodeHasColor, nodeK, colorK, 0);
+
   // ── structural results ─────────────────────────────────────────────────────────────────
 
   /// <summary>

--- a/src/Speckle.Sdk.Parquet/Pipelines/Nodes.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Nodes.cs
@@ -32,6 +32,8 @@ public static class RelKind
   public const byte DefinesMember = (byte)SpecRel.DEFINES_MEMBER;
   public const byte ObjectHasMaterial = (byte)SpecRel.OBJECT_HAS_MATERIAL;
   public const byte ObjectHasColor = (byte)SpecRel.OBJECT_HAS_COLOR;
+  public const byte NodeHasMaterial = (byte)SpecRel.NODE_HAS_MATERIAL;
+  public const byte NodeHasColor = (byte)SpecRel.NODE_HAS_COLOR;
 }
 
 /// <summary>Value-node kinds in the envelope <c>nodes</c> table — a thin facade over the generated

--- a/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
@@ -145,6 +145,14 @@ public sealed class ArtefactRelations
   /// resolved down the placement chain (member object → placement via <see cref="PlacesByObject"/>).</summary>
   public Dictionary<int, int> MaterialByObject { get; } = new();
 
+  /// <summary>NODE_HAS_MATERIAL (28): node → MATERIAL node — container appearance (e.g. a CONTAINER's
+  /// authored material). Node-plane sibling of <see cref="MaterialByObject"/>.</summary>
+  public Dictionary<int, int> MaterialByNode { get; } = new();
+
+  /// <summary>NODE_HAS_COLOR (29): node → COLOR node — container display colour (e.g. a layer/tag colour
+  /// as a first-class COLOR node rather than the CONTAINER argb overload).</summary>
+  public Dictionary<int, int> ColorByNode { get; } = new();
+
   private Dictionary<int, List<ArtefactEdge>>? _displayByObject;
 
   /// <summary>The DISPLAY edges (object → mesh geometry) for one object, or null. Lazily indexed.</summary>
@@ -775,6 +783,12 @@ public static class ArtefactBundleReader
         case RelKind.ObjectHasColor:
           // Same consumer home as the legacy ord=1-tagged HAS_COLOR object src — one map, two vintages.
           sets.ColorByObject[src[i]] = dst[i];
+          break;
+        case RelKind.NodeHasMaterial:
+          sets.MaterialByNode[src[i]] = dst[i];
+          break;
+        case RelKind.NodeHasColor:
+          sets.ColorByNode[src[i]] = dst[i];
           break;
         default:
           break;

--- a/tests/Speckle.Objects.Tests.Unit/Utils/BundleVocabAdditionsTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Utils/BundleVocabAdditionsTests.cs
@@ -73,6 +73,11 @@ public class BundleVocabAdditionsTests
         int colK = pipeline.AddColor(unchecked((int)0xFFE03A2F));
         pipeline.ObjectHasColor(topObjK, colK);
 
+        // Container appearance (rels 28/29): a CONTAINER node carrying material + colour.
+        int tagK = pipeline.AddContainer("tag:Interiors", "Interiors", null, "Collection");
+        pipeline.NodeHasMaterial(tagK, matK);
+        pipeline.NodeHasColor(tagK, colK);
+
         // Model-scoped attributes: the full reference-point transform + a document fact.
         pipeline.AddModelProperty("referencePoint.transform", "1,0,0,30.5,0,1,0,12.2,0,0,1,0,0,0,0,1");
         pipeline.AddModelProperty("referencePoint.kind", "projectBasePoint");
@@ -117,6 +122,8 @@ public class BundleVocabAdditionsTests
 
       // Object-plane appearance landed in the object-keyed maps.
       rels.MaterialByObject.Should().HaveCount(1);
+      rels.MaterialByNode.Should().HaveCount(1);
+      rels.ColorByNode.Should().HaveCount(1);
       rels.ColorByObject.Should().HaveCount(1);
       rels.MaterialByGeometry.Should().BeEmpty();
       rels.ColorByGeometry.Should().BeEmpty();


### PR DESCRIPTION
SDK alignment for speckle-bundle-spec #18 (rels 28 NODE_HAS_MATERIAL / 29 NODE_HAS_COLOR, node → node container appearance).

- RelKind facade entries from the generated Rel enum
- Pipeline helpers `NodeHasMaterial`/`NodeHasColor` with spec semantics
- Receive maps `MaterialByNode`/`ColorByNode` on ArtefactRelations
- Round-trip test (CONTAINER carrying material + colour); CI spec pin → a980a8e

Tests: 945/945 + 225/1-skip, both TFMs. Consumers feature-detect by rel presence — additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)