### PR TITLE
feat(bundle): write meta.schema_version as the spec semver string

### DIFF
--- a/.github/actions/checkout-bundle-spec/action.yml
+++ b/.github/actions/checkout-bundle-spec/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/checkout@v7
       with:
         repository: specklesystems/speckle-bundle-spec
-        ref: 96c55725fd2c711bc83a0de9fe2a9c8c553a1173
+        ref: fa1761e58565dc7299f7af5ebf32b0f7931d707f
         token: ${{ inputs.token }}
         path: speckle-bundle-spec
         persist-credentials: false

--- a/notes/handoff-packfileloader2-envelope.md
+++ b/notes/handoff-packfileloader2-envelope.md
@@ -37,7 +37,7 @@ Six parquet files (no manifest — see banner):
 |---|---|---|
 | `{base}.envelope.relations.parquet` | `rel:int, src:int, dst:int, ord:int` | typed edges; `src`/`dst` namespace is fixed by `rel` |
 | `{base}.envelope.nodes.parquet`     | `id:int, kind:int, name:string?, def_ref:int?, transform:string?, units:string?, argb:int?, opacity:double?, metalness:double?, roughness:double?, elevation:double?` | shared value-entities |
-| `{base}.envelope.meta.parquet`      | `schema_version:int, produced_by:string` | catalog |
+| `{base}.envelope.meta.parquet`      | `schema_version:string (semver), produced_by, producer_version, sdk_name, sdk_version:string, migrated_from_schema_version:int?` | catalog |
 | `{base}.envelope.rel_types.parquet` | `rel:int, name:string, src_ns:string, dst_ns:string` | catalog: what each `rel` means + its namespaces |
 | `{base}.envelope.node_kinds.parquet`| `kind:int, name:string` | catalog |
 | ~~`{base}.envelope.manifest.sql`~~ | — | *removed — not produced/served* |

--- a/notes/handoff-server-v2-data-endpoints.md
+++ b/notes/handoff-server-v2-data-endpoints.md
@@ -44,7 +44,7 @@ to generate them, fully streamable ("write and free"):
 
 {base}.envelope.relations.parquet    # typed topology edges
 {base}.envelope.nodes.parquet        # value-entities (definition/instance/material/colour/level)
-{base}.envelope.meta.parquet         # catalog: schema_version, produced_by
+{base}.envelope.meta.parquet         # catalog: schema_version (semver string), produced_by, producer_version, sdk_name, sdk_version, migrated_from_schema_version
 {base}.envelope.rel_types.parquet    # catalog: rel id → name + namespaces
 {base}.envelope.node_kinds.parquet   # catalog: kind id → name
 {base}.envelope.manifest.sql         # CREATE VIEWs over the 5 envelope tables

--- a/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Send/Artifacts/EnvelopeWriter.cs
@@ -69,7 +69,7 @@ public sealed record CameraView(
 ///         transform, units, subtype, argb, opacity,                CONTAINER discriminator (Model/Collection/…)
 ///         metalness, roughness, emissive, ior, elevation)
 ///   {base}.envelope.{rel_types,node_kinds}.parquet             -- self-describing catalog (SOT §6)
-///   {base}.envelope.meta.parquet(schema_version,               -- catalog + provenance: who produced the
+///   {base}.envelope.meta.parquet(schema_version (semver str), -- catalog + provenance: who produced the
 ///         produced_by, producer_version, sdk_name,                bundle, with which SDK, and when
 ///         sdk_version, migrated_from_schema_version)              migrated, from which graph vintage
 ///   {base}.envelope.scene_views.parquet(view, name,           -- producer-authored grouping projections
@@ -245,7 +245,9 @@ public sealed class EnvelopeWriter : IDisposable
     SafeDispose(_nodes);
   }
 
-  // meta (SOT §6): schema version + producer provenance. Written at Complete() (not eagerly in the ctor) so
+  // meta (SOT §6): schema version + producer provenance. schema_version is the spec's semver STRING (== the
+  // speckle-bundle-spec package version, spec PR #25) — one value names the vocabulary, so readers must treat the
+  // column as text; migrated_from_schema_version stays int (legacy graph vintage). Written at Complete() (not eagerly in the ctor) so
   // producers can record their identity via SetProducer first. The reference-point record does NOT live here —
   // it rides eav.model as referencePoint.* rows (the former meta.reference_point_* columns are removed from the
   // spec; the xyz-only offsets lost rotation and meta is the wrong home for model data).
@@ -254,7 +256,7 @@ public sealed class EnvelopeWriter : IDisposable
     using var meta = new ParquetTableWriter(
       P("meta.parquet"),
       new ParquetSchema(
-        I("schema_version"),
+        S("schema_version"),
         S("produced_by"),
         S("producer_version"),
         S("sdk_name"),

--- a/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Pipelines/EnvelopeWriterTests.cs
@@ -192,8 +192,10 @@ public sealed class EnvelopeWriterTests : IDisposable
     Scalar(db, "SELECT sdk_name FROM meta").Should().Be("Speckle.Sdk (.NET)");
     Scalar(db, "SELECT sdk_version FROM meta").Should().Be("3.1.0-alpha.1");
     Scalar(db, "SELECT migrated_from_schema_version FROM meta").Should().Be(2);
-    // Provenance is additive — the catalog column is untouched.
+    // Provenance is additive — the catalog column is untouched. schema_version is the spec semver as TEXT —
+    // a regression to an int column must fail on the type, not on a boxed-value mismatch.
     Scalar(db, "SELECT schema_version FROM meta").Should().Be(SpecBundle.SchemaVersion);
+    Scalar(db, "SELECT typeof(schema_version) FROM meta").Should().Be("VARCHAR");
   }
 
   // A native send leaves the migration vintage NULL; the reference point is its own opt-in.


### PR DESCRIPTION
## Summary
Companion to specklesystems/speckle-bundle-spec#25, which changes `meta.schema_version` from `INTEGER` to a `VARCHAR` carrying the spec package semver (`'1.0.0'`) and makes `BundleSpec.SchemaVersion` a `string` constant.

- `EnvelopeWriter.WriteMeta` declares `schema_version` as a string column (`S(...)` instead of `I(...)`); `migrated_from_schema_version` stays `int?` (legacy graph vintage, a different number).
- CI pin `checkout-bundle-spec/action.yml` → spec commit `fa1761e` (branch commit of #25). **Update to the merge SHA once #25 lands.**
- Test: asserts `typeof(schema_version) = 'VARCHAR'` via DuckDB so a regression to an int column fails on type, not on a boxed-value mismatch.
- Notes: refresh stale `meta` column descriptions.

## Test plan
- [x] `dotnet csharpier check .` clean
- [x] `dotnet build Speckle.Sdk.slnx -c Release -warnaserror` — 0 warnings
- [x] `dotnet test --filter Category!=Integration` — all green (946+946 unit, 40 migrator, 212+212 objects, 77 serialization)
- [ ] CI green against the pinned spec commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)