### PR TITLE
fix(parquet): concat multi-row-group columns by actual element type

### DIFF
--- a/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ParquetTableReader.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ParquetTableReader.cs
@@ -51,10 +51,18 @@ public static class ParquetTableReader
     return new ParquetTable(columns, rowCount, Array.ConvertAll(fields, f => f.Name));
   }
 
-  // Concatenates the per-row-group column arrays into one array of the column's element type. The element type is
-  // the field's CLR type (nullable for optional columns), so Array.Copy preserves null slots.
-  private static Array Concat(List<Array> chunks, Type elementType)
+  // Concatenates the per-row-group column arrays into one array. The element type is taken from the chunks
+  // themselves, NOT from DataField.ClrType: Parquet.Net reports the non-nullable type for optional columns
+  // (int for an optional int32) while ReadColumnAsync hands back int?[], and Array.Copy from int?[] into an
+  // int[] throws ArrayTypeMismatchException. Only multi-row-group files (large models) reach the copy. A file
+  // with no row groups at all (an optional table written empty) has no chunk to take the type from, so the
+  // schema type is used for the zero-length result — element type is immaterial when there are no elements.
+  private static Array Concat(List<Array> chunks, Type emptyElementType)
   {
+    if (chunks.Count == 0)
+    {
+      return Array.CreateInstance(emptyElementType, 0);
+    }
     if (chunks.Count == 1)
     {
       return chunks[0];
@@ -64,6 +72,9 @@ public static class ParquetTableReader
     {
       total += c.Length;
     }
+    var elementType =
+      chunks[0].GetType().GetElementType()
+      ?? throw new InvalidOperationException($"Row-group column data is not an array: {chunks[0].GetType()}");
     var result = Array.CreateInstance(elementType, total);
     int offset = 0;
     foreach (var c in chunks)

--- a/tests/Speckle.Sdk.Tests.Unit/Pipelines/Receive/Artifacts/ParquetTableReaderTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Pipelines/Receive/Artifacts/ParquetTableReaderTests.cs
@@ -1,0 +1,96 @@
+using AwesomeAssertions;
+using Speckle.Bundle.Spec;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using Speckle.Sdk.Pipelines.Send.Artifacts;
+
+namespace Speckle.Sdk.Tests.Unit.Pipelines.Receive.Artifacts;
+
+/// <summary>
+/// Guards the multi-row-group concat in <see cref="ParquetTableReader"/>. Parquet.Net's <c>DataField.ClrType</c>
+/// is the non-nullable type for optional columns while the column data comes back as <c>T?[]</c>; building the
+/// merged array from <c>ClrType</c> made <c>Array.Copy</c> throw
+/// <see cref="ArrayTypeMismatchException"/> ("Source array type cannot be assigned to destination array type")
+/// on every table large enough to have been flushed into more than one row group — i.e. only on big models.
+/// </summary>
+public class ParquetTableReaderTests : IDisposable
+{
+  private readonly string _dir = Path.Combine(Path.GetTempPath(), $"parquet-table-reader-{Guid.NewGuid():N}");
+
+  public ParquetTableReaderTests()
+  {
+    Directory.CreateDirectory(_dir);
+  }
+
+  public void Dispose()
+  {
+    if (Directory.Exists(_dir))
+    {
+      Directory.Delete(_dir, recursive: true);
+    }
+  }
+
+  private static object?[] NodeRow(int id, int? argb, double? ior)
+  {
+    var row = new object?[BundleCols.Nodes.ColumnCount];
+    row[BundleCols.Nodes.Id] = id;
+    row[BundleCols.Nodes.Kind] = 1;
+    row[BundleCols.Nodes.Argb] = argb;
+    row[BundleCols.Nodes.Ior] = ior;
+    return row;
+  }
+
+  [Fact]
+  public async Task ReadAsync_MultipleRowGroups_ConcatenatesNullableValueTypeColumns()
+  {
+    var path = Path.Combine(_dir, "nodes.parquet");
+    using (var scheduler = new ParquetWriteScheduler())
+    {
+      // flushRows: 2 → 5 rows land in 3 row groups, forcing the concat path.
+      using (
+        var writer = new ParquetTableWriter(
+          path,
+          BundleSchemas.Nodes,
+          BundleCols.Nodes.ColumnCount,
+          scheduler,
+          flushRows: 2
+        )
+      )
+      {
+        writer.AddRow(NodeRow(0, 0xFF0000, 1.5));
+        writer.AddRow(NodeRow(1, null, null));
+        writer.AddRow(NodeRow(2, 0x00FF00, null));
+        writer.AddRow(NodeRow(3, null, 2.25));
+        writer.AddRow(NodeRow(4, 0x0000FF, 3.0));
+        writer.Complete();
+      }
+      scheduler.CompleteAndWait();
+    }
+
+    var table = await ParquetTableReader.ReadAsync(path);
+
+    table.RowCount.Should().Be(5);
+    table.Ints("id").Should().Equal(0, 1, 2, 3, 4);
+    table.NullableInts("argb").Should().Equal(0xFF0000, null, 0x00FF00, null, 0x0000FF);
+    table.NullableDoubles("ior").Should().Equal(1.5, null, null, 2.25, 3.0);
+  }
+
+  [Fact]
+  public async Task ReadAsync_NoRows_ReturnsEmptyTable()
+  {
+    var path = Path.Combine(_dir, "nodes.parquet");
+    using (var scheduler = new ParquetWriteScheduler())
+    {
+      using (var writer = new ParquetTableWriter(path, BundleSchemas.Nodes, BundleCols.Nodes.ColumnCount, scheduler))
+      {
+        writer.Complete();
+      }
+      scheduler.CompleteAndWait();
+    }
+
+    var table = await ParquetTableReader.ReadAsync(path);
+
+    table.RowCount.Should().Be(0);
+    table.NullableInts("argb").Should().BeEmpty();
+    table.Strings("name").Should().BeEmpty();
+  }
+}


### PR DESCRIPTION
ParquetTableReader.Concat built the merged array from DataField.ClrType, which Parquet.Net reports as the non-nullable type for optional columns (int for an optional int32) while ReadColumnAsync returns int?[]. The Array.Copy from int?[] into int[] threw ArrayTypeMismatchException ("Source array type cannot be assigned to destination array type") on receive. Only tables flushed into more than one row group hit Concat, so this surfaced only on large models.

Derive the element type from the first chunk instead, and add a regression test that writes nodes across three row groups with nullable argb/ior columns and reads them back.


Claude-Session: https://claude.ai/code/session_01LYp7uL5muz5euHKwQ5pK2M