### PR TITLE
feat: carry v3 Grasshopper collection topology into nodes.gh_topology

### DIFF
--- a/src/Speckle.Sdk.BundleMigrator/Migration/PipelineExtensions.cs
+++ b/src/Speckle.Sdk.BundleMigrator/Migration/PipelineExtensions.cs
@@ -70,6 +70,12 @@ internal static class PipelineExtensions
     }
 #pragma warning restore CS0618 // Type or member is obsolete
 
+    // Vertex- or face-less meshes are not handled properly by the datgen (writes NaN into viewer.idx, which culls the WHOLE scene.)
+    if (geometry is Mesh { vertices.Count: 0 } or Mesh { faces.Count: 0 })
+    {
+      return null;
+    }
+
     return pipeline.AddGeometry(appId, geometry);
   }
 

--- a/src/Speckle.Sdk.BundleMigrator/Migration/Stats.cs
+++ b/src/Speckle.Sdk.BundleMigrator/Migration/Stats.cs
@@ -54,6 +54,10 @@ internal sealed class Stats
   // Root `referencePointTransform` re-emitted as referencePoint.* eav.model rows (ENG-9060).
   public int ReferencePoints;
 
+  // v3 Civil3D root `propertySetDefinitions` re-emitted as eav.property_set_definitions rows (ENG-9062).
+  public int PropertySets;
+  public int PropertySetFields;
+
   // v3 CSi root `analysisResults` flattened into structural_results, unit scalars into eav.model (ENG-9076).
   public int StructuralResultRows;
   public int StructuralElmFallbacks; // element name didn't resolve to a sent object; its raw name rides `location`
@@ -89,7 +93,7 @@ internal sealed class Stats
              IN_ROOM={InRoomEdges} CONNECTS_TO={ConnectsToEdges} SUBELEMENT(host)={HostSubelementEdges} IN_MODEL={InModelEdges}
       nodes: DEFINITION={Definitions} INSTANCE(def)={DefinitionInstances} MATERIAL={Materials} COLOR={Colors} LEVEL={Levels} COLLECTION={Collections} (ghTopology={GhTopologies}) GROUP={Groups} CAMERA_VIEW={CameraViews} MODEL={Models}
       structuralResults: rows={StructuralResultRows} elmFallback={StructuralElmFallbacks} skippedTypes={SkippedResultTypes} unitRows={ModelUnitRows}
