### PR TITLE
feat(receive): SceneViewResolver resolves container appearance (NODE_HAS_COLOR/NODE_HAS_MATERIAL)

### DIFF
--- a/src/Speckle.Sdk/Pipelines/Receive/Artifacts/SceneViewResolver.cs
+++ b/src/Speckle.Sdk/Pipelines/Receive/Artifacts/SceneViewResolver.cs
@@ -44,7 +44,26 @@ public static class SceneViewResolver
   /// tiers, so a host can colour layers, not just name them. eav tiers carry no node → null colour.</summary>
   public static IReadOnlyList<(string Name, int? Argb)> SegmentsWithColor(ArtefactBundle bundle, int objK)
   {
-    var segments = new List<(string, int?)>();
+    var appearance = SegmentsWithAppearance(bundle, objK);
+    var segments = new List<(string, int?)>(appearance.Count);
+    foreach (var (name, argb, _) in appearance)
+    {
+      segments.Add((name, argb));
+    }
+    return segments;
+  }
+
+  /// <summary>Like <see cref="SegmentsWithColor"/> but resolves each node ("rel") segment's full appearance: colour
+  /// prefers the node's NODE_HAS_COLOR edge (its COLOR node's argb) over the legacy argb stamped directly on the
+  /// container row (pre-vocab bundles), and the segment carries its node K so a host can look up NODE_HAS_MATERIAL
+  /// (<see cref="ArtefactRelations.MaterialByNode"/>) against whatever material it baked. eav tiers carry no node →
+  /// null colour and null node K.</summary>
+  public static IReadOnlyList<(string Name, int? Argb, int? NodeK)> SegmentsWithAppearance(
+    ArtefactBundle bundle,
+    int objK
+  )
+  {
+    var segments = new List<(string, int?, int?)>();
     foreach (var tier in bundle.DefaultSceneView)
     {
       if (tier.Source == "rel")
@@ -55,12 +74,12 @@ public static class SceneViewResolver
           && map.TryGetValue(objK, out int nodeK)
         )
         {
-          segments.AddRange(NodeAncestryWithColor(bundle.Nodes, nodeK));
+          segments.AddRange(NodeAncestryWithAppearance(bundle, nodeK));
         }
       }
       else if (tier.Source == "eav" && ResolveEav(bundle.Properties, objK, tier.Ref) is { Length: > 0 } val)
       {
-        segments.Add((val, null));
+        segments.Add((val, null, null));
       }
     }
     return segments;
@@ -79,6 +98,30 @@ public static class SceneViewResolver
     while (cursor is int c && nodes.TryGetValue(c, out var n) && guard++ < ANCESTRY_GUARD)
     {
       result.Insert(0, (n.Name is { Length: > 0 } nm ? nm : "unnamed", n.Argb));
+      cursor = n.DefRef;
+    }
+    return result;
+  }
+
+  /// <summary>A node + its grouping ancestry, outermost→leaf, each with its resolved colour (NODE_HAS_COLOR edge
+  /// first, the node's own argb as the pre-vocab fallback) and its node K (for NODE_HAS_MATERIAL lookups).</summary>
+  public static IReadOnlyList<(string Name, int? Argb, int? NodeK)> NodeAncestryWithAppearance(
+    ArtefactBundle bundle,
+    int nodeK
+  )
+  {
+    var result = new List<(string, int?, int?)>();
+    int? cursor = nodeK;
+    int guard = 0;
+    while (cursor is int c && bundle.Nodes.TryGetValue(c, out var n) && guard++ < ANCESTRY_GUARD)
+    {
+      int? argb =
+        bundle.Relations.ColorByNode.TryGetValue(c, out int colorK)
+        && bundle.Nodes.TryGetValue(colorK, out var colorNode)
+        && colorNode.Kind == NodeKind.Color
+          ? colorNode.Argb
+          : n.Argb;
+      result.Insert(0, (n.Name is { Length: > 0 } nm ? nm : "unnamed", argb, c));
       cursor = n.DefRef;
     }
     return result;


### PR DESCRIPTION
## What

- New SegmentsWithAppearance: each node-tier segment carries its resolved colour and its node K, so hosts can look up NODE_HAS_MATERIAL (Relations.MaterialByNode) against whatever material they baked.
- Colour resolution prefers the NODE_HAS_COLOR edge (the COLOR node argb) and falls back to the argb stamped directly on the container row (pre-vocab bundles).
- SegmentsWithColor delegates to it, so every existing caller (AutoCAD, member layers) becomes edge-aware with no signature change.

## Why

Consumer half of bundle-spec rels 28/29 (container appearance): Rhino/AutoCAD layers now ship colour as a first-class edge instead of the undocumented CONTAINER argb stamp, and Rhino layers ship their authored render material for the first time. Connector side: speckle-sharp-connectors oguzhan/bundle-vocab-additions (bdf66dbd7).

## What's a "segment"?

One name in an object's grouping path — one level of the nested layer tree, outermost → leaf.

An object on the Rhino layer `05.MATERIALS > 2.layer > 2.render` is, in the bundle, an
`IN_COLLECTION` edge to the leaf CONTAINER node (`2.render`), which chains to its parents via
`def_ref`. The resolver walks that chain and returns:

[("05.MATERIALS", argb?, nodeK), ("2.layer", argb?, nodeK), ("2.render", argb?, nodeK)]

Each tuple is a segment: one container's name + its resolved appearance. Appearance is per
segment because every level of the layer tree can carry its own colour/material, not just the
leaf. Colour resolution per segment: the node's NODE_HAS_COLOR edge → that COLOR node's argb;
fallback to the argb stamped directly on the container row (pre-vocab bundles). The node K lets
the host look up NODE_HAS_MATERIAL (`Relations.MaterialByNode`) against whatever material it baked.

Hosts then project the same segments differently: Rhino recreates each segment as a real nested
layer (applying that segment's own colour/material as it goes); AutoCAD has no layer nesting, so
it joins the names into one flat layer and colours it from the innermost segment that carries a
colour. eav-sourced tiers (group-by-property) contribute a segment with no node behind it — which
is why colour and node K are nullable.