### PR TITLE
fix: Fix minor migrator bugs

### DIFF
--- a/src/Speckle.Sdk.BundleMigrator/LargeStackRunner.cs
+++ b/src/Speckle.Sdk.BundleMigrator/LargeStackRunner.cs
@@ -1,0 +1,47 @@
+namespace Speckle.Sdk.BundleMigrator;
+
+/// <summary>
+/// Runs work on a dedicated thread with a large stack reservation. The legacy deserializer recurses one stack
+/// level per level of detached-object nesting, and every await on the packfile path completes synchronously, so a
+/// deep v2 tree overflows the ~1 MB default of a pool thread. The reservation is virtual — pages are committed only
+/// as the recursion actually uses them.
+/// </summary>
+internal static class LargeStackRunner
+{
+  public const int StackSize = 512 * 1024 * 1024;
+
+  /// <summary>
+  /// The work stays on the large-stack thread only while its awaits complete synchronously; a genuinely
+  /// asynchronous await resumes on the pool with a default stack.
+  /// </summary>
+  public static Task<T> Run<T>(Func<Task<T>> work, string threadName)
+  {
+    var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+    var thread = new Thread(
+      () =>
+      {
+        try
+        {
+          tcs.SetResult(work().GetAwaiter().GetResult());
+        }
+        catch (OperationCanceledException oce)
+        {
+          tcs.SetCanceled(oce.CancellationToken);
+        }
+#pragma warning disable CA1031 // marshalled to the awaiting caller, not swallowed
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+          tcs.SetException(ex);
+        }
+      },
+      StackSize
+    )
+    {
+      IsBackground = true,
+      Name = threadName,
+    };
+    thread.Start();
+    return tcs.Task;
+  }
+}

--- a/src/Speckle.Sdk.BundleMigrator/Migration/ArtifactHelper.cs
+++ b/src/Speckle.Sdk.BundleMigrator/Migration/ArtifactHelper.cs
@@ -77,8 +77,9 @@ internal sealed class ArtifactHelper
     string? typeKey
   ) ExtractProperties(Base obj, string linkedModelSuffix = "")
   {
+    // `properties` is non-nullable on DataObject, but v3 payloads with `"properties": null` deserialize to null.
     IReadOnlyDictionary<string, object?> props = obj is DataObject dobj
-      ? dobj.properties
+      ? (IReadOnlyDictionary<string, object?>?)dobj.properties ?? s_emptyProperties
       : obj.GetMembers(DynamicBaseMemberType.Instance | DynamicBaseMemberType.Dynamic);
 
     // `level` is the level NAME and lives at the top level (not under properties), so it must be listed here.
@@ -95,6 +96,8 @@ internal sealed class ArtifactHelper
 
     return (props, rootScalars, DeriveTypeKey(obj, linkedModelSuffix));
   }
+
+  private static readonly IReadOnlyDictionary<string, object?> s_emptyProperties = new Dictionary<string, object?>();
 
   // v3 Revit ships no type id; the only universal discriminator is the display triple at the object root,
   // document-scoped by the linked-placement suffix. "none" is v3's no-type sentinel — those stay inline in eav.

--- a/src/Speckle.Sdk.BundleMigrator/Migration/PipelineExtensions.cs
+++ b/src/Speckle.Sdk.BundleMigrator/Migration/PipelineExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Objects;
+using Speckle.Objects;
 using Speckle.Objects.Geometry;
 using Speckle.Objects.Primitive;
 using Speckle.Objects.Utils;
@@ -22,17 +22,12 @@ internal static class PipelineExtensions
 #pragma warning disable CS0618 // Type or member is obsolete
     // A v2 Brep that leaked into displayValue, or a v3 Grasshopper BrepX/ExtrusionX/SubDX nested there: only its
     // (single) display mesh is encodable here — the caller emits the raw solid. Recurse so the mesh is checked too.
