### PR TITLE
feat!(envelope): reference point rides eav.model only — meta.referenc…

### DIFF
--- a/.github/actions/checkout-bundle-spec/action.yml
+++ b/.github/actions/checkout-bundle-spec/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/checkout@v7
       with:
         repository: specklesystems/speckle-bundle-spec
-        ref: a980a8eb0354307d9e1ff18fee4ed93b7558cc61
+        ref: 3932569cb833ad2e597e4927d8490585dc4e49c6
         token: ${{ inputs.token }}
         path: speckle-bundle-spec
         persist-credentials: false

--- a/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactPipeline.cs
@@ -664,12 +664,6 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   /// model units, forward/up unit vectors, <see cref="CameraView.Fov"/> vertical DEGREES (perspective only).</summary>
   public void AddCameraView(CameraView view) => _envelopeWriter.AddCameraView(view);
 
-  /// <summary>Records the applied reference-point re-basing in the bundle <c>meta</c> so it is recoverable
-  /// downstream (federation/georeferencing). <paramref name="kind"/> ∈ <c>projectBasePoint | surveyPoint |
-  /// internalOriginFallback</c> (null = internal origin); <paramref name="offset"/> is <c>"x,y,z"</c> in display
-  /// units — the vector subtracted from world-space output. Call before <see cref="Complete"/>.</summary>
-  public void SetReferencePoint(string? kind, string? offset) => _envelopeWriter.SetReferencePoint(kind, offset);
-
   /// <summary>
   /// Records the producer information of this bundle in the <c>meta</c> file.
   /// </summary>

--- a/src/Speckle.Objects/Utils/ObjectsArtifactReader.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactReader.cs
@@ -133,27 +133,43 @@ public sealed class ObjectsArtifactReader
   // ENG-8947: rebuild the v1 root reference-point transform from the meta offset. Only the translation kinds carry an
   // offset; the display-unit offset is converted to feet (the internal unit v1 applies the transform in) and packed as
   // the 16-value matrix (identity basis + translation) ReferencePointHelper.GetTransformFromRootObject expects.
+  // The reference-point record rides eav.model (referencePoint.kind/.transform/.units — the former
+  // meta.reference_point_* columns are removed from the spec). transform is the FULL rigid transform,
+  // 16 row-major doubles in referencePoint.units (InstanceProxy layout, translation at 3/7/11); re-emitted
+  // here in the legacy root layout (basis columns first, translation at 12–14, internal feet).
   private static Dictionary<string, object>? BuildReferencePointRootValue(ArtefactBundle bundle)
   {
-    if (bundle.ReferencePointOffset is not { Length: > 0 } offsetCsv)
+    if (
+      !bundle.ModelProperties.TryGetValue("referencePoint", out var rpObj)
+      || rpObj is not Dictionary<string, object?> rp
+      || !rp.TryGetValue("transform", out var tObj)
+      || tObj is not string transformCsv
+    )
     {
       return null;
     }
-    var parts = offsetCsv.Split(',');
-    if (parts.Length != 3)
+    var parts = transformCsv.Split(',');
+    if (parts.Length != 16)
     {
       return null;
     }
-    var o = new double[3];
-    for (int i = 0; i < 3; i++)
+    var d = new double[16];
+    for (int i = 0; i < 16; i++)
     {
-      if (!double.TryParse(parts[i], NumberStyles.Float, CultureInfo.InvariantCulture, out o[i]))
+      if (!double.TryParse(parts[i], NumberStyles.Float, CultureInfo.InvariantCulture, out d[i]))
       {
         return null;
       }
     }
-    double toFeet = Units.GetConversionFactor(bundle.Units, Units.Feet);
-    var m = new double[] { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, o[0] * toFeet, o[1] * toFeet, o[2] * toFeet, 1 };
+    string units = rp.TryGetValue("units", out var uObj) && uObj is string u && u.Length > 0 ? u : bundle.Units;
+    double toFeet = Units.GetConversionFactor(units, Units.Feet);
+    var m = new double[]
+    {
+      d[0], d[4], d[8], 0,
+      d[1], d[5], d[9], 0,
+      d[2], d[6], d[10], 0,
+      d[3] * toFeet, d[7] * toFeet, d[11] * toFeet, 1,
+    };
     return new Dictionary<string, object> { ["transform"] = m };
   }
 

