### PR TITLE
ci: pin bundle spec to the #25 merge commit

### DIFF
--- a/.github/actions/checkout-bundle-spec/action.yml
+++ b/.github/actions/checkout-bundle-spec/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/checkout@v7
       with:
         repository: specklesystems/speckle-bundle-spec
-        ref: fa1761e58565dc7299f7af5ebf32b0f7931d707f
+        ref: 1f52b05f77e53822870c9097f911c764ce1c5198
         token: ${{ inputs.token }}
         path: speckle-bundle-spec
         persist-credentials: false


### PR DESCRIPTION
## Summary
Follow-up to #555: `checkout-bundle-spec` pinned the spec PR's branch head `fa1761e`, which vanished when specklesystems/speckle-bundle-spec#25 was squash-merged. Re-pin to the merge commit `1f52b05` (identical content).

## Test plan
- [ ] CI checks out the spec and builds/tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)