-    var displayMeshes = geometry switch
+    if (geometry is Brep or RawEncodedObject)
     {
-      Brep b => b.displayValue,
-      RawEncodedObject x => x.displayValue,
-      _ => null,
-    };
-#pragma warning restore CS0618
-    if (displayMeshes is not null)
-    {
-      return displayMeshes.Count > 0 ? pipeline.AddGeometryMigrated(appId, displayMeshes[0]) : null;
+      List<Mesh>? displayMeshes = ((IDisplayValue<List<Mesh>?>)geometry).displayValue;
+      return displayMeshes is { Count: > 0 } ? pipeline.AddGeometryMigrated(appId, displayMeshes[0]) : null;
     }
+#pragma warning restore CS0618
 
     if (geometry is Arc a)
     {

--- a/src/Speckle.Sdk.BundleMigrator/Migration/PipelineExtensions.cs
+++ b/src/Speckle.Sdk.BundleMigrator/Migration/PipelineExtensions.cs
@@ -61,7 +61,17 @@ internal static class PipelineExtensions
       };
     }
 
-    if (geometry is Surface or Vector or Plane)
+    if (geometry is Curve { points: null })
+    {
+      return null;
+    }
+
+    if (geometry is Arc { startPoint: null } or Arc { endPoint: null })
+    {
+      return null;
+    }
+
+    if (geometry is Surface or Vector or Plane or Spiral)
     {
       return null;
     }

--- a/src/Speckle.Sdk.BundleMigrator/Migrator.cs
+++ b/src/Speckle.Sdk.BundleMigrator/Migrator.cs
@@ -398,7 +398,9 @@ internal sealed class Migrator(
       .ConfigureAwait(false);
 
     var deserializer = new SpeckleObjectDeserializer { ReadTransport = transport };
-    return await deserializer.DeserializeAsync(rootJson).ConfigureAwait(false);
+    return await LargeStackRunner
+      .Run(() => deserializer.DeserializeAsync(rootJson).AsTask(), "packfile-deserialize")
+      .ConfigureAwait(false);
   }
 
   // Produce the bundle on disk from a resolved graph, then optionally upload it (when `upload` — the

--- a/tests/Speckle.Sdk.BundleMigrator.Tests/V3GraphArtifactProducerTypeParameterTests.cs
+++ b/tests/Speckle.Sdk.BundleMigrator.Tests/V3GraphArtifactProducerTypeParameterTests.cs
@@ -246,4 +246,30 @@ public class V3GraphArtifactProducerTypeParameterTests
       }
     }
   }
+
+  [Fact]
+  public async Task NullProperties_MigratesRootScalarsOnly()
+  {
+    var dir = TempDir();
+    try
+    {
+      var obj = RevitObject("n1", "Basic Wall", "Generic - 200mm");
+      obj.properties = null!; // v3 payloads can carry `"properties": null`
+
+      var stats = Migrate(Root(obj), dir);
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+
+      stats.Objects.Should().Be(1);
+      var props = bundle.Properties[ObjIdx(bundle, "n1")];
+      props["family"].Should().Be("Basic Wall");
+      props.Should().NotContainKey("properties");
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
 }


### PR DESCRIPTION
✅ DuckDB stack overflow - Override stack size
✅ SGEO: no encoding for 'Brep' — Fixed regression
✅  NRE in TrySplitTypeParameters - fixed (untested)
✅  NRE in SgeoEncoder.EncodeSpiral - Skipped spirals
🤷‍♂ Datgen: indices.length must be multiple  - Not fixed, proably just us testing
🤷‍♂ Objects missing from packfile and server - No fix possible
✅️ NRE in EavExtraction.WalkPropertiesNative - Fixed (untested)
🤷‍♂ RE in EmitProxies.BindByPlane  - Not fixed, proably just us testing
✅  NRE in SgeoEncoder.EncodeCurve — Fixed
🤷‍♂️ Null base64 in EmitSolidBlob - Not fixed, proably just us testing
✅  NRE in Arc.measure via reflection — Fixed (untested)


https://discord.com/channels/726756379083145269/763070885924962386/1542090244424208436