--- a/src/Speckle.Objects/Utils/ObjectsArtifactReader.cs
+++ b/src/Speckle.Objects/Utils/ObjectsArtifactReader.cs
@@ -130,13 +130,12 @@ public sealed class ObjectsArtifactReader
     return root;
   }
 
-  // ENG-8947: rebuild the v1 root reference-point transform from the meta offset. Only the translation kinds carry an
-  // offset; the display-unit offset is converted to feet (the internal unit v1 applies the transform in) and packed as
-  // the 16-value matrix (identity basis + translation) ReferencePointHelper.GetTransformFromRootObject expects.
-  // The reference-point record rides eav.model (referencePoint.kind/.transform/.units — the former
-  // meta.reference_point_* columns are removed from the spec). transform is the FULL rigid transform,
-  // 16 row-major doubles in referencePoint.units (InstanceProxy layout, translation at 3/7/11); re-emitted
-  // here in the legacy root layout (basis columns first, translation at 12–14, internal feet).
+  // ENG-8947: rebuild the v1 root reference-point transform from the eav.model record
+  // (referencePoint.kind/.transform/.units — the former meta.reference_point_* columns are removed from the
+  // spec). transform is the FULL rigid transform, 16 row-major doubles in referencePoint.units (InstanceProxy
+  // layout, translation at 3/7/11); re-emitted here in the legacy root layout
+  // ReferencePointHelper.GetTransformFromRootObject expects (basis columns first, translation at 12–14,
+  // internal feet — the unit v1 applies the transform in).
   private static Dictionary<string, object>? BuildReferencePointRootValue(ArtefactBundle bundle)
   {
     if (
@@ -165,10 +164,22 @@ public sealed class ObjectsArtifactReader
     double toFeet = Units.GetConversionFactor(units, Units.Feet);
     var m = new double[]
     {
-      d[0], d[4], d[8], 0,
-      d[1], d[5], d[9], 0,
-      d[2], d[6], d[10], 0,
-      d[3] * toFeet, d[7] * toFeet, d[11] * toFeet, 1,
+      d[0],
+      d[4],
+      d[8],
+      0,
+      d[1],
+      d[5],
+      d[9],
+      0,
+      d[2],
+      d[6],
+      d[10],
+      0,
+      d[3] * toFeet,
+      d[7] * toFeet,
+      d[11] * toFeet,
+      1,
     };
     return new Dictionary<string, object> { ["transform"] = m };
   }

--- a/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
@@ -224,13 +224,6 @@ public sealed class ArtefactBundle
   public required ArtefactRelations Relations { get; init; }
   public required string Units { get; init; }
 
-  /// <summary>ENG-8947 reference-point provision from the bundle <c>meta</c> (null = internal origin / absent).
-  /// <see cref="ReferencePointKind"/> ∈ <c>projectBasePoint | surveyPoint | internalOriginFallback</c>;
-  /// <see cref="ReferencePointOffset"/> is <c>"x,y,z"</c> in <see cref="Units"/> — the vector subtracted from
-  /// world-space output (null for the fallback / non-translation kinds).</summary>
-  public string? ReferencePointKind { get; init; }
-  public string? ReferencePointOffset { get; init; }
-
   /// <summary>The default scene view's grouping tiers (outermost→innermost), or empty if the bundle has none. Drives
   /// the received layer hierarchy (e.g. Revit: Model → Level → Category → Family).</summary>
   public required IReadOnlyList<SceneViewTier> DefaultSceneView { get; init; }
@@ -275,7 +268,6 @@ public static class ArtefactBundleReader
       .ConfigureAwait(false);
     var cameraViewsT = await TryReadTableAsync(bundleDir, ".envelope.camera_views.parquet", cancellationToken)
       .ConfigureAwait(false);
-    var metaT = await TryReadTableAsync(bundleDir, ".envelope.meta.parquet", cancellationToken).ConfigureAwait(false);
     // Type-scoped params (ENG-9136) — additive tables, absent from bundles predating type splitting.
     var typeEavT = await TryReadTableAsync(bundleDir, ".eav.type_eav.parquet", cancellationToken).ConfigureAwait(false);
     var objectTypeT = await TryReadTableAsync(bundleDir, ".eav.object_type.parquet", cancellationToken)
@@ -288,7 +280,6 @@ public static class ArtefactBundleReader
     var objIdToApp = BuildObjectIds(objectsT);
     var pathById = BuildPaths(pathsT);
     var propsByObject = BuildProperties(eavT, pathById, "object_index");
-    var (refPointKind, refPointOffset) = LoadReferencePoint(metaT);
     var geometries = LoadGeometries(geometriesTables);
     var relations = LoadRelations(relationsT);
     RecoverUntaggedObjectColors(relations, geometries, objIdToApp);
@@ -303,8 +294,6 @@ public static class ArtefactBundleReader
       Units = InferUnits(propsByObject),
       DefaultSceneView = LoadDefaultSceneView(sceneViewsT),
       CameraViews = LoadCameraViews(cameraViewsT),
-      ReferencePointKind = refPointKind,
-      ReferencePointOffset = refPointOffset,
       TypePropertiesByObject = LoadTypeProperties(typeEavT, objectTypeT, pathById),
       ModelProperties = LoadModelProperties(modelT),
       PropertySetDefinitions = LoadPropertySetDefinitions(psetDefsT),
@@ -439,19 +428,6 @@ public static class ArtefactBundleReader
 
   // ENG-8947: the reference-point provision from meta (single row). Columns are nullable + additive — older
   // bundles without them yield (null, null), i.e. internal origin.
-  private static (string? kind, string? offset) LoadReferencePoint(ParquetTable? t)
-  {
-    if (t is null || !t.Has("reference_point_kind"))
-    {
-      return (null, null);
-    }
-    var kinds = t.Strings("reference_point_kind");
-    var offsets = t.Has("reference_point_offset") ? t.Strings("reference_point_offset") : null;
-    var kind = kinds.Length > 0 ? kinds[0] : null;
-    var offset = offsets is { Length: > 0 } ? offsets[0] : null;
-    return (kind, offset);
-  }
-
   // object→node relations (per envelope rel_types) whose target node can form a scene-view grouping tier.
   private static readonly HashSet<int> s_objectNodeRels = new()
   {

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
@@ -70,9 +70,8 @@ public sealed record CameraView(
 ///         metalness, roughness, emissive, ior, elevation)
 ///   {base}.envelope.{rel_types,node_kinds}.parquet             -- self-describing catalog (SOT §6)
 ///   {base}.envelope.meta.parquet(schema_version,               -- catalog + provenance: who produced the
-///         produced_by, reference_point_kind|_offset,              bundle, with which SDK, and when
-///         producer_version, sdk_name, sdk_version,                migrated, from which graph vintage
-///         migrated_from_schema_version)
+///         produced_by, producer_version, sdk_name,                bundle, with which SDK, and when
+///         sdk_version, migrated_from_schema_version)              migrated, from which graph vintage
 ///   {base}.envelope.scene_views.parquet(view, name,           -- producer-authored grouping projections
 ///         is_default, ord, source, ref)                          (SOT §8); absent if none
 ///   {base}.envelope.camera_views.parquet(view, name,          -- named camera viewpoints
@@ -99,12 +98,6 @@ public sealed class EnvelopeWriter : IDisposable
   private readonly List<SceneView> _sceneViews = new();
   private readonly List<CameraView> _cameraViews = new();
   private bool _completed;
-
-  // ENG-8947: reference-point provision recorded in meta when a producer re-based geometry by a source
-  // reference point. kind ∈ projectBasePoint | surveyPoint | internalOriginFallback; offset "x,y,z" in
-  // display units (the vector subtracted). Both null = internal origin (no re-basing). See SetReferencePoint.
-  private string? _referencePointKind;
-  private string? _referencePointOffset;
 
   private string? _producedBy;
   private string? _producerVersion;
@@ -199,18 +192,6 @@ public sealed class EnvelopeWriter : IDisposable
   }
 
   /// <summary>
-  /// ENG-8947: records the applied reference-point re-basing in <c>meta</c> (written at <see cref="Complete"/>).
-  /// <paramref name="kind"/> ∈ <c>projectBasePoint | surveyPoint | internalOriginFallback</c> (null = internal
-  /// origin); <paramref name="offset"/> is <c>"x,y,z"</c> in display units — the vector subtracted from world-space
-  /// output (null when not a translation re-basing). Call before <see cref="Complete"/>.
-  /// </summary>
-  public void SetReferencePoint(string? kind, string? offset)
-  {
-    _referencePointKind = kind;
-    _referencePointOffset = offset;
-  }
-
-  /// <summary>
   /// Records the producer information of this bundle in the <c>meta</c> file.
   /// </summary>
   /// <param name="producedBy">slug of the producer of this version</param>
@@ -264,10 +245,10 @@ public sealed class EnvelopeWriter : IDisposable
     SafeDispose(_nodes);
   }
 
-  // meta (SOT §6): schema version + producer provenance + the ENG-8947 reference-point provision. Written at
-  // Complete() (not eagerly in the ctor) so producers can record their identity via SetProducer and a
-  // reference-point re-basing via SetReferencePoint first. Only reference_point_* and
-  // migrated_from_schema_version are conditional → NULL columns (readers that ignore them are unaffected).
+  // meta (SOT §6): schema version + producer provenance. Written at Complete() (not eagerly in the ctor) so
+  // producers can record their identity via SetProducer first. The reference-point record does NOT live here —
+  // it rides eav.model as referencePoint.* rows (the former meta.reference_point_* columns are removed from the
+  // spec; the xyz-only offsets lost rotation and meta is the wrong home for model data).
   private void WriteMeta()
   {
     using var meta = new ParquetTableWriter(
@@ -275,8 +256,6 @@ public sealed class EnvelopeWriter : IDisposable
       new ParquetSchema(
         I("schema_version"),
         S("produced_by"),
-        S("reference_point_kind"),
-        S("reference_point_offset"),
         S("producer_version"),
         S("sdk_name"),
         S("sdk_version"),
@@ -287,8 +266,6 @@ public sealed class EnvelopeWriter : IDisposable
     meta.AddRow(
       SpecBundle.SchemaVersion,
       _producedBy,
-      _referencePointKind,
-      _referencePointOffset,
       _producerVersion,
       _sdkName,
       _sdkVersion,

--- a/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
@@ -210,13 +210,7 @@ public sealed class EnvelopeWriterTests : IDisposable
     db.Open();
     View(db, "meta");
 
-    Scalar(
-        db,
-        @"SELECT count(*) FROM meta WHERE migrated_from_schema_version IS NULL
-            AND reference_point_kind IS NULL AND reference_point_offset IS NULL"
-      )
-      .Should()
-      .Be(1L);
+    Scalar(db, "SELECT count(*) FROM meta WHERE migrated_from_schema_version IS NULL").Should().Be(1L);
   }
 
   [Fact]


### PR DESCRIPTION
…e_point_* removed

SetReferencePoint and the meta reference_point_kind/_offset columns are gone (spec: oguzhan/retire-meta-reference-point). The record is the eav.model referencePoint.kind/.transform/.units rows — the full rigid transform, so sharedCoordinates' true-north rotation survives where the xyz-only meta offset lost it. ArtefactBundle no longer surfaces the meta pair; ObjectsArtifactReader's legacy root value now parses the model row (row-major 16, scaled via referencePoint.units).