-      referencePoints={ReferencePoints}
+      referencePoints={ReferencePoints}  propertySets={PropertySets} (fields={PropertySetFields})
       skipped (ref not in graph): {SkippedDangling}  (DEFINES={SkippedDefines} HAS_MATERIAL={SkippedMaterial} HAS_COLOR={SkippedColor} ON_LEVEL={SkippedLevel} IN_GROUP={SkippedGroup} IN_ROOM={SkippedRoom} CONNECTS_TO={SkippedConnects} SUBELEMENT(host)={SkippedHostParent})  byBlockColorProxies={ByBlockColorProxies}
       """;
 }

--- a/src/Speckle.Sdk.BundleMigrator/Migration/Stats.cs
+++ b/src/Speckle.Sdk.BundleMigrator/Migration/Stats.cs
@@ -24,6 +24,9 @@ internal sealed class Stats
   public int OnLevelEdges;
   public int Collections;
   public int InCollectionEdges;
+
+  // Grasshopper data-tree topology strings carried onto collection nodes (nodes.gh_topology).
+  public int GhTopologies;
   public int Groups;
   public int InGroupEdges;
   public int DefinitionGeometries;
@@ -84,7 +87,7 @@ internal sealed class Stats
              DEFINES={DefinesEdges} DEFINES_INSTANCE={DefinesInstanceEdges} HAS_MATERIAL={HasMaterialEdges} HAS_COLOR={HasColorEdges} ON_LEVEL={OnLevelEdges} IN_COLLECTION={InCollectionEdges} IN_GROUP={InGroupEdges}
              OBJECT_HAS_MATERIAL={ObjectHasMaterialEdges} OBJECT_HAS_COLOR={ObjectHasColorEdges} NODE_HAS_MATERIAL={NodeHasMaterialEdges} NODE_HAS_COLOR={NodeHasColorEdges}
              IN_ROOM={InRoomEdges} CONNECTS_TO={ConnectsToEdges} SUBELEMENT(host)={HostSubelementEdges} IN_MODEL={InModelEdges}
-      nodes: DEFINITION={Definitions} INSTANCE(def)={DefinitionInstances} MATERIAL={Materials} COLOR={Colors} LEVEL={Levels} COLLECTION={Collections} GROUP={Groups} CAMERA_VIEW={CameraViews} MODEL={Models}
+      nodes: DEFINITION={Definitions} INSTANCE(def)={DefinitionInstances} MATERIAL={Materials} COLOR={Colors} LEVEL={Levels} COLLECTION={Collections} (ghTopology={GhTopologies}) GROUP={Groups} CAMERA_VIEW={CameraViews} MODEL={Models}
       structuralResults: rows={StructuralResultRows} elmFallback={StructuralElmFallbacks} skippedTypes={SkippedResultTypes} unitRows={ModelUnitRows}
       referencePoints={ReferencePoints}
       skipped (ref not in graph): {SkippedDangling}  (DEFINES={SkippedDefines} HAS_MATERIAL={SkippedMaterial} HAS_COLOR={SkippedColor} ON_LEVEL={SkippedLevel} IN_GROUP={SkippedGroup} IN_ROOM={SkippedRoom} CONNECTS_TO={SkippedConnects} SUBELEMENT(host)={SkippedHostParent})  byBlockColorProxies={ByBlockColorProxies}

--- a/src/Speckle.Sdk.BundleMigrator/Migration/V3GraphArtifactProducer.cs
+++ b/src/Speckle.Sdk.BundleMigrator/Migration/V3GraphArtifactProducer.cs
@@ -1,5 +1,7 @@
 using System.Collections;
 using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
 using Speckle.Objects.Geometry;
 using Speckle.Objects.Other;
 using Speckle.Objects.Utils;
@@ -148,6 +150,7 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
     EmitCameraViews(root);
     EmitStructuralResults(root);
     EmitReferencePoint(root);
+    EmitPropertySetDefinitions(root);
     EmitSceneView();
 
     _stats.Geometries = _seenGeometryAppIds.Count;
@@ -1013,6 +1016,91 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
     }
     return m.ToArray();
   }
+
+  // v3 Civil3D root `propertySetDefinitions` → eav.property_set_definitions rows, one per field in dict
+  // (authored) order. Values already ride eav at properties.Property Sets.*; attachment derives from those paths.
+  private void EmitPropertySetDefinitions(Base root)
+  {
+    var raw = root["propertySetDefinitions"] ?? root["@propertySetDefinitions"];
+    if (raw is null)
+    {
+      return;
+    }
+    if (raw is not Dictionary<string, object?> sets)
+    {
+      _stats.Notes.Add("root propertySetDefinitions skipped: not a dictionary");
+      return;
+    }
+
+    foreach (var (setName, setValue) in sets)
+    {
+      if (
+        setValue is not Dictionary<string, object?> set
+        || set.GetValueOrDefault("propertyDefinitions") is not Dictionary<string, object?> { Count: > 0 } fieldDefs
+      )
+      {
+        _stats.Notes.Add($"property set '{setName}' skipped: no field definitions");
+        continue;
+      }
+
+      var setKey = ComputePropertySetKey(setName, fieldDefs);
+      var emitted = 0;
+      foreach (var (fieldName, fieldValue) in fieldDefs)
+      {
+        if (fieldValue is not Dictionary<string, object?> fd)
+        {
+          _stats.Notes.Add($"property set '{setName}' field '{fieldName}' skipped: not a definition");
+          continue;
+        }
+        var (defaultString, defaultDouble, defaultBoolean) = SplitPropertyDefault(fd.GetValueOrDefault("defaultValue"));
+        pipeline.AddPropertySetDefinition(
+          setName,
+          setKey,
+          fieldName,
+          fieldBucketId: null, // not recorded by v3; consumers fall back to matching fieldName
+          fd.GetValueOrDefault("dataType") as string,
+          defaultString,
+          defaultDouble,
+          defaultBoolean,
+          fd.GetValueOrDefault("units") as string,
+          fd.GetValueOrDefault("description") as string
+        );
+        emitted++;
+      }
+      if (emitted > 0)
+      {
+        _stats.PropertySets++;
+        _stats.PropertySetFields += emitted;
+      }
+    }
+  }
+
+  // Must stay byte-identical with PropertySetDefinitionLadder.ComputeSetKey (speckle-sharp-connectors) and
+  // dwgextract: sha256_hex_uppercase(setName + "\n" + join("\n", field|dataType|unit) in field order).
+  private static string ComputePropertySetKey(string setName, Dictionary<string, object?> fieldDefs)
+  {
+    var parts = new List<string> { setName };
+    foreach (var (fieldName, fieldValue) in fieldDefs)
+    {
+      if (fieldValue is Dictionary<string, object?> fd)
+      {
+        parts.Add(
+          $"{fieldName}|{fd.GetValueOrDefault("dataType") as string}|{fd.GetValueOrDefault("units") as string}"
+        );
+      }
+    }
+    return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(string.Join("\n", parts))));
+  }
+
+  // The file's exactly-one-of defaults rule, split the way the native v4 send does.
+  private static (string? S, double? D, bool? B) SplitPropertyDefault(object? value) =>
+    value switch
+    {
+      null => (null, null, null),
+      bool b => (null, null, b),
+      IConvertible c and not string => (null, Convert.ToDouble(c, CultureInfo.InvariantCulture), null),
+      _ => (value.ToString() is { Length: > 0 } s ? s : null, null, null),
+    };
 
   private void EmitSceneView()
   {

--- a/src/Speckle.Sdk.BundleMigrator/Migration/V3GraphArtifactProducer.cs
+++ b/src/Speckle.Sdk.BundleMigrator/Migration/V3GraphArtifactProducer.cs
@@ -115,9 +115,20 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
 
         // Parent is a Collection except at the root, which is skipped above and never mapped → top-level (null).
         int? parentK = _collectionMap.TryGetValue(helper.Aid(parent.Current), out var pk) ? pk : null;
-        var k = pipeline.AddCollection(helper.CollectionKey(col), col.name, parentK, helper.CollectionSubtype(col));
+        var ghTopology = ReadGhTopology(col);
+        var k = pipeline.AddCollection(
+          helper.CollectionKey(col),
+          col.name,
+          parentK,
+          helper.CollectionSubtype(col),
+          ghTopology
+        );
         _collectionMap[helper.Aid(col)] = k;
         _stats.Collections++;
+        if (ghTopology is not null)
+        {
+          _stats.GhTopologies++;
+        }
         continue;
       }
 
@@ -142,6 +153,23 @@ internal sealed class V3GraphArtifactProducer(ObjectsArtifactPipeline pipeline, 
     _stats.Geometries = _seenGeometryAppIds.Count;
     pipeline.Complete();
     return _stats;
+  }
+
+  // v3 Grasshopper carries its data-tree paths as a dynamic `topology` string on each collection
+  // (SpeckleCollectionWrapper.Topology); the bundle carries it verbatim as nodes.gh_topology.
+  // The connector writes an explicit null on collections without an authored tree.
+  private string? ReadGhTopology(Collection col)
+  {
+    var raw = col["topology"] ?? col["@topology"];
+    if (raw is string s && !string.IsNullOrWhiteSpace(s))
+    {
+      return s;
+    }
+    if (raw is not null and not string)
+    {
+      _stats.Notes.Add($"collection '{col.name}' topology skipped: not a string");
+    }
+    return null;
   }
 
   // Every atomic object belongs to its nearest ancestor collection (IN_COLLECTION), regardless of what sits

--- a/tests/Speckle.Sdk.BundleMigrator.Tests/Global.cs
+++ b/tests/Speckle.Sdk.BundleMigrator.Tests/Global.cs
@@ -1,0 +1,1 @@
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Speckle.Sdk.BundleMigrator.Tests/V3GraphArtifactProducerGhTopologyTests.cs
+++ b/tests/Speckle.Sdk.BundleMigrator.Tests/V3GraphArtifactProducerGhTopologyTests.cs
@@ -1,0 +1,147 @@
+using AwesomeAssertions;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Utils;
+using Speckle.Sdk.BundleMigrator.Migration;
+using Speckle.Sdk.Host;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Models.Collections;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+namespace Speckle.Sdk.BundleMigrator.Tests;
+
+/// <summary>
+/// Guards the v3 Grasshopper `topology` passthrough: the connector's dynamic data-tree string on each
+/// collection (e.g. <c>0-1 0;0-1</c>) lands verbatim on the container node's <c>gh_topology</c> column,
+/// while the explicit nulls it writes on non-tree collections stay null.
+/// </summary>
+public class V3GraphArtifactProducerGhTopologyTests
+{
+  public V3GraphArtifactProducerGhTopologyTests()
+  {
+    TypeLoader.Reset();
+    TypeLoader.Initialize(typeof(Base).Assembly, typeof(Mesh).Assembly);
+  }
+
+  private static readonly SpeckleApplication TestProducer = new()
+  {
+    HostApplication = "Test",
+    HostApplicationVersion = "1.2.3",
+    Slug = "test-connector",
+    SpeckleVersion = "999.1.0-alpha.1",
+  };
+
+  private static Mesh UnitMesh(string appId) =>
+    new()
+    {
+      vertices = new List<double> { 0, 0, 0, 1, 0, 0, 1, 1, 0 },
+      faces = new List<int> { 3, 0, 1, 2 },
+      units = "m",
+      applicationId = appId,
+      id = appId,
+    };
+
+  private static Collection MakeCollection(string name, string? topology, params Base[] elements)
+  {
+    var col = new Collection { name = name, applicationId = name };
+    col["topology"] = topology;
+    col.elements.AddRange(elements);
+    return col;
+  }
+
+  private static Stats Migrate(Collection root, string dir)
+  {
+    using var producer = new V3GraphArtifactProducer(
+      new ObjectsArtifactPipeline(dir, "v3", TestProducer),
+      new ArtifactHelper()
+    );
+    return producer.Produce(root);
+  }
+
+  private static string TempDir() =>
+    Path.Combine(Path.GetTempPath(), "SpeckleV3GhTopology", Guid.NewGuid().ToString("N"));
+
+  private static ArtefactNode NodeByName(ArtefactBundle bundle, string name) =>
+    bundle.Nodes.Values.Single(n => n.Name == name);
+
+  [Fact]
+  public async Task TopologyStrings_LandVerbatimOnContainerNodes()
+  {
+    var dir = TempDir();
+    try
+    {
+      // Mirrors the real GH shape: root → tree collection → nested tree collection → objects.
+      var inner = MakeCollection("Stacked Tower", "0-1", UnitMesh("m1"));
+      var outer = MakeCollection("Sub-Collection 1", "0-1 0;0-1", UnitMesh("m2"), inner);
+      var root = new Collection { name = "root", applicationId = "root", elements = { outer } };
+
+      var stats = Migrate(root, dir);
+
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+      NodeByName(bundle, "Sub-Collection 1").GhTopology.Should().Be("0-1 0;0-1");
+      NodeByName(bundle, "Stacked Tower").GhTopology.Should().Be("0-1");
+      stats.GhTopologies.Should().Be(2);
+      stats.Notes.Should().BeEmpty();
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+
+  [Fact]
+  public async Task NullOrAbsentTopology_StaysNull()
+  {
+    var dir = TempDir();
+    try
+    {
+      // GH writes an explicit null on collections without an authored tree; other producers omit the key.
+      var explicitNull = MakeCollection("L1", null, UnitMesh("m1"));
+      var noKey = new Collection { name = "L2", applicationId = "L2", elements = { UnitMesh("m2") } };
+      var root = new Collection { name = "root", applicationId = "root", elements = { explicitNull, noKey } };
+
+      var stats = Migrate(root, dir);
+
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+      NodeByName(bundle, "L1").GhTopology.Should().BeNull();
+      NodeByName(bundle, "L2").GhTopology.Should().BeNull();
+      stats.GhTopologies.Should().Be(0);
+      stats.Notes.Should().BeEmpty();
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+
+  [Fact]
+  public async Task NonStringTopology_SkippedWithNote()
+  {
+    var dir = TempDir();
+    try
+    {
+      var col = MakeCollection("odd", null, UnitMesh("m1"));
+      col["topology"] = 42L;
+      var root = new Collection { name = "root", applicationId = "root", elements = { col } };
+
+      var stats = Migrate(root, dir);
+
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+      NodeByName(bundle, "odd").GhTopology.Should().BeNull();
+      stats.GhTopologies.Should().Be(0);
+      stats.Notes.Should().ContainSingle(n => n.Contains("topology"));
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+}

--- a/tests/Speckle.Sdk.BundleMigrator.Tests/V3GraphArtifactProducerGhTopologyTests.cs
+++ b/tests/Speckle.Sdk.BundleMigrator.Tests/V3GraphArtifactProducerGhTopologyTests.cs
@@ -72,7 +72,12 @@ public class V3GraphArtifactProducerGhTopologyTests
       // Mirrors the real GH shape: root → tree collection → nested tree collection → objects.
       var inner = MakeCollection("Stacked Tower", "0-1", UnitMesh("m1"));
       var outer = MakeCollection("Sub-Collection 1", "0-1 0;0-1", UnitMesh("m2"), inner);
-      var root = new Collection { name = "root", applicationId = "root", elements = { outer } };
+      var root = new Collection
+      {
+        name = "root",
+        applicationId = "root",
+        elements = { outer },
+      };
 
       var stats = Migrate(root, dir);
 
@@ -99,8 +104,18 @@ public class V3GraphArtifactProducerGhTopologyTests
     {
       // GH writes an explicit null on collections without an authored tree; other producers omit the key.
       var explicitNull = MakeCollection("L1", null, UnitMesh("m1"));
-      var noKey = new Collection { name = "L2", applicationId = "L2", elements = { UnitMesh("m2") } };
-      var root = new Collection { name = "root", applicationId = "root", elements = { explicitNull, noKey } };
+      var noKey = new Collection
+      {
+        name = "L2",
+        applicationId = "L2",
+        elements = { UnitMesh("m2") },
+      };
+      var root = new Collection
+      {
+        name = "root",
+        applicationId = "root",
+        elements = { explicitNull, noKey },
+      };
 
       var stats = Migrate(root, dir);
 
@@ -127,7 +142,12 @@ public class V3GraphArtifactProducerGhTopologyTests
     {
       var col = MakeCollection("odd", null, UnitMesh("m1"));
       col["topology"] = 42L;
-      var root = new Collection { name = "root", applicationId = "root", elements = { col } };
+      var root = new Collection
+      {
+        name = "root",
+        applicationId = "root",
+        elements = { col },
+      };
 
       var stats = Migrate(root, dir);
 

--- a/tests/Speckle.Sdk.BundleMigrator.Tests/V3GraphArtifactProducerPropertySetTests.cs
+++ b/tests/Speckle.Sdk.BundleMigrator.Tests/V3GraphArtifactProducerPropertySetTests.cs
@@ -1,0 +1,224 @@
+using System.Security.Cryptography;
+using System.Text;
+using AwesomeAssertions;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Utils;
+using Speckle.Sdk.BundleMigrator.Migration;
+using Speckle.Sdk.Host;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Models.Collections;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+namespace Speckle.Sdk.BundleMigrator.Tests;
+
+/// <summary>
+/// Guards ENG-9062: a v3 Civil3D root's <c>propertySetDefinitions</c> re-emits as
+/// <c>eav.property_set_definitions</c> rows — one per field in authored (dict) order, native defaults split,
+/// the shared set_key recipe — and a root without it produces no file.
+/// </summary>
+public class V3GraphArtifactProducerPropertySetTests
+{
+  public V3GraphArtifactProducerPropertySetTests()
+  {
+    TypeLoader.Reset();
+    TypeLoader.Initialize(typeof(Base).Assembly, typeof(Mesh).Assembly);
+  }
+
+  private static readonly SpeckleApplication TestProducer = new()
+  {
+    HostApplication = "Test",
+    HostApplicationVersion = "1.2.3",
+    Slug = "test-connector",
+    SpeckleVersion = "999.1.0-alpha.1",
+  };
+
+  private static Collection RootWithMesh() =>
+    new()
+    {
+      name = "root",
+      applicationId = "root",
+      elements =
+      {
+        new Mesh
+        {
+          vertices = new List<double> { 0, 0, 0, 1, 0, 0, 1, 1, 0 },
+          faces = new List<int> { 3, 0, 1, 2 },
+          units = "m",
+          applicationId = "m1",
+          id = "m1",
+        },
+      },
+    };
+
+  private static Stats Migrate(Collection root, string dir)
+  {
+    using var producer = new V3GraphArtifactProducer(
+      new ObjectsArtifactPipeline(dir, "v3", TestProducer),
+      new ArtifactHelper()
+    );
+    return producer.Produce(root);
+  }
+
+  private static string TempDir() =>
+    Path.Combine(Path.GetTempPath(), "SpeckleV3PropSets", Guid.NewGuid().ToString("N"));
+
+  private static Dictionary<string, object?> D(params (string Key, object? Value)[] entries)
+  {
+    var d = new Dictionary<string, object?>();
+    foreach (var (key, value) in entries)
+    {
+      d[key] = value;
+    }
+    return d;
+  }
+
+  private static Dictionary<string, object?> SetDefinition(string name, Dictionary<string, object?> fieldDefs) =>
+    D(("name", name), ("propertyDefinitions", fieldDefs));
+
+  private static string ExpectedSetKey(string material) =>
+    Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(material)));
+
+  [Fact]
+  public async Task Definitions_MapToSpecRows_InDictOrder()
+  {
+    var dir = TempDir();
+    try
+    {
+      var root = RootWithMesh();
+      root["propertySetDefinitions"] = D(
+        (
+          "Pipe Data",
+          SetDefinition(
+            "Pipe Data",
+            D(
+              (
+                "Slope",
+                D(
+                  ("name", "Slope"),
+                  ("description", "Design slope"),
+                  ("id", 1L),
+                  ("dataType", "Real"),
+                  ("defaultValue", 2L), // integral JSON deserializes as long → default_double
+                  ("units", "%")
+                )
+              ),
+              ("Service", D(("dataType", "Text"), ("defaultValue", "Supply"))),
+              ("Insulated", D(("dataType", "TrueFalse"), ("defaultValue", false)))
+            )
+          )
+        )
+      );
+
+      var stats = Migrate(root, dir);
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+      var rows = bundle.PropertySetDefinitions;
+
+      rows.Should().HaveCount(3);
+      rows.Select(r => r.FieldName).Should().Equal("Slope", "Service", "Insulated");
+      rows.Should().OnlyContain(r => r.SetName == "Pipe Data");
+      var expectedKey = ExpectedSetKey("Pipe Data\nSlope|Real|%\nService|Text|\nInsulated|TrueFalse|");
+      rows.Should().OnlyContain(r => r.SetKey == expectedKey);
+      rows.Should().OnlyContain(r => r.FieldBucketId == null && r.SetDescription == null && r.AppliesTo == null);
+
+      var slope = rows[0];
+      (slope.DataType, slope.Unit, slope.Description).Should().Be(("Real", "%", "Design slope"));
+      (slope.DefaultDouble, slope.DefaultString, slope.DefaultBoolean).Should().Be((2.0, null, null));
+      (rows[1].DefaultString, rows[1].DefaultDouble, rows[1].DefaultBoolean).Should().Be(("Supply", null, null));
+      (rows[2].DefaultBoolean, rows[2].DefaultString, rows[2].DefaultDouble).Should().Be((false, null, null));
+
+      stats.PropertySets.Should().Be(1);
+      stats.PropertySetFields.Should().Be(3);
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+
+  [Fact]
+  public async Task DetachedRootKey_IsAlsoRead()
+  {
+    var dir = TempDir();
+    try
+    {
+      var root = RootWithMesh();
+      root["@propertySetDefinitions"] = D(("Minimal", SetDefinition("Minimal", D(("Depth", D(("dataType", "Real")))))));
+
+      var stats = Migrate(root, dir);
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+
+      var row = bundle.PropertySetDefinitions.Should().ContainSingle().Subject;
+      (row.SetName, row.FieldName, row.DataType).Should().Be(("Minimal", "Depth", "Real"));
+      (row.DefaultString, row.DefaultDouble, row.DefaultBoolean).Should().Be((null, null, null));
+      stats.PropertySets.Should().Be(1);
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+
+  [Fact]
+  public async Task NoRootKey_ProducesNoFile()
+  {
+    var dir = TempDir();
+    try
+    {
+      var stats = Migrate(RootWithMesh(), dir);
+
+      File.Exists(Path.Combine(dir, "v3.eav.property_set_definitions.parquet")).Should().BeFalse();
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+      bundle.PropertySetDefinitions.Should().BeEmpty();
+      stats.PropertySets.Should().Be(0);
+      stats.PropertySetFields.Should().Be(0);
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+
+  [Fact]
+  public async Task MalformedEntries_SkippedWithNotes_ValidRowsStillEmitted()
+  {
+    var dir = TempDir();
+    try
+    {
+      var root = RootWithMesh();
+      root["propertySetDefinitions"] = D(
+        ("NotADict", "nope"),
+        ("NoFields", D(("name", "NoFields"))),
+        ("Good", SetDefinition("Good", D(("Width", D(("dataType", "Real"), ("units", "mm"))), ("Broken", 5L))))
+      );
+
+      var stats = Migrate(root, dir);
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+
+      var row = bundle.PropertySetDefinitions.Should().ContainSingle().Subject;
+      (row.SetName, row.FieldName, row.Unit).Should().Be(("Good", "Width", "mm"));
+      row.SetKey.Should().Be(ExpectedSetKey("Good\nWidth|Real|mm")); // non-dict fields excluded from the hash too
+
+      stats.PropertySets.Should().Be(1);
+      stats.PropertySetFields.Should().Be(1);
+      stats.Notes.Should().Contain(n => n.Contains("NotADict"));
+      stats.Notes.Should().Contain(n => n.Contains("NoFields"));
+      stats.Notes.Should().Contain(n => n.Contains("Broken"));
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+}


### PR DESCRIPTION
The v3 GH connector stores its data-tree paths as a dynamic `topology` string on each collection; pass it through AddCollection's existing ghTopology parameter so a migrated bundle round-trips the tree.