### PR TITLE
feat(sdk): BundleBuilder + Send3 — the write side of the bundle façade

### DIFF
--- a/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
@@ -72,15 +72,16 @@ public sealed record ArtefactNode(
   string? Subtype = null
 );
 
-/// <summary>A relation edge in the envelope graph (<c>rel</c> = <see cref="RelKind"/>, <c>src</c>/<c>dst</c> dense ints).</summary>
-public readonly record struct ArtefactEdge(int Src, int Dst, int Ord);
+/// <summary>One row of <c>envelope.relations</c>: (src, dst, ord) for a rel the reader has already grouped by — the
+/// collection you hold it in tells you which rel. Ks are dense ints in the rel's src/dst namespaces.</summary>
+public readonly record struct RelationRow(int Src, int Dst, int Ord);
 
 /// <summary>Envelope relations grouped by kind for direct lookup. The three dense-int namespaces are object
 /// (<c>eav.object_index</c>), geometry (<c>geometryIndex</c>) and node (<c>nodes.id</c>); each relation maps between
 /// two of them (e.g. DISPLAY src=object dst=geometry; IN_COLLECTION src=object dst=node).</summary>
 public sealed class ArtefactRelations
 {
-  public List<ArtefactEdge> Display { get; } = new();
+  public List<RelationRow> Display { get; } = new();
   public Dictionary<int, List<int>> SolidByObject { get; } = new();
   public Dictionary<int, int> CollectionByObject { get; } = new();
 
@@ -90,22 +91,22 @@ public sealed class ArtefactRelations
   public Dictionary<int, List<int>> GroupsByObject { get; } = new();
 
   /// <summary>SUBELEMENT (3): parent object → child object edges (ownership; ord = child order).</summary>
-  public List<ArtefactEdge> Subelement { get; } = new();
+  public List<RelationRow> Subelement { get; } = new();
 
   /// <summary>HOSTED_ON (22): hosted object → host object edges (a door placed on a wall — not ownership).</summary>
-  public List<ArtefactEdge> HostedOn { get; } = new();
+  public List<RelationRow> HostedOn { get; } = new();
 
   /// <summary>CONNECTS_TO (21): source object → target object edges (MEP connectivity; ord = scope).</summary>
-  public List<ArtefactEdge> ConnectsTo { get; } = new();
+  public List<RelationRow> ConnectsTo { get; } = new();
 
   /// <summary>BOUNDS (23): bounding object → room object edges (ord = boundary order).</summary>
-  public List<ArtefactEdge> Bounds { get; } = new();
+  public List<RelationRow> Bounds { get; } = new();
 
   /// <summary>IN_ROOM (12): object → containing room OBJECT (rooms are objects, not nodes).</summary>
-  public List<ArtefactEdge> InRoom { get; } = new();
+  public List<RelationRow> InRoom { get; } = new();
 
   /// <summary>IN_ASSEMBLY (18): member object → containing assembly object (ord = member order).</summary>
-  public List<ArtefactEdge> InAssembly { get; } = new();
+  public List<RelationRow> InAssembly { get; } = new();
 
   /// <summary>Relation numbers present in the bundle that this SDK's vocabulary doesn't know (a newer bundle spec).
   /// Their edges are dropped; consumers should surface this rather than silently miss data.</summary>
@@ -116,7 +117,7 @@ public sealed class ArtefactRelations
 
   /// <summary>All DISPLAY_INSTANCE edges (object → INSTANCE node). An object may place several instances (e.g. a Revit
   /// railing → many balusters), so the native baker iterates these rather than the last-wins map above.</summary>
-  public List<ArtefactEdge> DisplayInstanceEdges { get; } = new();
+  public List<RelationRow> DisplayInstanceEdges { get; } = new();
 
   /// <summary>For object→node relations (ON_LEVEL=7, IN_COLLECTION=10, IN_MODEL=11, IN_ROOM=12, …): rel → (object →
   /// target node). Used to resolve scene-view grouping tiers (e.g. an object's level/model/container) to a layer path.</summary>
@@ -177,10 +178,10 @@ public sealed class ArtefactRelations
   /// as a first-class COLOR node rather than the CONTAINER argb overload).</summary>
   public Dictionary<int, int> ColorByNode { get; } = new();
 
-  private Dictionary<int, List<ArtefactEdge>>? _displayByObject;
+  private Dictionary<int, List<RelationRow>>? _displayByObject;
 
   /// <summary>The DISPLAY edges (object → mesh geometry) for one object, or null. Lazily indexed.</summary>
-  public List<ArtefactEdge>? DisplayByObject(int objK)
+  public List<RelationRow>? DisplayByObject(int objK)
   {
     _displayByObject ??= Display.GroupBy(e => e.Src).ToDictionary(g => g.Key, g => g.ToList());
     return _displayByObject.TryGetValue(objK, out var list) ? list : null;
@@ -852,7 +853,7 @@ public static class ArtefactBundleReader
       switch (rel[i])
       {
         case RelKind.Display:
-          sets.Display.Add(new ArtefactEdge(src[i], dst[i], ord[i]));
+          sets.Display.Add(new RelationRow(src[i], dst[i], ord[i]));
           break;
         case RelKind.Solid:
           sets.Add(sets.SolidByObject, src[i], dst[i]);
@@ -865,7 +866,7 @@ public static class ArtefactBundleReader
           break;
         case RelKind.DisplayInstance:
           sets.DisplayInstanceByObject[src[i]] = dst[i];
-          sets.DisplayInstanceEdges.Add(new ArtefactEdge(src[i], dst[i], ord[i]));
+          sets.DisplayInstanceEdges.Add(new RelationRow(src[i], dst[i], ord[i]));
           break;
         case RelKind.HasMaterial:
           // ord tags the src namespace: 1 = INSTANCE node (a placement-painted material), 0/absent = geometry
@@ -901,22 +902,22 @@ public static class ArtefactBundleReader
           sets.PlacesByObject[src[i]] = dst[i];
           break;
         case RelKind.Subelement:
-          sets.Subelement.Add(new ArtefactEdge(src[i], dst[i], ord[i]));
+          sets.Subelement.Add(new RelationRow(src[i], dst[i], ord[i]));
           break;
         case RelKind.HostedOn:
-          sets.HostedOn.Add(new ArtefactEdge(src[i], dst[i], ord[i]));
+          sets.HostedOn.Add(new RelationRow(src[i], dst[i], ord[i]));
           break;
         case RelKind.ConnectsTo:
-          sets.ConnectsTo.Add(new ArtefactEdge(src[i], dst[i], ord[i]));
+          sets.ConnectsTo.Add(new RelationRow(src[i], dst[i], ord[i]));
           break;
         case RelKind.Bounds:
-          sets.Bounds.Add(new ArtefactEdge(src[i], dst[i], ord[i]));
+          sets.Bounds.Add(new RelationRow(src[i], dst[i], ord[i]));
           break;
         case RelKind.InRoom:
-          sets.InRoom.Add(new ArtefactEdge(src[i], dst[i], ord[i]));
+          sets.InRoom.Add(new RelationRow(src[i], dst[i], ord[i]));
           break;
         case RelKind.InAssembly:
-          sets.InAssembly.Add(new ArtefactEdge(src[i], dst[i], ord[i]));
+          sets.InAssembly.Add(new RelationRow(src[i], dst[i], ord[i]));
           break;
         case RelKind.DefinesMember:
           sets.Add(sets.MemberObjectsByDefinition, src[i], dst[i]);

--- a/src/Speckle.Sdk/Api/Operations/Operations.Receive.cs
+++ b/src/Speckle.Sdk/Api/Operations/Operations.Receive.cs
@@ -1,8 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Speckle.InterfaceGenerator;
-using Speckle.Objects.Utils;
 using Speckle.Sdk.Bundles;
-using Speckle.Sdk.Credentials;
 using Speckle.Sdk.Logging;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Pipelines.Receive.Artifacts;
@@ -30,7 +28,10 @@ public partial class Operations
   {
     var url = ModelUrl.Parse(new Uri(modelUrl, UriKind.Absolute));
     string versionId =
-      url.VersionId ?? await ResolveLatestVersionId(url, authorizationToken, cancellationToken).ConfigureAwait(false);
+      url.VersionId
+      ?? await bundleReceiver
+        .ResolveLatestVersionIdAsync(url, authorizationToken, cancellationToken)
+        .ConfigureAwait(false);
     return await Receive3(
         url.Server,
         url.ProjectId,
@@ -41,25 +42,6 @@ public partial class Operations
         cancellationToken
       )
       .ConfigureAwait(false);
-  }
-
-  private async Task<string> ResolveLatestVersionId(ModelUrl url, string? authorizationToken, CancellationToken ct)
-  {
-    var account = new Account
-    {
-      token = authorizationToken ?? string.Empty,
-      serverInfo = new() { url = url.Server.ToString() },
-      userInfo = new(),
-    };
-    using var client = clientFactory.Create(account);
-    var model = await client
-      .Model.GetWithVersions(url.ModelId, url.ProjectId, versionsLimit: 1, cancellationToken: ct)
-      .ConfigureAwait(false);
-    if (model.versions.items.Count == 0)
-    {
-      throw new SpeckleException($"Model '{url.ModelId}' in project '{url.ProjectId}' has no versions yet.");
-    }
-    return model.versions.items[0].id;
   }
 
   /// <summary>
@@ -104,15 +86,8 @@ public partial class Operations
 
     try
     {
-      var model = await DownloadBundleModel(
-          url,
-          projectId,
-          modelId,
-          versionId,
-          authorizationToken,
-          options,
-          cancellationToken
-        )
+      var model = await bundleReceiver
+        .ReceiveAsync(url, projectId, modelId, versionId, authorizationToken, options, cancellationToken)
         .ConfigureAwait(false);
       receiveActivity?.SetStatus(SdkActivityStatusCode.Ok);
       return model;
@@ -444,31 +419,16 @@ public partial class Operations
         );
       }
 
-      using var model = await DownloadBundleModel(
+      var root = await bundleReceiver
+        .ReceiveAsBaseAsync(
           url,
           reference.ProjectId,
           reference.ModelId,
           reference.VersionId,
           authorizationToken,
-          ReceiveOptions.Default,
           cancellationToken
         )
         .ConfigureAwait(false);
-
-      // The Base projection walks nested property dictionaries and decodes every mesh: re-read the downloaded files
-      // in the eager profile. This is the lossy compat path; its memory cost is the reason Receive2 is obsolete.
-      var eager = await ArtefactBundleReader
-        .ReadAsync(model.Directory, ArtefactReadOptions.Eager, cancellationToken)
-        .ConfigureAwait(false);
-      var root = new ObjectsArtifactReader().Build(
-        eager,
-        new ArtifactReceiveOptions(PreferSolids: false),
-        cancellationToken
-      );
-
-      // Vintage marker: lets consumers (and the migrator's IsV3 check) tell a materialized tree from a genuine
-      // v2/v3 graph. Same convention as BundleMigrator's TreeMaterializer.
-      root["version"] = 4;
 
       receiveActivity?.SetStatus(SdkActivityStatusCode.Ok);
       return root;
@@ -482,90 +442,6 @@ public partial class Operations
       receiveActivity?.SetStatus(SdkActivityStatusCode.Error);
       receiveActivity?.RecordException(ex);
       throw;
-    }
-  }
-
-  /// <summary>Downloads the bundle into a scratch directory and parses it. The returned <see cref="Model"/> owns the
-  /// directory; on any failure the directory is removed here.</summary>
-  private async Task<Model> DownloadBundleModel(
-    Uri url,
-    string projectId,
-    string modelId,
-    string versionId,
-    string? authorizationToken,
-    ReceiveOptions options,
-    CancellationToken cancellationToken
-  )
-  {
-    // ArtifactDownloader only reads token + serverInfo.url off the account.
-    var account = new Account
-    {
-      token = authorizationToken ?? string.Empty,
-      serverInfo = new() { url = url.ToString() },
-      userInfo = new(),
-    };
-
-    string bundleDir = Path.Combine(
-      SpecklePathProvider.UserApplicationDataPath(),
-      "Speckle",
-      "BundleReceive",
-      Guid.NewGuid().ToString("N")
-    );
-    try
-    {
-      var files = await artifactDownloader
-        .DownloadBundleAsync(
-          account,
-          projectId,
-          modelId,
-          versionId,
-          bundleDir,
-          options.ShouldDownload,
-          cancellationToken
-        )
-        .ConfigureAwait(false);
-
-      if (files.Count == 0)
-      {
-        // Never fall back to the legacy object path from here: a caller on this rail asked for the bundle, and for
-        // a bundle-only version there is no legacy graph anyway.
-        throw new SpeckleException(
-          $"Version '{versionId}' (model '{modelId}', project '{projectId}') has no artefact bundle on the server at "
-            + $"'{url}'. Either the server does not serve the /api/v2 artifacts endpoint yet, the token cannot read the "
-            + "project, or the bundle has not been produced for this version."
-        );
-      }
-
-      // Geometry stays on disk until Model.Geometries is touched — it is the bulk of every bundle — and properties
-      // stay columnar (PropertyTable) so memory tracks the parquet size, not a dictionary per nesting level.
-      var bundle = await ArtefactBundleReader
-        .ReadAsync(bundleDir, ArtefactReadOptions.Columnar, cancellationToken)
-        .ConfigureAwait(false);
-      return new Model(projectId, modelId, versionId, bundleDir, files, bundle, options.IncludeGeometry, logger);
-    }
-    catch
-    {
-      TryDeleteDirectory(bundleDir);
-      throw;
-    }
-  }
-
-  private void TryDeleteDirectory(string dir)
-  {
-    try
-    {
-      if (Directory.Exists(dir))
-      {
-        Directory.Delete(dir, true);
-      }
-    }
-    catch (IOException ex)
-    {
-      logger.LogWarning(ex, "Could not clean up bundle scratch directory {bundleDir}", dir);
-    }
-    catch (UnauthorizedAccessException ex)
-    {
-      logger.LogWarning(ex, "Could not clean up bundle scratch directory {bundleDir}", dir);
     }
   }
 }

--- a/src/Speckle.Sdk/Api/Operations/Operations.Send.cs
+++ b/src/Speckle.Sdk/Api/Operations/Operations.Send.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Speckle.Newtonsoft.Json.Linq;
+using Speckle.Sdk.Bundles;
 using Speckle.Sdk.Logging;
 using Speckle.Sdk.Models;
 using Speckle.Sdk.Serialisation;
@@ -11,6 +12,83 @@ namespace Speckle.Sdk.Api;
 
 public partial class Operations
 {
+  /// <summary>
+  /// Publishes a bundle as a new version — the Speckle 2026.9.0 send path. Creates the ingestion (the server
+  /// pre-allocates the version id), finishes the <paramref name="builder"/> and re-keys its files to that id, uploads
+  /// them over the <c>/api/v2</c> artifacts rail, and returns. The version becomes visible when the server finishes
+  /// ingesting; subscribe on <see cref="SendResult.IngestionId"/> for that.
+  /// </summary>
+  /// <remarks>
+  /// The version's <c>referencedObject</c> is the bundle reference (<c>bundle.&lt;projectId&gt;.&lt;modelId&gt;.&lt;versionId&gt;</c>),
+  /// which is what <see cref="Receive2"/> dispatches on. On any failure the ingestion is marked failed (or cancelled)
+  /// on the server before the exception propagates. The builder is finished by this call and cannot be reused.
+  /// </remarks>
+  /// <exception cref="SpeckleException">The server did not pre-allocate a version id (it predates the v2 data endpoints).</exception>
+  public async Task<SendResult> Send3(
+    Uri url,
+    string projectId,
+    string modelId,
+    BundleBuilder builder,
+    string? authorizationToken,
+    SendOptions? options,
+    CancellationToken cancellationToken
+  )
+  {
+    using var sendActivity = activityFactory.Start("Operations.Send3");
+    metricsFactory.CreateCounter<long>("Send").Add(1);
+    try
+    {
+      var result = await bundleSender
+        .SendAsync(
+          url,
+          projectId,
+          modelId,
+          builder,
+          authorizationToken,
+          options ?? SendOptions.Default,
+          cancellationToken
+        )
+        .ConfigureAwait(false);
+      sendActivity?.SetStatus(SdkActivityStatusCode.Ok);
+      return result;
+    }
+    catch (OperationCanceledException)
+    {
+      throw;
+    }
+    catch (Exception ex)
+    {
+      sendActivity?.SetStatus(SdkActivityStatusCode.Error);
+      sendActivity?.RecordException(ex);
+      throw;
+    }
+  }
+
+  /// <summary>
+  /// <see cref="Send3(Uri, string, string, BundleBuilder, string?, SendOptions?, CancellationToken)"/> addressed by a
+  /// model url — <c>{server}/projects/{projectId}/models/{modelId}</c>. A <c>@versionId</c> suffix is rejected: a send
+  /// always creates a new version.
+  /// </summary>
+  /// <exception cref="ArgumentException"><paramref name="modelUrl"/> is not a model url, or pins a version.</exception>
+  public Task<SendResult> Send3(
+    string modelUrl,
+    BundleBuilder builder,
+    string? authorizationToken,
+    SendOptions? options,
+    CancellationToken cancellationToken
+  )
+  {
+    var url = ModelUrl.Parse(new Uri(modelUrl, UriKind.Absolute));
+    if (url.HasVersion)
+    {
+      throw new ArgumentException(
+        $"'{modelUrl}' pins version '{url.VersionId}'; a send creates a new version, so pass the model url without @versionId.",
+        nameof(modelUrl)
+      );
+    }
+    return Send3(url.Server, url.ProjectId, url.ModelId, builder, authorizationToken, options, cancellationToken);
+  }
+
   /// <summary>
   /// Sends a Speckle Object to the provided URL and Caches the results
   /// </summary>

--- a/src/Speckle.Sdk/Api/Operations/Operations.cs
+++ b/src/Speckle.Sdk/Api/Operations/Operations.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Speckle.InterfaceGenerator;
+using Speckle.Sdk.Bundles;
 using Speckle.Sdk.Logging;
-using Speckle.Sdk.Pipelines.Receive.Artifacts;
 using Speckle.Sdk.Serialisation.V2;
 
 namespace Speckle.Sdk.Api;
@@ -18,6 +18,6 @@ public partial class Operations(
   ISdkMetricsFactory metricsFactory,
   ISerializeProcessFactory serializeProcessFactory,
   IDeserializeProcessFactory deserializeProcessFactory,
-  IArtifactDownloader artifactDownloader,
-  IClientFactory clientFactory
+  IBundleReceiver bundleReceiver,
+  IBundleSender bundleSender
 ) : IOperations;

--- a/src/Speckle.Sdk/Bundles/BundleBuilder.cs
+++ b/src/Speckle.Sdk/Bundles/BundleBuilder.cs
@@ -17,10 +17,12 @@ namespace Speckle.Sdk.Bundles;
 /// <code>
 /// using var b = new BundleBuilder(app, units: "m");
 /// var walls = b.GetOrAddCollection(["Level 1", "Walls"], subtype: "Category");
-/// var wall  = b.GetOrAddObject("wall-1", walls, properties, name: "Basic Wall", speckleType: "Objects.Data.DataObject");
+/// var wall  = b.GetOrAddObject("wall-1");
+/// wall.SetProperties(properties, name: "Basic Wall", speckleType: "Objects.Data.DataObject");
+/// wall.Collection = walls;
 /// wall.AddGeometry(mesh).Material = b.GetOrAddMaterial("concrete", "Concrete", 0xFF808080, 1, 0, 0.8);
 /// wall.Level = b.GetOrAddLevel("L1", "Level 1", 0);
-/// var chair = b.GetOrAddObject("chair-1", walls, null, name: "Chair");
+/// var chair = b.GetOrAddObject("chair-1");
 /// chair.Place(b.GetOrAddDefinition("def-chair", "Chair", d => d.AddGeometry(chairMesh)), transform, "m");
 /// BundleFiles files = b.Build();
 /// </code>
@@ -126,75 +128,43 @@ public sealed class BundleBuilder : IDisposable
   // ── objects ───────────────────────────────────────────────────────────────────────────────────────────
 
   /// <summary>
-  /// Gets or adds an object (the property carrier a host element becomes) and writes its properties. Interns on
-  /// <paramref name="applicationId"/>. An object may be referenced before it is described — <c>GetOrAddObject(id, null, null)</c>
-  /// yields a handle to point edges at (a joint a frame connects to, a group member) and a later call carrying
-  /// properties fills it in; properties can be written once.
+  /// Gets or adds an object (the property carrier a host element becomes) by <paramref name="applicationId"/> — a
+  /// handle only, nothing written yet. Describe it with <see cref="BundleObject.SetProperties"/>; point edges at it
+  /// before or after (a joint a frame connects to may be described later).
   /// </summary>
-  /// <param name="collection">Where it sits in the authored scene tree (<c>IN_COLLECTION</c>); null for objects that
-  /// are grouped some other way (Revit: model + level + property tiers).</param>
-  /// <param name="properties">The nested property tree (<c>properties.*</c> in the bundle); null for none.</param>
-  /// <param name="name">Root <c>name</c> scalar.</param>
-  /// <param name="speckleType">Root <c>speckle_type</c> scalar — what the v3 graph would have carried.</param>
-  /// <param name="sourceType">Root <c>type</c> scalar — the host's own type (Rhino ObjectType, Revit category …).</param>
-  /// <param name="units">Root <c>units</c>; the builder's <see cref="Units"/> when null.</param>
-  /// <param name="typeKey">Stable per-type identity (Revit type element UniqueId). When set, <c>Type Parameters</c> /
-  /// <c>System Type Parameters</c> under <c>properties.Parameters</c> are deduplicated into the type tables.</param>
-  /// <param name="rootScalars">Any further root scalars (Revit: <c>category</c>, <c>family</c>).</param>
-  public BundleObject GetOrAddObject(
-    string applicationId,
-    BundleCollection? collection,
-    IReadOnlyDictionary<string, object?>? properties,
-    string? name = null,
-    string? speckleType = null,
-    string? sourceType = null,
-    string? units = null,
-    string? typeKey = null,
-    IEnumerable<KeyValuePair<string, object?>>? rootScalars = null
-  )
+  public BundleObject GetOrAddObject(string applicationId)
   {
-    bool describes =
-      properties is not null
-      || name is not null
-      || speckleType is not null
-      || sourceType is not null
-      || units is not null
-      || typeKey is not null
-      || rootScalars is not null;
-
     if (!_objects.TryGetValue(applicationId, out var obj))
     {
       obj = new BundleObject(this, Pipeline.InternObject(applicationId), applicationId);
       _objects[applicationId] = obj;
     }
-    if (describes)
-    {
-      if (obj.PropertiesWritten)
-      {
-        throw new InvalidOperationException(
-          $"Object '{applicationId}' already has its properties written; they can be written once. "
-            + "Reference an existing object with GetOrAddObject(id, null, null)."
-        );
-      }
-      var scalars = new List<KeyValuePair<string, object?>>
-      {
-        new("speckle_type", speckleType),
-        new("name", name),
-        new("units", units ?? Units),
-        new("type", sourceType),
-      };
-      if (rootScalars is not null)
-      {
-        scalars.AddRange(rootScalars);
-      }
-      Pipeline.AddProperties(applicationId, properties ?? s_noProperties, scalars, typeKey);
-      obj.MarkDescribed(name);
-    }
-    if (collection is not null)
-    {
-      obj.Collection = collection;
-    }
     return obj;
+  }
+
+  internal void WriteProperties(
+    BundleObject obj,
+    IReadOnlyDictionary<string, object?>? properties,
+    string? name,
+    string? speckleType,
+    string? sourceType,
+    string? units,
+    string? typeKey,
+    IEnumerable<KeyValuePair<string, object?>>? rootScalars
+  )
+  {
+    var scalars = new List<KeyValuePair<string, object?>>
+    {
+      new("speckle_type", speckleType),
+      new("name", name),
+      new("units", units ?? Units),
+      new("type", sourceType),
+    };
+    if (rootScalars is not null)
+    {
+      scalars.AddRange(rootScalars);
+    }
+    Pipeline.AddProperties(obj.ApplicationId, properties ?? s_noProperties, scalars, typeKey);
   }
 
   /// <summary>Object handle by application id, if it has been added.</summary>

--- a/src/Speckle.Sdk/Bundles/BundleBuilder.cs
+++ b/src/Speckle.Sdk/Bundles/BundleBuilder.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Speckle.Objects.Utils;
 using Speckle.Sdk.Pipelines;
 using Speckle.Sdk.Pipelines.Send.Artifacts;
@@ -38,6 +39,7 @@ public sealed class BundleBuilder : IDisposable
   private readonly Dictionary<string, BundleMaterial> _materials = new(StringComparer.Ordinal);
   private readonly Dictionary<int, BundleColor> _colors = new();
   private readonly Dictionary<string, BundleLevel> _levels = new(StringComparer.Ordinal);
+  private readonly Dictionary<string, BundleGeometry> _geometries = new(StringComparer.Ordinal);
   private readonly List<SceneView> _sceneViews = new();
   private bool _built;
   private bool _disposed;
@@ -112,8 +114,10 @@ public sealed class BundleBuilder : IDisposable
   // ── objects ───────────────────────────────────────────────────────────────────────────────────────────
 
   /// <summary>
-  /// Adds an object (the property carrier a host element becomes) and writes its properties. Interns on
-  /// <paramref name="applicationId"/>: a repeat returns the existing handle and writes nothing.
+  /// Gets or adds an object (the property carrier a host element becomes) and writes its properties. Interns on
+  /// <paramref name="applicationId"/>. An object may be referenced before it is described — <c>GetOrAddObject(id, null, null)</c>
+  /// yields a handle to point edges at (a joint a frame connects to, a group member) and a later call carrying
+  /// properties fills it in; properties can be written once.
   /// </summary>
   /// <param name="collection">Where it sits in the authored scene tree (<c>IN_COLLECTION</c>); null for objects that
   /// are grouped some other way (Revit: model + level + property tiers).</param>
@@ -137,31 +141,64 @@ public sealed class BundleBuilder : IDisposable
     IEnumerable<KeyValuePair<string, object?>>? rootScalars = null
   )
   {
-    if (_objects.TryGetValue(applicationId, out var existing))
-    {
-      return existing;
-    }
-    int k = Pipeline.InternObject(applicationId);
-    var scalars = new List<KeyValuePair<string, object?>>
-    {
-      new("speckle_type", speckleType),
-      new("name", name),
-      new("units", units ?? Units),
-      new("type", sourceType),
-    };
-    if (rootScalars is not null)
-    {
-      scalars.AddRange(rootScalars);
-    }
-    Pipeline.AddProperties(applicationId, properties ?? s_noProperties, scalars, typeKey);
+    bool describes =
+      properties is not null
+      || name is not null
+      || speckleType is not null
+      || sourceType is not null
+      || units is not null
+      || typeKey is not null
+      || rootScalars is not null;
 
-    var obj = new BundleObject(this, k, applicationId, name);
-    _objects[applicationId] = obj;
+    if (!_objects.TryGetValue(applicationId, out var obj))
+    {
+      obj = new BundleObject(this, Pipeline.InternObject(applicationId), applicationId);
+      _objects[applicationId] = obj;
+    }
+    if (describes)
+    {
+      if (obj.PropertiesWritten)
+      {
+        throw new InvalidOperationException(
+          $"Object '{applicationId}' already has its properties written; they can be written once. "
+            + "Reference an existing object with GetOrAddObject(id, null, null)."
+        );
+      }
+      var scalars = new List<KeyValuePair<string, object?>>
+      {
+        new("speckle_type", speckleType),
+        new("name", name),
+        new("units", units ?? Units),
+        new("type", sourceType),
+      };
+      if (rootScalars is not null)
+      {
+        scalars.AddRange(rootScalars);
+      }
+      Pipeline.AddProperties(applicationId, properties ?? s_noProperties, scalars, typeKey);
+      obj.MarkDescribed(name);
+    }
     if (collection is not null)
     {
       obj.Collection = collection;
     }
     return obj;
+  }
+
+  /// <summary>Object handle by application id, if it has been added.</summary>
+  public bool TryGetObject(string applicationId, [NotNullWhen(true)] out BundleObject? obj) =>
+    _objects.TryGetValue(applicationId, out obj);
+
+  /// <summary>Geometry handle by the key it was added under (explicit <c>geometryKey</c>, or the generated
+  /// <c>{applicationId}:g{n}</c>), for post-loop edges that reference meshes by key — e.g. a definition that shares a
+  /// mesh already written for an object.</summary>
+  public bool TryGetGeometry(string geometryKey, [NotNullWhen(true)] out BundleGeometry? geometry) =>
+    _geometries.TryGetValue(geometryKey, out geometry);
+
+  internal BundleGeometry RegisterGeometry(string key, BundleGeometry geometry)
+  {
+    _geometries[key] = geometry;
+    return geometry;
   }
 
   private static readonly IReadOnlyDictionary<string, object?> s_noProperties = new Dictionary<string, object?>();

--- a/src/Speckle.Sdk/Bundles/BundleBuilder.cs
+++ b/src/Speckle.Sdk/Bundles/BundleBuilder.cs
@@ -15,16 +15,18 @@ namespace Speckle.Sdk.Bundles;
 /// Typical shape:
 /// <code>
 /// using var b = new BundleBuilder(app, units: "m");
-/// var walls = b.Collection(["Level 1", "Walls"], subtype: "Category");
-/// var wall  = b.Object("wall-1", walls, properties, name: "Basic Wall", speckleType: "Objects.Data.DataObject");
-/// wall.AddGeometry(mesh).Material = b.Material("concrete", "Concrete", 0xFF808080, 1, 0, 0.8);
-/// wall.Level = b.Level("L1", "Level 1", 0);
-/// var chair = b.Object("chair-1", walls, null, name: "Chair");
-/// chair.Place(b.Definition("def-chair", "Chair", d => d.AddGeometry(chairMesh)), transform, "m");
+/// var walls = b.GetOrAddCollection(["Level 1", "Walls"], subtype: "Category");
+/// var wall  = b.GetOrAddObject("wall-1", walls, properties, name: "Basic Wall", speckleType: "Objects.Data.DataObject");
+/// wall.AddGeometry(mesh).Material = b.GetOrAddMaterial("concrete", "Concrete", 0xFF808080, 1, 0, 0.8);
+/// wall.Level = b.GetOrAddLevel("L1", "Level 1", 0);
+/// var chair = b.GetOrAddObject("chair-1", walls, null, name: "Chair");
+/// chair.Place(b.GetOrAddDefinition("def-chair", "Chair", d => d.AddGeometry(chairMesh)), transform, "m");
 /// BundleFiles files = b.Build();
 /// </code>
-/// Keys (<c>applicationId</c>, definition / material / level keys) intern: adding the same key twice returns the same
-/// handle and writes nothing new. Edge ordinals are assigned in call order per object.
+/// Naming rule: <c>GetOrAdd…</c> interns a node by key — the same key returns the same handle and writes nothing new,
+/// and a repeat with different attributes throws (a key collision with different content would be a corrupt bundle).
+/// <c>Add…</c> appends a row every call (geometry, model properties, results, camera views). Verbs and property
+/// setters (<c>Place</c>, <c>ConnectTo</c>, <c>Host =</c>) emit one edge each. Edge ordinals follow call order.
 /// </remarks>
 public sealed class BundleBuilder : IDisposable
 {
@@ -74,7 +76,7 @@ public sealed class BundleBuilder : IDisposable
   /// parent-linked. Each segment is keyed by its full path, so two branches sharing a name stay distinct.</summary>
   /// <param name="subtype">Tag for the leaf (and any newly created ancestors): <c>"Layer"</c>, <c>"Category"</c>,
   /// <c>"Collection"</c> …</param>
-  public BundleCollection Collection(IReadOnlyList<string> path, string subtype = "Collection")
+  public BundleCollection GetOrAddCollection(IReadOnlyList<string> path, string subtype = "Collection")
   {
     if (path.Count == 0)
     {
@@ -85,17 +87,20 @@ public sealed class BundleBuilder : IDisposable
     foreach (var segment in path)
     {
       key = key.Length == 0 ? segment : key + "/" + segment;
-      parent = Container(key, segment, parent, subtype);
+      parent = GetOrAddContainer(key, segment, parent, subtype);
     }
     return parent!;
   }
 
   /// <summary>Gets or creates one CONTAINER by explicit key — for containers that aren't a name path: a federated
   /// <c>Model</c>, a <c>Group</c>, an MEP <c>System</c>/<c>Network</c>.</summary>
-  public BundleCollection Container(string key, string? name, BundleCollection? parent, string subtype)
+  public BundleCollection GetOrAddContainer(string key, string? name, BundleCollection? parent, string subtype)
   {
     if (_collections.TryGetValue(key, out var existing))
     {
+      Same(key, existing.Name, name, "name");
+      Same(key, existing.Subtype, subtype, "subtype");
+      Same(key, existing.Parent?.Key, parent?.Key, "parent");
       return existing;
     }
     int k = Pipeline.AddContainer(key, name, parent?.K, subtype);
@@ -120,7 +125,7 @@ public sealed class BundleBuilder : IDisposable
   /// <param name="typeKey">Stable per-type identity (Revit type element UniqueId). When set, <c>Type Parameters</c> /
   /// <c>System Type Parameters</c> under <c>properties.Parameters</c> are deduplicated into the type tables.</param>
   /// <param name="rootScalars">Any further root scalars (Revit: <c>category</c>, <c>family</c>).</param>
-  public BundleObject Object(
+  public BundleObject GetOrAddObject(
     string applicationId,
     BundleCollection? collection,
     IReadOnlyDictionary<string, object?>? properties,
@@ -161,11 +166,22 @@ public sealed class BundleBuilder : IDisposable
 
   private static readonly IReadOnlyDictionary<string, object?> s_noProperties = new Dictionary<string, object?>();
 
+  private static void Same<T>(string key, T written, T requested, string what)
+  {
+    if (!EqualityComparer<T>.Default.Equals(written, requested))
+    {
+      throw new InvalidOperationException(
+        $"Key '{key}' was already added with {what} '{written}'; a second GetOrAdd asked for '{requested}'. "
+          + "One key means one node — use a different key for different content."
+      );
+    }
+  }
+
   // ── value nodes ───────────────────────────────────────────────────────────────────────────────────────
 
   /// <summary>Gets or creates a MATERIAL node. <paramref name="key"/> is the dedup identity (host material id);
   /// <paramref name="name"/> is the authored name receivers recreate the host material under.</summary>
-  public BundleMaterial Material(
+  public BundleMaterial GetOrAddMaterial(
     string key,
     string? name,
     int argb,
@@ -178,6 +194,8 @@ public sealed class BundleBuilder : IDisposable
   {
     if (_materials.TryGetValue(key, out var existing))
     {
+      Same(key, existing.Name, name, "name");
+      Same(key, existing.Argb, argb, "argb");
       return existing;
     }
     int k = Pipeline.AddMaterial(key, name, argb, opacity, metalness, roughness, emissive, ior);
@@ -187,7 +205,7 @@ public sealed class BundleBuilder : IDisposable
   }
 
   /// <summary>Gets or creates a COLOR node, keyed by its ARGB value.</summary>
-  public BundleColor Color(int argb)
+  public BundleColor GetOrAddColor(int argb)
   {
     if (_colors.TryGetValue(argb, out var existing))
     {
@@ -199,10 +217,12 @@ public sealed class BundleBuilder : IDisposable
   }
 
   /// <summary>Gets or creates a LEVEL node.</summary>
-  public BundleLevel Level(string key, string? name, double elevation)
+  public BundleLevel GetOrAddLevel(string key, string? name, double elevation)
   {
     if (_levels.TryGetValue(key, out var existing))
     {
+      Same(key, existing.Name, name, "name");
+      Same(key, existing.Elevation, elevation, "elevation");
       return existing;
     }
     var l = new BundleLevel(this, Pipeline.AddLevel(key, name, elevation), key, name, elevation);
@@ -212,10 +232,14 @@ public sealed class BundleBuilder : IDisposable
 
   /// <summary>Gets or creates a DEFINITION (block / family symbol). <paramref name="populate"/> runs only on first
   /// creation — put the definition's geometry, nested placements and member objects there.</summary>
-  public BundleDefinition Definition(string key, string? name, Action<BundleDefinition>? populate = null)
+  public BundleDefinition GetOrAddDefinition(string key, string? name, Action<BundleDefinition>? populate = null)
   {
     if (_definitions.TryGetValue(key, out var existing))
     {
+      if (name is not null)
+      {
+        Same(key, existing.Name, name, "name"); // null = "whatever it was named" (a placement only knows the id)
+      }
       return existing;
     }
     var d = new BundleDefinition(this, Pipeline.AddDefinition(key, name), key, name);

--- a/src/Speckle.Sdk/Bundles/BundleBuilder.cs
+++ b/src/Speckle.Sdk/Bundles/BundleBuilder.cs
@@ -1,0 +1,393 @@
+using Speckle.Objects.Utils;
+using Speckle.Sdk.Pipelines;
+using Speckle.Sdk.Pipelines.Send.Artifacts;
+
+namespace Speckle.Sdk.Bundles;
+
+/// <summary>
+/// Writes a Speckle 2026.9.0 artefact bundle from typed handles — the write-side twin of <see cref="Model"/>. Wraps
+/// <see cref="ObjectsArtifactPipeline"/> and owns everything the connectors' send builders used to re-implement:
+/// dense-int allocation, edge ordinals, collection paths, the producer stamp, the default scene view, and the final
+/// file listing. Everything streams to parquet as it is added (geometry is SGEO-encoded on the spot), so memory does
+/// not grow with the model.
+/// </summary>
+/// <remarks>
+/// Typical shape:
+/// <code>
+/// using var b = new BundleBuilder(app, units: "m");
+/// var walls = b.Collection(["Level 1", "Walls"], subtype: "Category");
+/// var wall  = b.Object("wall-1", walls, properties, name: "Basic Wall", speckleType: "Objects.Data.DataObject");
+/// wall.AddGeometry(mesh).Material = b.Material("concrete", "Concrete", 0xFF808080, 1, 0, 0.8);
+/// wall.Level = b.Level("L1", "Level 1", 0);
+/// var chair = b.Object("chair-1", walls, null, name: "Chair");
+/// chair.Place(b.Definition("def-chair", "Chair", d => d.AddGeometry(chairMesh)), transform, "m");
+/// BundleFiles files = b.Build();
+/// </code>
+/// Keys (<c>applicationId</c>, definition / material / level keys) intern: adding the same key twice returns the same
+/// handle and writes nothing new. Edge ordinals are assigned in call order per object.
+/// </remarks>
+public sealed class BundleBuilder : IDisposable
+{
+  private const string DEFAULT_BASE_NAME = "bundle";
+
+  private readonly Dictionary<string, BundleObject> _objects = new(StringComparer.Ordinal);
+  private readonly Dictionary<string, BundleCollection> _collections = new(StringComparer.Ordinal);
+  private readonly Dictionary<string, BundleDefinition> _definitions = new(StringComparer.Ordinal);
+  private readonly Dictionary<string, BundleMaterial> _materials = new(StringComparer.Ordinal);
+  private readonly Dictionary<int, BundleColor> _colors = new();
+  private readonly Dictionary<string, BundleLevel> _levels = new(StringComparer.Ordinal);
+  private readonly List<SceneView> _sceneViews = new();
+  private bool _built;
+  private bool _disposed;
+
+  /// <param name="producer">Who is writing the bundle — stamped into <c>envelope.meta</c>. Required.</param>
+  /// <param name="units">Model length unit (<c>"m"</c>, <c>"mm"</c>, <c>"ft"</c> …), written as each object's root <c>units</c>
+  /// scalar unless overridden per object.</param>
+  /// <param name="outputDir">Where the parquet files go; a fresh directory under the temp path when null.</param>
+  /// <param name="baseName">File basename (<c>{baseName}.eav.parquet</c> …). Defaults to <c>"bundle"</c>;
+  /// <see cref="BundleFiles.RenameTo"/> re-keys the files to a version id before upload.</param>
+  public BundleBuilder(ISpeckleApplication producer, string units, string? outputDir = null, string? baseName = null)
+  {
+    Producer = producer ?? throw new ArgumentNullException(nameof(producer));
+    Units = string.IsNullOrWhiteSpace(units) ? throw new ArgumentException("units is required", nameof(units)) : units;
+    Directory = outputDir ?? Path.Combine(Path.GetTempPath(), "Speckle", "bundles", Guid.NewGuid().ToString("N"));
+    BaseName = baseName ?? DEFAULT_BASE_NAME;
+    System.IO.Directory.CreateDirectory(Directory);
+    Pipeline = new ObjectsArtifactPipeline(Directory, BaseName, producer);
+  }
+
+  /// <summary>Who is writing the bundle.</summary>
+  public ISpeckleApplication Producer { get; }
+
+  public string Units { get; }
+  public string Directory { get; }
+  public string BaseName { get; }
+
+  /// <summary>Objects added so far, in insertion order.</summary>
+  public IReadOnlyCollection<BundleObject> Objects => _objects.Values;
+
+  internal ObjectsArtifactPipeline Pipeline { get; }
+
+  // ── scene tree ────────────────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>Gets or creates the CONTAINER chain for a path (<c>["Level 1", "Walls"]</c>) — one node per segment,
+  /// parent-linked. Each segment is keyed by its full path, so two branches sharing a name stay distinct.</summary>
+  /// <param name="subtype">Tag for the leaf (and any newly created ancestors): <c>"Layer"</c>, <c>"Category"</c>,
+  /// <c>"Collection"</c> …</param>
+  public BundleCollection Collection(IReadOnlyList<string> path, string subtype = "Collection")
+  {
+    if (path.Count == 0)
+    {
+      throw new ArgumentException("A collection path needs at least one segment.", nameof(path));
+    }
+    BundleCollection? parent = null;
+    string key = "";
+    foreach (var segment in path)
+    {
+      key = key.Length == 0 ? segment : key + "/" + segment;
+      parent = Container(key, segment, parent, subtype);
+    }
+    return parent!;
+  }
+
+  /// <summary>Gets or creates one CONTAINER by explicit key — for containers that aren't a name path: a federated
+  /// <c>Model</c>, a <c>Group</c>, an MEP <c>System</c>/<c>Network</c>.</summary>
+  public BundleCollection Container(string key, string? name, BundleCollection? parent, string subtype)
+  {
+    if (_collections.TryGetValue(key, out var existing))
+    {
+      return existing;
+    }
+    int k = Pipeline.AddContainer(key, name, parent?.K, subtype);
+    var c = new BundleCollection(this, k, key, name, subtype, parent);
+    _collections[key] = c;
+    return c;
+  }
+
+  // ── objects ───────────────────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>
+  /// Adds an object (the property carrier a host element becomes) and writes its properties. Interns on
+  /// <paramref name="applicationId"/>: a repeat returns the existing handle and writes nothing.
+  /// </summary>
+  /// <param name="collection">Where it sits in the authored scene tree (<c>IN_COLLECTION</c>); null for objects that
+  /// are grouped some other way (Revit: model + level + property tiers).</param>
+  /// <param name="properties">The nested property tree (<c>properties.*</c> in the bundle); null for none.</param>
+  /// <param name="name">Root <c>name</c> scalar.</param>
+  /// <param name="speckleType">Root <c>speckle_type</c> scalar — what the v3 graph would have carried.</param>
+  /// <param name="sourceType">Root <c>type</c> scalar — the host's own type (Rhino ObjectType, Revit category …).</param>
+  /// <param name="units">Root <c>units</c>; the builder's <see cref="Units"/> when null.</param>
+  /// <param name="typeKey">Stable per-type identity (Revit type element UniqueId). When set, <c>Type Parameters</c> /
+  /// <c>System Type Parameters</c> under <c>properties.Parameters</c> are deduplicated into the type tables.</param>
+  /// <param name="rootScalars">Any further root scalars (Revit: <c>category</c>, <c>family</c>).</param>
+  public BundleObject Object(
+    string applicationId,
+    BundleCollection? collection,
+    IReadOnlyDictionary<string, object?>? properties,
+    string? name = null,
+    string? speckleType = null,
+    string? sourceType = null,
+    string? units = null,
+    string? typeKey = null,
+    IEnumerable<KeyValuePair<string, object?>>? rootScalars = null
+  )
+  {
+    if (_objects.TryGetValue(applicationId, out var existing))
+    {
+      return existing;
+    }
+    int k = Pipeline.InternObject(applicationId);
+    var scalars = new List<KeyValuePair<string, object?>>
+    {
+      new("speckle_type", speckleType),
+      new("name", name),
+      new("units", units ?? Units),
+      new("type", sourceType),
+    };
+    if (rootScalars is not null)
+    {
+      scalars.AddRange(rootScalars);
+    }
+    Pipeline.AddProperties(applicationId, properties ?? s_noProperties, scalars, typeKey);
+
+    var obj = new BundleObject(this, k, applicationId, name);
+    _objects[applicationId] = obj;
+    if (collection is not null)
+    {
+      obj.Collection = collection;
+    }
+    return obj;
+  }
+
+  private static readonly IReadOnlyDictionary<string, object?> s_noProperties = new Dictionary<string, object?>();
+
+  // ── value nodes ───────────────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>Gets or creates a MATERIAL node. <paramref name="key"/> is the dedup identity (host material id);
+  /// <paramref name="name"/> is the authored name receivers recreate the host material under.</summary>
+  public BundleMaterial Material(
+    string key,
+    string? name,
+    int argb,
+    double opacity = 1,
+    double metalness = 0,
+    double roughness = 1,
+    int? emissive = null,
+    double? ior = null
+  )
+  {
+    if (_materials.TryGetValue(key, out var existing))
+    {
+      return existing;
+    }
+    int k = Pipeline.AddMaterial(key, name, argb, opacity, metalness, roughness, emissive, ior);
+    var m = new BundleMaterial(this, k, key, name, argb);
+    _materials[key] = m;
+    return m;
+  }
+
+  /// <summary>Gets or creates a COLOR node, keyed by its ARGB value.</summary>
+  public BundleColor Color(int argb)
+  {
+    if (_colors.TryGetValue(argb, out var existing))
+    {
+      return existing;
+    }
+    var c = new BundleColor(this, Pipeline.AddColor(argb), argb);
+    _colors[argb] = c;
+    return c;
+  }
+
+  /// <summary>Gets or creates a LEVEL node.</summary>
+  public BundleLevel Level(string key, string? name, double elevation)
+  {
+    if (_levels.TryGetValue(key, out var existing))
+    {
+      return existing;
+    }
+    var l = new BundleLevel(this, Pipeline.AddLevel(key, name, elevation), key, name, elevation);
+    _levels[key] = l;
+    return l;
+  }
+
+  /// <summary>Gets or creates a DEFINITION (block / family symbol). <paramref name="populate"/> runs only on first
+  /// creation — put the definition's geometry, nested placements and member objects there.</summary>
+  public BundleDefinition Definition(string key, string? name, Action<BundleDefinition>? populate = null)
+  {
+    if (_definitions.TryGetValue(key, out var existing))
+    {
+      return existing;
+    }
+    var d = new BundleDefinition(this, Pipeline.AddDefinition(key, name), key, name);
+    _definitions[key] = d;
+    populate?.Invoke(d);
+    return d;
+  }
+
+  // ── model-scoped extras ───────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>A model-scoped attribute (<c>eav.model</c>): project information, the placement transform, document
+  /// settings — anything with no owning object. Null values write nothing.</summary>
+  public void ModelProperty(string path, object? value, string? unit = null) =>
+    Pipeline.AddModelProperty(path, value, unit);
+
+  /// <summary>One analysis-result row (<c>eav.structural_results</c>); see <see cref="ObjectsArtifactPipeline.AddStructuralResult"/>.</summary>
+  public void StructuralResult(
+    BundleObject? owner,
+    string? location,
+    string resultType,
+    string loadCase,
+    string component,
+    double? station = null,
+    int? step = null,
+    double? value = null,
+    string? valueText = null,
+    string? elementName = null,
+    string? positionLabel = null
+  ) =>
+    Pipeline.AddStructuralResult(
+      owner?.ApplicationId,
+      location,
+      resultType,
+      loadCase,
+      component,
+      station,
+      step,
+      value,
+      valueText,
+      elementName,
+      positionLabel
+    );
+
+  /// <summary>One property-set field definition (<c>eav.property_set_definitions</c>), in authored field order.</summary>
+  public void PropertySetDefinition(
+    string setName,
+    string setKey,
+    string fieldName,
+    string? fieldBucketId,
+    string? dataType,
+    string? defaultString = null,
+    double? defaultDouble = null,
+    bool? defaultBoolean = null,
+    string? unit = null,
+    string? description = null,
+    string? setDescription = null,
+    string? appliesTo = null
+  ) =>
+    Pipeline.AddPropertySetDefinition(
+      setName,
+      setKey,
+      fieldName,
+      fieldBucketId,
+      dataType,
+      defaultString,
+      defaultDouble,
+      defaultBoolean,
+      unit,
+      description,
+      setDescription,
+      appliesTo
+    );
+
+  /// <summary>A named camera viewpoint (<c>envelope.camera_views</c>).</summary>
+  public void CameraView(CameraView view) => Pipeline.AddCameraView(view);
+
+  /// <summary>
+  /// Declares a scene view — how the viewer groups objects. Tiers are outermost first; each is either a relation
+  /// (<see cref="SceneViewKey.Rel"/>: <c>IN_MODEL</c>, <c>ON_LEVEL</c>, <c>IN_COLLECTION</c> …) or a property value
+  /// (<see cref="SceneViewKey.Eav"/>: <c>"category"</c>). When no view is declared by <see cref="Build"/>, the
+  /// default view is the authored collection tree (<c>IN_COLLECTION</c>).
+  /// </summary>
+  public void SceneView(string name, bool isDefault, params SceneViewKey[] tiers)
+  {
+    var view = new SceneView(_sceneViews.Count, name, isDefault, tiers);
+    _sceneViews.Add(view);
+    Pipeline.AddSceneView(view);
+  }
+
+  // ── finish ────────────────────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>Flushes every table and returns the files. Adds the default <c>IN_COLLECTION</c> scene view if none
+  /// was declared. Callable once.</summary>
+  public BundleFiles Build()
+  {
+    if (_built)
+    {
+      throw new InvalidOperationException("Build() has already been called on this BundleBuilder.");
+    }
+    _built = true;
+    if (_sceneViews.Count == 0)
+    {
+      SceneView("Default", isDefault: true, SceneViewKey.Rel(RelKind.InCollection));
+    }
+    Pipeline.SetProducer(Producer);
+    Pipeline.Complete();
+
+    var files = System
+      .IO.Directory.EnumerateFiles(Directory, BaseName + ".*")
+      .Where(p => p.EndsWith(".parquet", StringComparison.Ordinal))
+      .OrderBy(p => p, StringComparer.Ordinal)
+      .ToList();
+    return new BundleFiles(Directory, BaseName, files, _objects.Count);
+  }
+
+  public void Dispose()
+  {
+    if (_disposed)
+    {
+      return;
+    }
+    _disposed = true;
+    Pipeline.Dispose();
+  }
+}
+
+/// <summary>The written bundle: where it is and what it contains. Hand <see cref="Files"/> to the uploader.</summary>
+public sealed class BundleFiles
+{
+  internal BundleFiles(string directory, string baseName, IReadOnlyList<string> files, int objectCount)
+  {
+    Directory = directory;
+    BaseName = baseName;
+    Files = files;
+    ObjectCount = objectCount;
+  }
+
+  public string Directory { get; }
+  public string BaseName { get; }
+
+  /// <summary>Full paths, sorted.</summary>
+  public IReadOnlyList<string> Files { get; }
+
+  public int ObjectCount { get; }
+
+  /// <summary>File name → full path, as the v2 upload endpoints key files.</summary>
+  public IReadOnlyDictionary<string, string> ByName =>
+    Files.ToDictionary(p => Path.GetFileName(p), p => p, StringComparer.Ordinal);
+
+  /// <summary>
+  /// Re-keys every file from <see cref="BaseName"/> to <paramref name="versionId"/> (<c>{versionId}.eav.parquet</c> …) —
+  /// the server pre-allocates the version id at ingestion time and keys uploads per basename, so a bundle built
+  /// before the id is known is renamed rather than rewritten.
+  /// </summary>
+  public BundleFiles RenameTo(string versionId)
+  {
+    if (versionId == BaseName)
+    {
+      return this;
+    }
+    var renamed = new List<string>(Files.Count);
+    foreach (var path in Files)
+    {
+      string name = Path.GetFileName(path);
+#if NETSTANDARD2_0
+      string target = Path.Combine(Directory, versionId + name.Substring(BaseName.Length));
+#else
+      string target = Path.Combine(Directory, string.Concat(versionId, name.AsSpan(BaseName.Length)));
+#endif
+      File.Move(path, target);
+      renamed.Add(target);
+    }
+    return new BundleFiles(Directory, versionId, renamed, ObjectCount);
+  }
+}

--- a/src/Speckle.Sdk/Bundles/BundleBuilder.cs
+++ b/src/Speckle.Sdk/Bundles/BundleBuilder.cs
@@ -16,7 +16,7 @@ namespace Speckle.Sdk.Bundles;
 /// Typical shape:
 /// <code>
 /// using var b = new BundleBuilder(app, units: "m");
-/// var walls = b.GetOrAddCollection(["Level 1", "Walls"], subtype: "Category");
+/// var walls = b.GetOrAddContainerPath(["Level 1", "Walls"], subtype: "Category");
 /// var wall  = b.GetOrAddObject("wall-1");
 /// wall.SetProperties(properties, name: "Basic Wall", speckleType: "Objects.Data.DataObject");
 /// wall.Collection = walls;
@@ -36,7 +36,7 @@ public sealed class BundleBuilder : IDisposable
   private const string DEFAULT_BASE_NAME = "bundle";
 
   private readonly Dictionary<string, BundleObject> _objects = new(StringComparer.Ordinal);
-  private readonly Dictionary<string, BundleCollection> _collections = new(StringComparer.Ordinal);
+  private readonly Dictionary<string, BundleContainer> _containers = new(StringComparer.Ordinal);
   private readonly Dictionary<string, BundleDefinition> _definitions = new(StringComparer.Ordinal);
   private readonly Dictionary<string, BundleMaterial> _materials = new(StringComparer.Ordinal);
   private readonly Dictionary<int, BundleColor> _colors = new();
@@ -74,14 +74,16 @@ public sealed class BundleBuilder : IDisposable
 
   internal ObjectsArtifactPipeline Pipeline { get; }
 
-  // ── scene tree ────────────────────────────────────────────────────────────────────────────────────────
+  // ── containers (scene tree) ────────────────────────────────────────────────────────────────────────────────────────
 
-  /// <summary>Gets or creates the CONTAINER chain for a path (<c>["Level 1", "Walls"]</c>) — one node per segment,
-  /// parent-linked. Each segment is keyed by its full path, so two branches sharing a name stay distinct.</summary>
+  /// <summary>Gets or creates a CONTAINER chain for a name path (<c>["Level 1", "Walls"]</c>) — one node per segment,
+  /// parent-linked, each keyed by its full path so two branches sharing a name stay distinct. Containers are the
+  /// scene-tree nodes (spec node kind CONTAINER; <paramref name="subtype"/> says which flavour); objects join them
+  /// through the <c>IN_COLLECTION</c> / <c>IN_MODEL</c> / <c>IN_GROUP</c> / <c>IN_SYSTEM</c> rels.</summary>
   /// <param name="subtype">Tag for the leaf (and any newly created ancestors): <c>"Layer"</c>, <c>"Category"</c>,
   /// <c>"Collection"</c> …</param>
   /// <param name="ghTopology">Grasshopper data-tree topology for the leaf (<c>nodes.gh_topology</c>); null otherwise.</param>
-  public BundleCollection GetOrAddCollection(
+  public BundleContainer GetOrAddContainerPath(
     IReadOnlyList<string> path,
     string subtype = "Collection",
     string? ghTopology = null
@@ -91,7 +93,7 @@ public sealed class BundleBuilder : IDisposable
     {
       throw new ArgumentException("A collection path needs at least one segment.", nameof(path));
     }
-    BundleCollection? parent = null;
+    BundleContainer? parent = null;
     string key = "";
     foreach (var segment in path)
     {
@@ -104,15 +106,15 @@ public sealed class BundleBuilder : IDisposable
 
   /// <summary>Gets or creates one CONTAINER by explicit key — for containers that aren't a name path: a federated
   /// <c>Model</c>, a <c>Group</c>, an MEP <c>System</c>/<c>Network</c>.</summary>
-  public BundleCollection GetOrAddContainer(
+  public BundleContainer GetOrAddContainer(
     string key,
     string? name,
-    BundleCollection? parent,
+    BundleContainer? parent,
     string subtype,
     string? ghTopology = null
   )
   {
-    if (_collections.TryGetValue(key, out var existing))
+    if (_containers.TryGetValue(key, out var existing))
     {
       Same(key, existing.Name, name, "name");
       Same(key, existing.Subtype, subtype, "subtype");
@@ -120,8 +122,8 @@ public sealed class BundleBuilder : IDisposable
       return existing;
     }
     int k = Pipeline.AddCollection(key, name, parent?.K, subtype, ghTopology);
-    var c = new BundleCollection(this, k, key, name, subtype, parent);
-    _collections[key] = c;
+    var c = new BundleContainer(this, k, key, name, subtype, parent);
+    _containers[key] = c;
     return c;
   }
 

--- a/src/Speckle.Sdk/Bundles/BundleBuilder.cs
+++ b/src/Speckle.Sdk/Bundles/BundleBuilder.cs
@@ -78,7 +78,12 @@ public sealed class BundleBuilder : IDisposable
   /// parent-linked. Each segment is keyed by its full path, so two branches sharing a name stay distinct.</summary>
   /// <param name="subtype">Tag for the leaf (and any newly created ancestors): <c>"Layer"</c>, <c>"Category"</c>,
   /// <c>"Collection"</c> …</param>
-  public BundleCollection GetOrAddCollection(IReadOnlyList<string> path, string subtype = "Collection")
+  /// <param name="ghTopology">Grasshopper data-tree topology for the leaf (<c>nodes.gh_topology</c>); null otherwise.</param>
+  public BundleCollection GetOrAddCollection(
+    IReadOnlyList<string> path,
+    string subtype = "Collection",
+    string? ghTopology = null
+  )
   {
     if (path.Count == 0)
     {
@@ -89,14 +94,21 @@ public sealed class BundleBuilder : IDisposable
     foreach (var segment in path)
     {
       key = key.Length == 0 ? segment : key + "/" + segment;
-      parent = GetOrAddContainer(key, segment, parent, subtype);
+      bool leaf = ReferenceEquals(segment, path[path.Count - 1]);
+      parent = GetOrAddContainer(key, segment, parent, subtype, leaf ? ghTopology : null);
     }
     return parent!;
   }
 
   /// <summary>Gets or creates one CONTAINER by explicit key — for containers that aren't a name path: a federated
   /// <c>Model</c>, a <c>Group</c>, an MEP <c>System</c>/<c>Network</c>.</summary>
-  public BundleCollection GetOrAddContainer(string key, string? name, BundleCollection? parent, string subtype)
+  public BundleCollection GetOrAddContainer(
+    string key,
+    string? name,
+    BundleCollection? parent,
+    string subtype,
+    string? ghTopology = null
+  )
   {
     if (_collections.TryGetValue(key, out var existing))
     {
@@ -105,7 +117,7 @@ public sealed class BundleBuilder : IDisposable
       Same(key, existing.Parent?.Key, parent?.Key, "parent");
       return existing;
     }
-    int k = Pipeline.AddContainer(key, name, parent?.K, subtype);
+    int k = Pipeline.AddCollection(key, name, parent?.K, subtype, ghTopology);
     var c = new BundleCollection(this, k, key, name, subtype, parent);
     _collections[key] = c;
     return c;

--- a/src/Speckle.Sdk/Bundles/BundleHandles.cs
+++ b/src/Speckle.Sdk/Bundles/BundleHandles.cs
@@ -166,20 +166,77 @@ public sealed class BundleDefinition : BundleNode
     return new BundleInstance(Builder, instK, definition);
   }
 
-  /// <summary>Declares <paramref name="member"/> an authored member of this definition (<c>DEFINES_MEMBER</c>, ordinal
-  /// shared with the member's geometry); a nested-block member also gets <c>PLACES</c> to its placement.</summary>
-  public void AddMember(BundleObject member, int? memberOrd = null, BundleInstance? placement = null)
+  /// <summary>
+  /// An authored member of this definition that owns its own geometry (Rhino / AutoCAD block contents): the member's
+  /// object row carries its layer and properties, its geometry renders ONLY through placements of this definition —
+  /// so it gets <c>DEFINES</c> + <c>DEFINES_MEMBER</c> on one member ordinal and no <c>DISPLAY</c> edge of its own.
+  /// Returns the geometry handles (set <see cref="BundleGeometry.Material"/> on them as usual).
+  /// </summary>
+  public IReadOnlyList<BundleGeometry> AddMember(BundleObject member, IEnumerable<Base> geometry, int? memberOrd = null)
   {
-    Builder.Pipeline.DefinesMember(K, member.K, memberOrd ?? _memberOrd++);
-    if (placement is not null)
+    int ord = memberOrd ?? NextMemberOrdinal();
+    Builder.Pipeline.DefinesMember(K, member.K, ord);
+    var handles = new List<BundleGeometry>();
+    int i = 0;
+    foreach (var g in geometry)
     {
-      Builder.Pipeline.Places(member.K, placement.K);
+      string key = $"{member.ApplicationId}:g{i++}";
+      int gK = Builder.Pipeline.AddGeometry(key, g);
+      Builder.Pipeline.Defines(K, gK, ord);
+      handles.Add(Builder.RegisterGeometry(key, new BundleGeometry(Builder, gK, ord)));
     }
+    Bump(ord);
+    return handles;
   }
 
-  /// <summary>Next member ordinal — hand it to both <see cref="AddGeometry"/> and <see cref="AddMember"/> so a member's
-  /// geometry and its object row join on the same ordinal.</summary>
+  /// <summary>A member's raw host geometry (a 3dm solid) alongside its display meshes — same member ordinal, so a
+  /// receiver can pick the solid over its shadow. Call after <see cref="AddMember(BundleObject, IEnumerable{Base}, int?)"/>
+  /// with the ordinal it returned via <see cref="BundleGeometry.Ord"/>.</summary>
+  public BundleGeometry AddMemberRawGeometry(BundleObject member, byte[] content, string type, int memberOrd)
+  {
+    string key = $"{member.ApplicationId}:raw{memberOrd}";
+    int gK = Builder.Pipeline.AddRawGeometry(key, content, type);
+    Builder.Pipeline.Defines(K, gK, memberOrd);
+    return Builder.RegisterGeometry(key, new BundleGeometry(Builder, gK, memberOrd));
+  }
+
+  /// <summary>A member that is itself a placement of another definition (a block inside a block): <c>INSTANCE</c> +
+  /// <c>DEFINES_INSTANCE</c> + <c>DEFINES_MEMBER</c> + <c>PLACES</c> (member → its placement), no <c>DISPLAY_INSTANCE</c>.</summary>
+  public BundleInstance AddMemberPlacement(
+    BundleObject member,
+    BundleDefinition nested,
+    IReadOnlyList<double> transform,
+    string? units = null,
+    int? memberOrd = null
+  )
+  {
+    int ord = memberOrd ?? NextMemberOrdinal();
+    int instK = Builder.Pipeline.AddInstance(member.ApplicationId, nested.K, transform, units ?? Builder.Units);
+    Builder.Pipeline.DefinesInstance(K, instK, ord);
+    Builder.Pipeline.DefinesMember(K, member.K, ord);
+    Builder.Pipeline.Places(member.K, instK);
+    Bump(ord);
+    return new BundleInstance(Builder, instK, nested);
+  }
+
+  /// <summary>References geometry already written elsewhere (Revit: a family's mesh added under an element, shared by
+  /// the symbol) as this definition's geometry (<c>DEFINES</c>), without re-encoding.</summary>
+  public void AddExistingGeometry(BundleGeometry geometry, int? memberOrd = null)
+  {
+    int ord = memberOrd ?? NextMemberOrdinal();
+    Builder.Pipeline.Defines(K, geometry.K, ord);
+    Bump(ord);
+  }
+
+  /// <summary>The next unused member ordinal. The (definition, ordinal) pair joins a member's object row to its
+  /// geometry, which is what survives content-hash geometry dedup.</summary>
   public int NextMemberOrdinal() => Math.Max(_geometryOrd, _memberOrd);
+
+  private void Bump(int ord)
+  {
+    _memberOrd = Math.Max(_memberOrd, ord + 1);
+    _geometryOrd = Math.Max(_geometryOrd, ord + 1);
+  }
 }
 
 /// <summary>An INSTANCE node: one placement of a <see cref="BundleDefinition"/>.</summary>
@@ -262,19 +319,27 @@ public sealed class BundleObject
   private BundleObject? _host;
   private BundleObject? _room;
 
-  internal BundleObject(BundleBuilder builder, int k, string applicationId, string? name)
+  internal BundleObject(BundleBuilder builder, int k, string applicationId)
   {
     _builder = builder;
     K = k;
     ApplicationId = applicationId;
-    Name = name;
   }
 
   /// <summary>Dense object index inside this bundle.</summary>
   public int K { get; }
 
   public string ApplicationId { get; }
-  public string? Name { get; }
+  public string? Name { get; private set; }
+
+  /// <summary>Whether properties (and root scalars) have been written for this object.</summary>
+  public bool PropertiesWritten { get; private set; }
+
+  internal void MarkDescribed(string? name)
+  {
+    PropertiesWritten = true;
+    Name = name;
+  }
 
   public IReadOnlyList<BundleGeometry> Geometries => _geometries;
 
@@ -284,9 +349,10 @@ public sealed class BundleObject
   public BundleGeometry AddGeometry(Base geometry, string? geometryKey = null)
   {
     int ord = _ord++;
-    int gK = _builder.Pipeline.AddGeometry(geometryKey ?? $"{ApplicationId}:g{ord}", geometry);
+    string key = geometryKey ?? $"{ApplicationId}:g{ord}";
+    int gK = _builder.Pipeline.AddGeometry(key, geometry);
     _builder.Pipeline.Display(K, gK, ord);
-    var g = new BundleGeometry(_builder, gK, ord);
+    var g = _builder.RegisterGeometry(key, new BundleGeometry(_builder, gK, ord));
     _geometries.Add(g);
     return g;
   }
@@ -296,9 +362,10 @@ public sealed class BundleObject
   public BundleGeometry AddRawGeometry(byte[] content, string type, string? geometryKey = null)
   {
     int ord = _ord++;
-    int gK = _builder.Pipeline.AddRawGeometry(geometryKey ?? $"{ApplicationId}:raw{ord}", content, type);
+    string key = geometryKey ?? $"{ApplicationId}:raw{ord}";
+    int gK = _builder.Pipeline.AddRawGeometry(key, content, type);
     _builder.Pipeline.Solid(K, gK, ord);
-    var g = new BundleGeometry(_builder, gK, ord);
+    var g = _builder.RegisterGeometry(key, new BundleGeometry(_builder, gK, ord));
     _geometries.Add(g);
     return g;
   }
@@ -372,14 +439,41 @@ public sealed class BundleObject
 
   // ── object → object ───────────────────────────────────────────────────────────────────────────────────
 
-  /// <summary>Owning element (<c>SUBELEMENT</c>): this object is a component of <c>Parent</c>.</summary>
+  /// <summary>Owning element (<c>SUBELEMENT</c>): this object is a component of <c>Parent</c>. Sugar for
+  /// <c>value.AddChild(this)</c> with the next child ordinal.</summary>
   public BundleObject? Parent
   {
     get => _parent;
-    set => Set(ref _parent, value, k => _builder.Pipeline.Subelement(k, K, value!._childOrd++));
+    set
+    {
+      if (value is not null && !ReferenceEquals(_parent, value))
+      {
+        value.AddChild(this);
+      }
+    }
   }
 
   private int _childOrd;
+
+  /// <summary>Declares <paramref name="child"/> a component of this object (<c>SUBELEMENT</c>). <paramref name="ord"/>
+  /// is the child's position; null = next.</summary>
+  public void AddChild(BundleObject child, int? ord = null)
+  {
+    if (child._parent is not null)
+    {
+      if (ReferenceEquals(child._parent, this))
+      {
+        return;
+      }
+      throw new InvalidOperationException(
+        $"Object '{child.ApplicationId}' already has parent '{child._parent.ApplicationId}'; a bundle edge cannot be retracted."
+      );
+    }
+    int o = ord ?? _childOrd;
+    _childOrd = Math.Max(_childOrd, o + 1);
+    child._parent = this;
+    _builder.Pipeline.Subelement(K, child.K, o);
+  }
 
   /// <summary>Host (<c>HOSTED_ON</c>): the wall a door is placed on. Not ownership.</summary>
   public BundleObject? Host

--- a/src/Speckle.Sdk/Bundles/BundleHandles.cs
+++ b/src/Speckle.Sdk/Bundles/BundleHandles.cs
@@ -1,0 +1,429 @@
+using Speckle.Sdk.Models;
+
+namespace Speckle.Sdk.Bundles;
+
+/// <summary>A node handle: carries the dense K the pipeline assigned. Handles are only valid on the builder that made them.</summary>
+public abstract class BundleNode
+{
+  private protected BundleNode(BundleBuilder builder, int k)
+  {
+    Builder = builder;
+    K = k;
+  }
+
+  internal BundleBuilder Builder { get; }
+
+  /// <summary>Dense node index inside this bundle.</summary>
+  public int K { get; }
+
+  private BundleMaterial? _material;
+  private BundleColor? _color;
+
+  /// <summary>Material painted on the node itself (<c>NODE_HAS_MATERIAL</c>): a layer's render material, a placement's override.</summary>
+  public BundleMaterial? Material
+  {
+    get => _material;
+    set
+    {
+      if (value is not null && !ReferenceEquals(_material, value))
+      {
+        Builder.Pipeline.NodeHasMaterial(K, value.K);
+      }
+      _material = value;
+    }
+  }
+
+  /// <summary>Colour painted on the node itself (<c>NODE_HAS_COLOR</c>): a layer / tag display colour.</summary>
+  public BundleColor? Color
+  {
+    get => _color;
+    set
+    {
+      if (value is not null && !ReferenceEquals(_color, value))
+      {
+        Builder.Pipeline.NodeHasColor(K, value.K);
+      }
+      _color = value;
+    }
+  }
+}
+
+/// <summary>A CONTAINER node: layer, category, folder, federated model, group, MEP system … (<see cref="Subtype"/>).</summary>
+public sealed class BundleCollection : BundleNode
+{
+  internal BundleCollection(
+    BundleBuilder builder,
+    int k,
+    string key,
+    string? name,
+    string subtype,
+    BundleCollection? parent
+  )
+    : base(builder, k)
+  {
+    Key = key;
+    Name = name;
+    Subtype = subtype;
+    Parent = parent;
+  }
+
+  public string Key { get; }
+  public string? Name { get; }
+  public string Subtype { get; }
+  public BundleCollection? Parent { get; }
+
+  public override string ToString() => $"{Subtype} '{Name}'";
+}
+
+public sealed class BundleLevel : BundleNode
+{
+  internal BundleLevel(BundleBuilder builder, int k, string key, string? name, double elevation)
+    : base(builder, k)
+  {
+    Key = key;
+    Name = name;
+    Elevation = elevation;
+  }
+
+  public string Key { get; }
+  public string? Name { get; }
+  public double Elevation { get; }
+}
+
+public sealed class BundleMaterial : BundleNode
+{
+  internal BundleMaterial(BundleBuilder builder, int k, string key, string? name, int argb)
+    : base(builder, k)
+  {
+    Key = key;
+    Name = name;
+    Argb = argb;
+  }
+
+  public string Key { get; }
+  public string? Name { get; }
+  public int Argb { get; }
+}
+
+public sealed class BundleColor : BundleNode
+{
+  internal BundleColor(BundleBuilder builder, int k, int argb)
+    : base(builder, k)
+  {
+    Argb = argb;
+  }
+
+  public int Argb { get; }
+}
+
+/// <summary>A DEFINITION node (block / family symbol): geometry shared by every placement, plus nested placements
+/// and member objects.</summary>
+public sealed class BundleDefinition : BundleNode
+{
+  private int _geometryOrd;
+  private int _memberOrd;
+
+  internal BundleDefinition(BundleBuilder builder, int k, string key, string? name)
+    : base(builder, k)
+  {
+    Key = key;
+    Name = name;
+  }
+
+  public string Key { get; }
+  public string? Name { get; }
+
+  /// <summary>Definition geometry (<c>DEFINES</c>). <paramref name="memberOrd"/> groups several geometries under one
+  /// member (a member's solid and its display meshes share an ordinal); null = next ordinal.</summary>
+  public BundleGeometry AddGeometry(Base geometry, string? geometryKey = null, int? memberOrd = null)
+  {
+    int ord = memberOrd ?? _geometryOrd++;
+    int gK = Builder.Pipeline.AddGeometry(geometryKey ?? $"{Key}:g{ord}", geometry);
+    Builder.Pipeline.Defines(K, gK, ord);
+    return new BundleGeometry(Builder, gK, ord);
+  }
+
+  /// <summary>Raw host-format definition geometry (a 3dm brep), kept losslessly next to its display meshes.</summary>
+  public BundleGeometry AddRawGeometry(byte[] content, string type, string? geometryKey = null, int? memberOrd = null)
+  {
+    int ord = memberOrd ?? _geometryOrd++;
+    int gK = Builder.Pipeline.AddRawGeometry(geometryKey ?? $"{Key}:raw{ord}", content, type);
+    Builder.Pipeline.Defines(K, gK, ord);
+    return new BundleGeometry(Builder, gK, ord);
+  }
+
+  /// <summary>A nested placement inside this definition (<c>DEFINES_INSTANCE</c>): a block that contains a block.</summary>
+  public BundleInstance PlaceNested(
+    BundleDefinition definition,
+    IReadOnlyList<double> transform,
+    string? units,
+    string? key = null
+  )
+  {
+    int ord = _geometryOrd++;
+    int instK = Builder.Pipeline.AddInstance(key ?? $"{Key}:inst{ord}", definition.K, transform, units);
+    Builder.Pipeline.DefinesInstance(K, instK, ord);
+    return new BundleInstance(Builder, instK, definition);
+  }
+
+  /// <summary>Declares <paramref name="member"/> an authored member of this definition (<c>DEFINES_MEMBER</c>, ordinal
+  /// shared with the member's geometry); a nested-block member also gets <c>PLACES</c> to its placement.</summary>
+  public void AddMember(BundleObject member, int? memberOrd = null, BundleInstance? placement = null)
+  {
+    Builder.Pipeline.DefinesMember(K, member.K, memberOrd ?? _memberOrd++);
+    if (placement is not null)
+    {
+      Builder.Pipeline.Places(member.K, placement.K);
+    }
+  }
+
+  /// <summary>Next member ordinal — hand it to both <see cref="AddGeometry"/> and <see cref="AddMember"/> so a member's
+  /// geometry and its object row join on the same ordinal.</summary>
+  public int NextMemberOrdinal() => Math.Max(_geometryOrd, _memberOrd);
+}
+
+/// <summary>An INSTANCE node: one placement of a <see cref="BundleDefinition"/>.</summary>
+public sealed class BundleInstance : BundleNode
+{
+  internal BundleInstance(BundleBuilder builder, int k, BundleDefinition definition)
+    : base(builder, k)
+  {
+    Definition = definition;
+  }
+
+  public BundleDefinition Definition { get; }
+}
+
+/// <summary>One geometry (SGEO mesh or raw host blob) already written; set <see cref="Material"/> / <see cref="Color"/>
+/// for per-geometry appearance (<c>HAS_MATERIAL</c> / <c>HAS_COLOR</c>, the geometry plane).</summary>
+public sealed class BundleGeometry
+{
+  private readonly BundleBuilder _builder;
+  private BundleMaterial? _material;
+  private BundleColor? _color;
+
+  internal BundleGeometry(BundleBuilder builder, int k, int ord)
+  {
+    _builder = builder;
+    K = k;
+    Ord = ord;
+  }
+
+  /// <summary>Dense geometry index inside this bundle.</summary>
+  public int K { get; }
+
+  /// <summary>Draw order within its owner.</summary>
+  public int Ord { get; }
+
+  public BundleMaterial? Material
+  {
+    get => _material;
+    set
+    {
+      if (value is not null && !ReferenceEquals(_material, value))
+      {
+        _builder.Pipeline.HasMaterial(K, value.K);
+      }
+      _material = value;
+    }
+  }
+
+  public BundleColor? Color
+  {
+    get => _color;
+    set
+    {
+      if (value is not null && !ReferenceEquals(_color, value))
+      {
+        _builder.Pipeline.HasColor(K, value.K);
+      }
+      _color = value;
+    }
+  }
+}
+
+/// <summary>
+/// An object being written: the property carrier a host element becomes. Geometry, placements and every relation
+/// hang off it; each setter writes its edge immediately, so set each relation once.
+/// </summary>
+public sealed class BundleObject
+{
+  private readonly BundleBuilder _builder;
+  private readonly List<BundleGeometry> _geometries = new();
+  private int _ord;
+  private int _placementOrd;
+  private BundleCollection? _collection;
+  private BundleCollection? _model;
+  private BundleCollection? _system;
+  private BundleLevel? _level;
+  private BundleMaterial? _material;
+  private BundleColor? _color;
+  private BundleObject? _parent;
+  private BundleObject? _host;
+  private BundleObject? _room;
+
+  internal BundleObject(BundleBuilder builder, int k, string applicationId, string? name)
+  {
+    _builder = builder;
+    K = k;
+    ApplicationId = applicationId;
+    Name = name;
+  }
+
+  /// <summary>Dense object index inside this bundle.</summary>
+  public int K { get; }
+
+  public string ApplicationId { get; }
+  public string? Name { get; }
+
+  public IReadOnlyList<BundleGeometry> Geometries => _geometries;
+
+  // ── geometry ──────────────────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>Render geometry (<c>DISPLAY</c>), SGEO-encoded now. Ordinal = call order.</summary>
+  public BundleGeometry AddGeometry(Base geometry, string? geometryKey = null)
+  {
+    int ord = _ord++;
+    int gK = _builder.Pipeline.AddGeometry(geometryKey ?? $"{ApplicationId}:g{ord}", geometry);
+    _builder.Pipeline.Display(K, gK, ord);
+    var g = new BundleGeometry(_builder, gK, ord);
+    _geometries.Add(g);
+    return g;
+  }
+
+  /// <summary>Authoritative host solid (<c>SOLID</c>): raw bytes kept verbatim (a 3dm brep, <c>type = "3dm"</c>) so a
+  /// host that can import them bakes the real solid instead of the display mesh.</summary>
+  public BundleGeometry AddRawGeometry(byte[] content, string type, string? geometryKey = null)
+  {
+    int ord = _ord++;
+    int gK = _builder.Pipeline.AddRawGeometry(geometryKey ?? $"{ApplicationId}:raw{ord}", content, type);
+    _builder.Pipeline.Solid(K, gK, ord);
+    var g = new BundleGeometry(_builder, gK, ord);
+    _geometries.Add(g);
+    return g;
+  }
+
+  /// <summary>Renders this object through a placement of <paramref name="definition"/> (<c>DISPLAY_INSTANCE</c>).
+  /// <paramref name="transform"/> is 16 row-major values. An object may place several instances.</summary>
+  public BundleInstance Place(
+    BundleDefinition definition,
+    IReadOnlyList<double> transform,
+    string? units = null,
+    string? key = null
+  )
+  {
+    int ord = _placementOrd++;
+    int instK = _builder.Pipeline.AddInstance(
+      key ?? $"{ApplicationId}:inst{ord}",
+      definition.K,
+      transform,
+      units ?? _builder.Units
+    );
+    _builder.Pipeline.DisplayInstance(K, instK, ord);
+    return new BundleInstance(_builder, instK, definition);
+  }
+
+  // ── object → node ─────────────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>Authored scene-tree container (<c>IN_COLLECTION</c>).</summary>
+  public BundleCollection? Collection
+  {
+    get => _collection;
+    set => Set(ref _collection, value, k => _builder.Pipeline.InCollection(K, k, 0));
+  }
+
+  /// <summary>Federated-model container (<c>IN_MODEL</c>): the Revit host / linked model the object came from.</summary>
+  public BundleCollection? Model
+  {
+    get => _model;
+    set => Set(ref _model, value, k => _builder.Pipeline.InModel(K, k, 0));
+  }
+
+  /// <summary>MEP system / network container (<c>IN_SYSTEM</c>).</summary>
+  public BundleCollection? System
+  {
+    get => _system;
+    set => Set(ref _system, value, k => _builder.Pipeline.InSystem(K, k, 0));
+  }
+
+  /// <summary>Storey (<c>ON_LEVEL</c>).</summary>
+  public BundleLevel? Level
+  {
+    get => _level;
+    set => Set(ref _level, value, k => _builder.Pipeline.OnLevel(K, k));
+  }
+
+  /// <summary>Object-plane material (<c>OBJECT_HAS_MATERIAL</c>): fills where a geometry has none of its own.</summary>
+  public BundleMaterial? Material
+  {
+    get => _material;
+    set => Set(ref _material, value, k => _builder.Pipeline.ObjectHasMaterial(K, k));
+  }
+
+  /// <summary>Object-plane colour (<c>OBJECT_HAS_COLOR</c>): overrides the geometry's own.</summary>
+  public BundleColor? Color
+  {
+    get => _color;
+    set => Set(ref _color, value, k => _builder.Pipeline.ObjectHasColor(K, k));
+  }
+
+  /// <summary>Authored group membership (<c>IN_GROUP</c>) — an object may sit in several, nested or not.</summary>
+  public void AddToGroup(BundleCollection group, int ord = 0) => _builder.Pipeline.InGroup(K, group.K, ord);
+
+  // ── object → object ───────────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>Owning element (<c>SUBELEMENT</c>): this object is a component of <c>Parent</c>.</summary>
+  public BundleObject? Parent
+  {
+    get => _parent;
+    set => Set(ref _parent, value, k => _builder.Pipeline.Subelement(k, K, value!._childOrd++));
+  }
+
+  private int _childOrd;
+
+  /// <summary>Host (<c>HOSTED_ON</c>): the wall a door is placed on. Not ownership.</summary>
+  public BundleObject? Host
+  {
+    get => _host;
+    set => Set(ref _host, value, k => _builder.Pipeline.HostedOn(K, k));
+  }
+
+  /// <summary>Containing room object (<c>IN_ROOM</c>).</summary>
+  public BundleObject? Room
+  {
+    get => _room;
+    set => Set(ref _room, value, k => _builder.Pipeline.InRoom(K, k, 0));
+  }
+
+  /// <summary>MEP connectivity (<c>CONNECTS_TO</c>); <paramref name="scope"/> is the producer's connection scope tag.</summary>
+  public void ConnectTo(BundleObject other, int scope = 0) => _builder.Pipeline.ConnectsTo(K, other.K, scope);
+
+  /// <summary>This object bounds <paramref name="room"/> (<c>BOUNDS</c>): a wall enclosing a room.</summary>
+  public void Bounds(BundleObject room, int ord = 0) => _builder.Pipeline.Bounds(K, room.K, ord);
+
+  public override string ToString() => Name is null ? ApplicationId : $"{Name} ({ApplicationId})";
+
+  private static void Set<T>(ref T? field, T? value, Action<int> emit)
+    where T : class
+  {
+    if (value is null || ReferenceEquals(field, value))
+    {
+      field = value;
+      return;
+    }
+    if (field is not null)
+    {
+      throw new InvalidOperationException("This relation was already set; a bundle edge cannot be retracted.");
+    }
+    field = value;
+    emit(KOf(value));
+  }
+
+  private static int KOf(object node) =>
+    node switch
+    {
+      BundleNode n => n.K,
+      BundleObject o => o.K,
+      _ => throw new ArgumentException("Not a bundle handle", nameof(node)),
+    };
+}

--- a/src/Speckle.Sdk/Bundles/BundleHandles.cs
+++ b/src/Speckle.Sdk/Bundles/BundleHandles.cs
@@ -309,7 +309,8 @@ public sealed class BundleObject
 {
   private readonly BundleBuilder _builder;
   private readonly List<BundleGeometry> _geometries = new();
-  private int _ord;
+  private int _displayOrd;
+  private int _solidOrd;
   private int _placementOrd;
   private BundleContainer? _collection;
   private BundleContainer? _model;
@@ -375,10 +376,11 @@ public sealed class BundleObject
 
   // ── geometry ──────────────────────────────────────────────────────────────────────────────────────────
 
-  /// <summary>Render geometry (<c>DISPLAY</c>), SGEO-encoded now. Ordinal = call order.</summary>
+  /// <summary>Render geometry (<c>DISPLAY</c>), SGEO-encoded now. Ordinal = call order, counted per relation:
+  /// an object's first display mesh is ord 0 whether or not a solid preceded it.</summary>
   public BundleGeometry AddGeometry(Base geometry, string? geometryKey = null)
   {
-    int ord = _ord++;
+    int ord = _displayOrd++;
     string key = geometryKey ?? $"{ApplicationId}:g{ord}";
     int gK = _builder.Pipeline.AddGeometry(key, geometry);
     _builder.Pipeline.Display(K, gK, ord);
@@ -391,7 +393,7 @@ public sealed class BundleObject
   /// host that can import them bakes the real solid instead of the display mesh.</summary>
   public BundleGeometry AddRawGeometry(byte[] content, string type, string? geometryKey = null)
   {
-    int ord = _ord++;
+    int ord = _solidOrd++;
     string key = geometryKey ?? $"{ApplicationId}:raw{ord}";
     int gK = _builder.Pipeline.AddRawGeometry(key, content, type);
     _builder.Pipeline.Solid(K, gK, ord);

--- a/src/Speckle.Sdk/Bundles/BundleHandles.cs
+++ b/src/Speckle.Sdk/Bundles/BundleHandles.cs
@@ -332,13 +332,41 @@ public sealed class BundleObject
   public string ApplicationId { get; }
   public string? Name { get; private set; }
 
-  /// <summary>Whether properties (and root scalars) have been written for this object.</summary>
+  /// <summary>Whether <see cref="SetProperties"/> has been called.</summary>
   public bool PropertiesWritten { get; private set; }
 
-  internal void MarkDescribed(string? name)
+  /// <summary>
+  /// Writes the object's properties and root scalars — once. <paramref name="properties"/> is the nested tree
+  /// (<c>properties.*</c> in the bundle); the root scalars are what every producer stamps beside it.
+  /// </summary>
+  /// <param name="name">Root <c>name</c>.</param>
+  /// <param name="speckleType">Root <c>speckle_type</c> — what the v3 graph would have carried.</param>
+  /// <param name="sourceType">Root <c>type</c> — the host's own type (Rhino ObjectType, Revit category …).</param>
+  /// <param name="units">Root <c>units</c>; the builder's <see cref="BundleBuilder.Units"/> when null.</param>
+  /// <param name="typeKey">Stable per-type identity (Revit type element UniqueId). When set, <c>Type Parameters</c> /
+  /// <c>System Type Parameters</c> under <c>properties.Parameters</c> are deduplicated into the type tables.</param>
+  /// <param name="rootScalars">Any further root scalars (Revit: <c>category</c>, <c>family</c>).</param>
+  /// <exception cref="InvalidOperationException">Properties were already written for this object.</exception>
+  public BundleObject SetProperties(
+    IReadOnlyDictionary<string, object?>? properties,
+    string? name = null,
+    string? speckleType = null,
+    string? sourceType = null,
+    string? units = null,
+    string? typeKey = null,
+    IEnumerable<KeyValuePair<string, object?>>? rootScalars = null
+  )
   {
+    if (PropertiesWritten)
+    {
+      throw new InvalidOperationException(
+        $"Properties for '{ApplicationId}' were already written; an object's properties are written once."
+      );
+    }
+    _builder.WriteProperties(this, properties, name, speckleType, sourceType, units, typeKey, rootScalars);
     PropertiesWritten = true;
     Name = name;
+    return this;
   }
 
   public IReadOnlyList<BundleGeometry> Geometries => _geometries;

--- a/src/Speckle.Sdk/Bundles/BundleHandles.cs
+++ b/src/Speckle.Sdk/Bundles/BundleHandles.cs
@@ -48,16 +48,18 @@ public abstract class BundleNode
   }
 }
 
-/// <summary>A CONTAINER node: layer, category, folder, federated model, group, MEP system … (<see cref="Subtype"/>).</summary>
-public sealed class BundleCollection : BundleNode
+/// <summary>A CONTAINER node (spec node kind 7): layer, category, folder, federated model, group, MEP system …
+/// (<see cref="Subtype"/>). Objects reference it through a rel — <c>IN_COLLECTION</c> for the authored scene tree,
+/// <c>IN_MODEL</c>, <c>IN_GROUP</c>, <c>IN_SYSTEM</c> for the other axes.</summary>
+public sealed class BundleContainer : BundleNode
 {
-  internal BundleCollection(
+  internal BundleContainer(
     BundleBuilder builder,
     int k,
     string key,
     string? name,
     string subtype,
-    BundleCollection? parent
+    BundleContainer? parent
   )
     : base(builder, k)
   {
@@ -70,7 +72,7 @@ public sealed class BundleCollection : BundleNode
   public string Key { get; }
   public string? Name { get; }
   public string Subtype { get; }
-  public BundleCollection? Parent { get; }
+  public BundleContainer? Parent { get; }
 
   public override string ToString() => $"{Subtype} '{Name}'";
 }
@@ -309,9 +311,9 @@ public sealed class BundleObject
   private readonly List<BundleGeometry> _geometries = new();
   private int _ord;
   private int _placementOrd;
-  private BundleCollection? _collection;
-  private BundleCollection? _model;
-  private BundleCollection? _system;
+  private BundleContainer? _collection;
+  private BundleContainer? _model;
+  private BundleContainer? _system;
   private BundleLevel? _level;
   private BundleMaterial? _material;
   private BundleColor? _color;
@@ -421,21 +423,21 @@ public sealed class BundleObject
   // ── object → node ─────────────────────────────────────────────────────────────────────────────────────
 
   /// <summary>Authored scene-tree container (<c>IN_COLLECTION</c>).</summary>
-  public BundleCollection? Collection
+  public BundleContainer? Collection
   {
     get => _collection;
     set => Set(ref _collection, value, k => _builder.Pipeline.InCollection(K, k, 0));
   }
 
   /// <summary>Federated-model container (<c>IN_MODEL</c>): the Revit host / linked model the object came from.</summary>
-  public BundleCollection? Model
+  public BundleContainer? Model
   {
     get => _model;
     set => Set(ref _model, value, k => _builder.Pipeline.InModel(K, k, 0));
   }
 
   /// <summary>MEP system / network container (<c>IN_SYSTEM</c>).</summary>
-  public BundleCollection? System
+  public BundleContainer? System
   {
     get => _system;
     set => Set(ref _system, value, k => _builder.Pipeline.InSystem(K, k, 0));
@@ -463,7 +465,7 @@ public sealed class BundleObject
   }
 
   /// <summary>Authored group membership (<c>IN_GROUP</c>) — an object may sit in several, nested or not.</summary>
-  public void AddToGroup(BundleCollection group, int ord = 0) => _builder.Pipeline.InGroup(K, group.K, ord);
+  public void AddToGroup(BundleContainer group, int ord = 0) => _builder.Pipeline.InGroup(K, group.K, ord);
 
   // ── object → object ───────────────────────────────────────────────────────────────────────────────────
 

--- a/src/Speckle.Sdk/Bundles/BundleReceiver.cs
+++ b/src/Speckle.Sdk/Bundles/BundleReceiver.cs
@@ -1,0 +1,204 @@
+using Microsoft.Extensions.Logging;
+using Speckle.InterfaceGenerator;
+using Speckle.Objects.Utils;
+using Speckle.Sdk.Api;
+using Speckle.Sdk.Credentials;
+using Speckle.Sdk.Logging;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+namespace Speckle.Sdk.Bundles;
+
+/// <summary>
+/// Fetches a version's artefact bundle over the <c>/api/v2</c> artifacts rail and parses it — the orchestration behind
+/// <see cref="Operations.Receive3(Uri, string, string, string, string?, ReceiveOptions?, CancellationToken)"/>.
+/// The <see cref="Model"/> profile (columnar properties, deferred geometry) is the read surface; the <see cref="Base"/>
+/// profile is the lossy projection <see cref="Operations.Receive2"/> hands legacy scripts.
+/// </summary>
+[GenerateAutoInterface]
+public sealed class BundleReceiver(
+  IArtifactDownloader artifactDownloader,
+  IClientFactory clientFactory,
+  ILogger<BundleReceiver> logger
+) : IBundleReceiver
+{
+  /// <summary>Downloads the bundle into a scratch directory and parses it in the columnar profile. The returned
+  /// <see cref="Model"/> owns the directory; on any failure the directory is removed here.</summary>
+  /// <exception cref="SpeckleException">The server returned no artefact files for this version.</exception>
+  public async Task<Model> ReceiveAsync(
+    Uri url,
+    string projectId,
+    string modelId,
+    string versionId,
+    string? authorizationToken,
+    ReceiveOptions options,
+    CancellationToken cancellationToken
+  )
+  {
+    string bundleDir = await DownloadAsync(
+        url,
+        projectId,
+        modelId,
+        versionId,
+        authorizationToken,
+        options,
+        cancellationToken
+      )
+      .ConfigureAwait(false);
+    try
+    {
+      // Geometry stays on disk until Model.Geometries is touched — it is the bulk of every bundle — and properties
+      // stay columnar (PropertyTable) so memory tracks the parquet size, not a dictionary per nesting level.
+      var bundle = await ArtefactBundleReader
+        .ReadAsync(bundleDir, ArtefactReadOptions.Columnar, cancellationToken)
+        .ConfigureAwait(false);
+      var files = Directory.EnumerateFiles(bundleDir).OrderBy(p => p, StringComparer.Ordinal).ToList();
+      return new Model(projectId, modelId, versionId, bundleDir, files, bundle, options.IncludeGeometry, logger);
+    }
+    catch
+    {
+      TryDeleteDirectory(bundleDir);
+      throw;
+    }
+  }
+
+  /// <summary>
+  /// The legacy projection: downloads the bundle and materializes it into a <see cref="Base"/> tree in the v3
+  /// DataObject idiom (atlas spec <c>2026-08-big-truck-dev-compat</c> §6) — a <c>Collection</c> root carrying
+  /// <c>units</c>, <c>version = 4</c> and the proxy lists; <c>DataObject</c>s keyed by <c>applicationId</c> with
+  /// SGEO-decoded <c>displayValue</c> and nested <c>properties</c>; synthetic per-bundle ids for non-object entities;
+  /// no typed-class rehydration. Reads the eager profile (every property nested, every mesh decoded) — the memory
+  /// cost that makes <see cref="Operations.Receive2"/> obsolete. The scratch files are deleted before returning.
+  /// </summary>
+  public async Task<Base> ReceiveAsBaseAsync(
+    Uri url,
+    string projectId,
+    string modelId,
+    string versionId,
+    string? authorizationToken,
+    CancellationToken cancellationToken
+  )
+  {
+    string bundleDir = await DownloadAsync(
+        url,
+        projectId,
+        modelId,
+        versionId,
+        authorizationToken,
+        ReceiveOptions.Default,
+        cancellationToken
+      )
+      .ConfigureAwait(false);
+    try
+    {
+      var eager = await ArtefactBundleReader
+        .ReadAsync(bundleDir, ArtefactReadOptions.Eager, cancellationToken)
+        .ConfigureAwait(false);
+      var root = new ObjectsArtifactReader().Build(
+        eager,
+        new ArtifactReceiveOptions(PreferSolids: false),
+        cancellationToken
+      );
+      // Vintage marker: lets consumers (and the migrator's IsV3 check) tell a materialized tree from a genuine
+      // v2/v3 graph. Same convention as BundleMigrator's TreeMaterializer.
+      root["version"] = 4;
+      return root;
+    }
+    finally
+    {
+      TryDeleteDirectory(bundleDir);
+    }
+  }
+
+  /// <summary>The model's latest version id, for a url without <c>@versionId</c>.</summary>
+  /// <exception cref="SpeckleException">The model has no versions.</exception>
+  public async Task<string> ResolveLatestVersionIdAsync(ModelUrl url, string? authorizationToken, CancellationToken ct)
+  {
+    using var client = clientFactory.Create(AccountFor(url.Server, authorizationToken));
+    var model = await client
+      .Model.GetWithVersions(url.ModelId, url.ProjectId, versionsLimit: 1, cancellationToken: ct)
+      .ConfigureAwait(false);
+    if (model.versions.items.Count == 0)
+    {
+      throw new SpeckleException($"Model '{url.ModelId}' in project '{url.ProjectId}' has no versions yet.");
+    }
+    return model.versions.items[0].id;
+  }
+
+  // ArtifactDownloader (and the GraphQL client) only read token + serverInfo.url off the account.
+  private static Account AccountFor(Uri server, string? token) =>
+    new()
+    {
+      token = token ?? string.Empty,
+      serverInfo = new() { url = server.ToString() },
+      userInfo = new(),
+    };
+
+  private async Task<string> DownloadAsync(
+    Uri url,
+    string projectId,
+    string modelId,
+    string versionId,
+    string? authorizationToken,
+    ReceiveOptions options,
+    CancellationToken cancellationToken
+  )
+  {
+    string bundleDir = Path.Combine(
+      SpecklePathProvider.UserApplicationDataPath(),
+      "Speckle",
+      "BundleReceive",
+      Guid.NewGuid().ToString("N")
+    );
+    try
+    {
+      var files = await artifactDownloader
+        .DownloadBundleAsync(
+          AccountFor(url, authorizationToken),
+          projectId,
+          modelId,
+          versionId,
+          bundleDir,
+          options.ShouldDownload,
+          cancellationToken
+        )
+        .ConfigureAwait(false);
+
+      if (files.Count == 0)
+      {
+        // Never fall back to the legacy object path from here: a caller on this rail asked for the bundle, and for
+        // a bundle-only version there is no legacy graph anyway.
+        throw new SpeckleException(
+          $"Version '{versionId}' (model '{modelId}', project '{projectId}') has no artefact bundle on the server at "
+            + $"'{url}'. Either the server does not serve the /api/v2 artifacts endpoint yet, the token cannot read the "
+            + "project, or the bundle has not been produced for this version."
+        );
+      }
+      return bundleDir;
+    }
+    catch
+    {
+      TryDeleteDirectory(bundleDir);
+      throw;
+    }
+  }
+
+  private void TryDeleteDirectory(string dir)
+  {
+    try
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+    catch (IOException ex)
+    {
+      logger.LogWarning(ex, "Could not clean up bundle scratch directory {bundleDir}", dir);
+    }
+    catch (UnauthorizedAccessException ex)
+    {
+      logger.LogWarning(ex, "Could not clean up bundle scratch directory {bundleDir}", dir);
+    }
+  }
+}

--- a/src/Speckle.Sdk/Bundles/BundleSender.cs
+++ b/src/Speckle.Sdk/Bundles/BundleSender.cs
@@ -1,0 +1,138 @@
+using Microsoft.Extensions.Logging;
+using Speckle.InterfaceGenerator;
+using Speckle.Sdk.Api;
+using Speckle.Sdk.Api.GraphQL.Inputs;
+using Speckle.Sdk.Credentials;
+using Speckle.Sdk.Logging;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using Speckle.Sdk.Pipelines.Send.Artifacts;
+
+namespace Speckle.Sdk.Bundles;
+
+/// <summary>
+/// Publishes a <see cref="BundleBuilder"/> as a new version: creates the ingestion (the server pre-allocates the
+/// version id), finishes the builder and re-keys its files to that id, uploads them over the <c>/api/v2</c> artifacts
+/// rail (sign → presigned PUT per file → complete), and marks the ingestion failed or cancelled on any error. The
+/// orchestration behind <see cref="Operations.Send3(Uri, string, string, BundleBuilder, string?, SendOptions?, CancellationToken)"/>;
+/// connectors can drive it directly once their host objects are in a builder.
+/// </summary>
+[GenerateAutoInterface]
+public sealed class BundleSender(
+  IClientFactory clientFactory,
+  IArtifactPipelineFactory artifactPipelineFactory,
+  ISdkActivityFactory activityFactory,
+  ILogger<BundleSender> logger
+) : IBundleSender
+{
+  /// <exception cref="SpeckleException">The server did not pre-allocate a version id (it predates the v2 data endpoints).</exception>
+  public async Task<SendResult> SendAsync(
+    Uri url,
+    string projectId,
+    string modelId,
+    BundleBuilder builder,
+    string? authorizationToken,
+    SendOptions options,
+    CancellationToken cancellationToken
+  )
+  {
+    using var activity = activityFactory.Start("BundleSender.Send");
+    activity?.SetTag("speckle.url", url);
+    activity?.SetTag("speckle.projectId", projectId);
+    activity?.SetTag("speckle.modelId", modelId);
+
+    var account = new Account
+    {
+      token = authorizationToken ?? string.Empty,
+      serverInfo = new() { url = url.ToString() },
+      userInfo = new(),
+    };
+    using var client = clientFactory.Create(account);
+
+    var ingestion = await client
+      .Ingestion.Create(
+        new(
+          modelId,
+          projectId,
+          options.Message ?? $"Sending from {builder.Producer.ApplicationAndVersion}",
+          new(builder.Producer.Slug, builder.Producer.HostApplicationVersion, options.FileName, options.FileSizeBytes),
+          options.MaxIdleTimeoutSeconds
+        ),
+        cancellationToken
+      )
+      .ConfigureAwait(false);
+    activity?.SetTag("speckle.ingestionId", ingestion.id);
+
+    if (ingestion.versionId is not { Length: > 0 } versionId)
+    {
+      throw new SpeckleException(
+        $"The server at '{url}' did not pre-allocate a version id for the ingestion; the Speckle 2026.9.0 bundle "
+          + "upload requires a server with the /api/v2 data endpoints."
+      );
+    }
+
+    try
+    {
+      // Build under the temporary basename, then re-key the files to the version id the server just allocated:
+      // the v2 upload signs and keys every file by its basename.
+      BundleFiles files = builder.Build().RenameTo(versionId);
+      string rootId = new BundleReference(projectId, modelId, versionId).ToString();
+
+      using var pipeline = artifactPipelineFactory.CreateInstance(
+        projectId,
+        ingestion.id,
+        versionId,
+        account,
+        files.Directory,
+        cancellationToken
+      );
+      string committedVersionId = await pipeline
+        .UploadFilesAsync(files.ByName, rootId, files.ObjectCount)
+        .ConfigureAwait(false);
+
+      if (!options.KeepFiles)
+      {
+        TryDeleteDirectory(files.Directory);
+      }
+      activity?.SetStatus(SdkActivityStatusCode.Ok);
+      return new SendResult(projectId, modelId, committedVersionId, ingestion.id, files.ObjectCount);
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+      await client
+        .Ingestion.FailWithCancel(new(ingestion.id, projectId, "Cancelled by the caller"), CancellationToken.None)
+        .ConfigureAwait(false);
+      throw;
+    }
+    catch (Exception ex)
+    {
+      activity?.SetStatus(SdkActivityStatusCode.Error);
+      activity?.RecordException(ex);
+      await client
+        .Ingestion.FailWithError(
+          ModelIngestionFailedInput.FromException(ingestion.id, projectId, ex),
+          CancellationToken.None
+        )
+        .ConfigureAwait(false);
+      throw;
+    }
+  }
+
+  private void TryDeleteDirectory(string dir)
+  {
+    try
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+    catch (IOException ex)
+    {
+      logger.LogWarning(ex, "Could not clean up bundle directory {dir}", dir);
+    }
+    catch (UnauthorizedAccessException ex)
+    {
+      logger.LogWarning(ex, "Could not clean up bundle directory {dir}", dir);
+    }
+  }
+}

--- a/src/Speckle.Sdk/Bundles/Model.cs
+++ b/src/Speckle.Sdk/Bundles/Model.cs
@@ -28,6 +28,7 @@ public sealed class Model : IDisposable
   private readonly Lazy<IReadOnlyDictionary<int, ArtefactGeometry>> _geometries;
   private readonly Lazy<RelationIndex> _index;
   private readonly Lazy<IReadOnlyList<ModelSceneViewTier>> _sceneView;
+  private readonly Lazy<IReadOnlyDictionary<string, object?>> _modelProperties;
   private bool _disposed;
 
   internal Model(
@@ -56,6 +57,7 @@ public sealed class Model : IDisposable
     _geometries = new(LoadGeometries);
     _index = new(() => new RelationIndex(Bundle));
     _sceneView = new(() => Bundle.DefaultSceneView.Select(t => new ModelSceneViewTier(t)).ToList());
+    _modelProperties = new(() => Flatten(Bundle.ModelProperties));
     if (bundle.Relations.UnknownRels.Count > 0)
     {
       logger.LogWarning(
@@ -79,8 +81,9 @@ public sealed class Model : IDisposable
   /// <summary>Length unit every geometry in the bundle is expressed in (e.g. <c>"m"</c>, <c>"mm"</c>).</summary>
   public string Units => Bundle.Units;
 
-  /// <summary>Model-level properties (<c>eav.model</c>), flat path-keyed.</summary>
-  public IReadOnlyDictionary<string, object?> Properties => Bundle.ModelProperties;
+  /// <summary>Model-level properties (<c>eav.model</c>: project information, placement transform, document settings),
+  /// flat path-keyed like object properties.</summary>
+  public IReadOnlyDictionary<string, object?> Properties => _modelProperties.Value;
 
   /// <summary>The default scene view's grouping tiers, outermost first — how the viewer builds its tree. Empty when the
   /// producer declared none (the scene tree is then the <c>IN_COLLECTION</c> hierarchy).</summary>
@@ -231,6 +234,30 @@ public sealed class Model : IDisposable
 
   internal IReadOnlyList<ModelObject> MembersOfDefinition(int definitionK) =>
     ObjectsFor(Bundle.Relations.MemberObjectsByDefinition.TryGetValue(definitionK, out var m) ? m : null);
+
+  // The reader nests model-scoped rows by dotted path; the façade addresses them flat, like everything else.
+  private static IReadOnlyDictionary<string, object?> Flatten(IReadOnlyDictionary<string, object?> nested)
+  {
+    var flat = new Dictionary<string, object?>(StringComparer.Ordinal);
+    Walk(nested, null);
+    return flat;
+
+    void Walk(IReadOnlyDictionary<string, object?> dict, string? prefix)
+    {
+      foreach (var kv in dict)
+      {
+        string path = prefix is null ? kv.Key : prefix + "." + kv.Key;
+        if (kv.Value is IReadOnlyDictionary<string, object?> child)
+        {
+          Walk(child, path);
+        }
+        else
+        {
+          flat[path] = kv.Value;
+        }
+      }
+    }
+  }
 
   private IReadOnlyList<ModelObject> BuildObjects()
   {

--- a/src/Speckle.Sdk/Bundles/ModelNode.cs
+++ b/src/Speckle.Sdk/Bundles/ModelNode.cs
@@ -161,6 +161,9 @@ public sealed class ModelContainer : ModelNode
   /// <c>MEP System</c>, <c>Network</c>, <c>Group</c> … Null on bundles written before the column existed.</summary>
   public string? Subtype => _node.Subtype;
 
+  /// <summary>Grasshopper data-tree topology (<c>nodes.gh_topology</c>) for containers a GH send wrote; null otherwise.</summary>
+  public string? GhTopology => _node.GhTopology;
+
   /// <summary>The enclosing container. Null at the root.</summary>
   public ModelContainer? Parent => _model.NodeOrNull(_node.DefRef) as ModelContainer;
 

--- a/src/Speckle.Sdk/Bundles/SendOptions.cs
+++ b/src/Speckle.Sdk/Bundles/SendOptions.cs
@@ -1,0 +1,27 @@
+namespace Speckle.Sdk.Bundles;
+
+/// <summary>Options for <see cref="Api.Operations.Send3(Uri, string, string, BundleBuilder, string?, SendOptions?, CancellationToken)"/>.</summary>
+/// <param name="Message">Progress / version message shown while the server ingests.</param>
+/// <param name="FileName">The source file the bundle came from, if any — recorded on the ingestion.</param>
+/// <param name="FileSizeBytes">Its size, if known.</param>
+/// <param name="MaxIdleTimeoutSeconds">How long the server keeps the ingestion open without progress before failing it.</param>
+/// <param name="KeepFiles">Leave the bundle files on disk after upload (default deletes the builder's directory).</param>
+public sealed record SendOptions(
+  string? Message = null,
+  string? FileName = null,
+  long? FileSizeBytes = null,
+  int MaxIdleTimeoutSeconds = 600,
+  bool KeepFiles = false
+)
+{
+  public static readonly SendOptions Default = new();
+}
+
+/// <summary>What a send produced. The version exists on the server once the ingestion completes — the
+/// <see cref="IngestionId"/> is what to subscribe to for that; <see cref="VersionId"/> is its pre-allocated id.</summary>
+public sealed record SendResult(string ProjectId, string ModelId, string VersionId, string IngestionId, int ObjectCount)
+{
+  /// <summary>The value the version carries in <c>referencedObject</c>: the bundle reference.</summary>
+  public string BundleReference =>
+    new Pipelines.Receive.Artifacts.BundleReference(ProjectId, ModelId, VersionId).ToString();
+}

--- a/tests/Speckle.Sdk.Tests.Integration/Bundles/BundleBuilderTestExtensions.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Bundles/BundleBuilderTestExtensions.cs
@@ -1,0 +1,40 @@
+using Speckle.Sdk.Bundles;
+
+namespace Speckle.Sdk.Tests.Integration.Bundles;
+
+/// <summary>Test sugar: intern + describe + place in one call, the shape most fixture lines want.</summary>
+internal static class BundleBuilderTestExtensions
+{
+  public static BundleObject GetOrAddObject(
+    this BundleBuilder b,
+    string applicationId,
+    BundleCollection? collection,
+    IReadOnlyDictionary<string, object?>? properties,
+    string? name = null,
+    string? speckleType = null,
+    string? sourceType = null,
+    string? units = null,
+    string? typeKey = null,
+    IEnumerable<KeyValuePair<string, object?>>? rootScalars = null
+  )
+  {
+    var obj = b.GetOrAddObject(applicationId);
+    bool describes =
+      properties is not null
+      || name is not null
+      || speckleType is not null
+      || sourceType is not null
+      || units is not null
+      || typeKey is not null
+      || rootScalars is not null;
+    if (describes)
+    {
+      obj.SetProperties(properties, name, speckleType, sourceType, units, typeKey, rootScalars);
+    }
+    if (collection is not null)
+    {
+      obj.Collection = collection;
+    }
+    return obj;
+  }
+}

--- a/tests/Speckle.Sdk.Tests.Integration/Bundles/BundleBuilderTestExtensions.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Bundles/BundleBuilderTestExtensions.cs
@@ -8,7 +8,7 @@ internal static class BundleBuilderTestExtensions
   public static BundleObject GetOrAddObject(
     this BundleBuilder b,
     string applicationId,
-    BundleCollection? collection,
+    BundleContainer? collection,
     IReadOnlyDictionary<string, object?>? properties,
     string? name = null,
     string? speckleType = null,

--- a/tests/Speckle.Sdk.Tests.Integration/Bundles/SendReceiveBundleTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Bundles/SendReceiveBundleTests.cs
@@ -50,7 +50,7 @@ public sealed class SendReceiveBundleTests : IAsyncLifetime
     SendResult sent;
     using (var b = new BundleBuilder(s_app, "m"))
     {
-      var walls = b.GetOrAddCollection(["Level 1", "Walls"], subtype: "Category");
+      var walls = b.GetOrAddContainerPath(["Level 1", "Walls"], subtype: "Category");
       var concrete = b.GetOrAddMaterial("mat-concrete", "Concrete", unchecked((int)0xFF808080), roughness: 0.8);
       var l1 = b.GetOrAddLevel("L1", "Level 1", 0);
       var wall = b.GetOrAddObject(

--- a/tests/Speckle.Sdk.Tests.Integration/Bundles/SendReceiveBundleTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Bundles/SendReceiveBundleTests.cs
@@ -1,0 +1,143 @@
+using Microsoft.Extensions.DependencyInjection;
+using Speckle.Objects.Geometry;
+using Speckle.Sdk.Api;
+using Speckle.Sdk.Api.GraphQL.Enums;
+using Speckle.Sdk.Bundles;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using Model = Speckle.Sdk.Bundles.Model;
+
+namespace Speckle.Sdk.Tests.Integration.Bundles;
+
+/// <summary>
+/// The Speckle 2026.9.0 round trip against a real server: BundleBuilder → Send3 (ingestion, sign/PUT/complete) →
+/// Receive3 (artifacts listing, download, parse) → the same objects, properties, relations and geometry come back;
+/// and the version's <c>referencedObject</c> is the bundle reference Receive2 dispatches on.
+/// </summary>
+[Trait("Server", "Internal")]
+public sealed class SendReceiveBundleTests : IAsyncLifetime
+{
+  private static readonly SpeckleApplication s_app = new()
+  {
+    HostApplication = "IntegrationTest",
+    HostApplicationVersion = "1.0",
+    Slug = "test",
+    SpeckleVersion = "0.0.0",
+  };
+
+  private IClient _client = null!;
+  private string _projectId = null!;
+  private string _modelId = null!;
+
+  public async Task InitializeAsync()
+  {
+    _client = await Fixtures.SeedUserWithClient();
+    var project = await _client.Project.Create(new("Bundle round trip", null, ProjectVisibility.Private));
+    _projectId = project.id;
+    var model = await _client.Model.Create(new("bundle", null, _projectId));
+    _modelId = model.id;
+  }
+
+  public Task DisposeAsync() => Task.CompletedTask;
+
+  [Fact]
+  public async Task Send3_Then_Receive3_RoundTrips()
+  {
+    var operations = Fixtures.ServiceProvider.GetRequiredService<IOperations>();
+    var server = new Uri(_client.Account.serverInfo.url);
+    string token = _client.Account.token;
+
+    // ── send ────────────────────────────────────────────────────────────────────────────────────────────
+    SendResult sent;
+    using (var b = new BundleBuilder(s_app, "m"))
+    {
+      var walls = b.Collection(["Level 1", "Walls"], subtype: "Category");
+      var concrete = b.Material("mat-concrete", "Concrete", unchecked((int)0xFF808080), roughness: 0.8);
+      var l1 = b.Level("L1", "Level 1", 0);
+      var wall = b.Object(
+        "wall-1",
+        walls,
+        new Dictionary<string, object?>
+        {
+          ["Constraints"] = new Dictionary<string, object?> { ["Base Offset"] = 0.5 },
+          ["Identity Data"] = new Dictionary<string, object?> { ["Mark"] = "W-01" },
+        },
+        name: "Basic Wall",
+        speckleType: "Objects.Data.DataObject",
+        sourceType: "Walls"
+      );
+      wall.AddGeometry(
+        new Mesh
+        {
+          vertices = [0, 0, 0, 1, 0, 0, 0, 1, 0],
+          faces = [3, 0, 1, 2],
+          units = "m",
+        }
+      ).Material = concrete;
+      wall.Level = l1;
+      var door = b.Object("door-1", walls, new Dictionary<string, object?> { ["Width"] = 0.9 }, name: "Door");
+      door.Host = wall;
+      door.Parent = wall;
+      b.ModelProperty("projectInformation.number", 42.0);
+
+      sent = await operations.Send3(server, _projectId, _modelId, b, token, null, CancellationToken.None);
+    }
+
+    Assert.Equal(_projectId, sent.ProjectId);
+    Assert.Equal(_modelId, sent.ModelId);
+    Assert.Equal(2, sent.ObjectCount);
+    Assert.False(string.IsNullOrEmpty(sent.VersionId));
+
+    // ── the version exists once the ingestion completes; poll briefly ──────────────────────────────────
+    Speckle.Sdk.Api.GraphQL.Models.Version? version = null;
+    for (int i = 0; i < 60 && version is null; i++)
+    {
+      try
+      {
+        version = await _client.Version.Get(sent.VersionId, _projectId);
+      }
+      catch (SpeckleException)
+      {
+        await Task.Delay(500);
+      }
+    }
+    Assert.NotNull(version);
+    Assert.Equal(sent.BundleReference, version.referencedObject); // what Receive2 dispatches on
+    Assert.True(BundleReference.TryParse(version.referencedObject, out _));
+
+    // ── receive ─────────────────────────────────────────────────────────────────────────────────────────
+    using Model received = await operations.Receive3(
+      server,
+      _projectId,
+      _modelId,
+      sent.VersionId,
+      token,
+      null,
+      CancellationToken.None
+    );
+
+    Assert.Equal("m", received.Units);
+    Assert.Equal(2, received.Objects.Count);
+    var wallBack = received.ObjectByApplicationId("wall-1")!;
+    Assert.Equal("Basic Wall", wallBack.Name);
+    Assert.Equal(0.5, wallBack.GetDouble("Constraints.Base Offset"));
+    Assert.Equal("W-01", wallBack.GetString("Identity Data.Mark"));
+    Assert.Equal(["Level 1", "Walls"], wallBack.CollectionPath);
+    Assert.Equal("Level 1", wallBack.Level!.Name);
+    var g = Assert.Single(wallBack.Geometries);
+    Assert.Equal(9, g.DecodeMesh()!.Value.Vertices.Length);
+    Assert.Equal("Concrete", g.Material!.Name);
+    var doorBack = received.ObjectByApplicationId("door-1")!;
+    Assert.Same(wallBack, doorBack.Host);
+    Assert.Same(wallBack, doorBack.Parent);
+    Assert.Equal(42.0, received.Properties["projectInformation.number"]);
+
+    // ── and by url, latest version ──────────────────────────────────────────────────────────────────────
+    using Model latest = await operations.Receive3(
+      $"{server.ToString().TrimEnd('/')}/projects/{_projectId}/models/{_modelId}",
+      token,
+      null,
+      CancellationToken.None
+    );
+    Assert.Equal(sent.VersionId, latest.VersionId);
+  }
+}

--- a/tests/Speckle.Sdk.Tests.Integration/Bundles/SendReceiveBundleTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Bundles/SendReceiveBundleTests.cs
@@ -50,10 +50,10 @@ public sealed class SendReceiveBundleTests : IAsyncLifetime
     SendResult sent;
     using (var b = new BundleBuilder(s_app, "m"))
     {
-      var walls = b.Collection(["Level 1", "Walls"], subtype: "Category");
-      var concrete = b.Material("mat-concrete", "Concrete", unchecked((int)0xFF808080), roughness: 0.8);
-      var l1 = b.Level("L1", "Level 1", 0);
-      var wall = b.Object(
+      var walls = b.GetOrAddCollection(["Level 1", "Walls"], subtype: "Category");
+      var concrete = b.GetOrAddMaterial("mat-concrete", "Concrete", unchecked((int)0xFF808080), roughness: 0.8);
+      var l1 = b.GetOrAddLevel("L1", "Level 1", 0);
+      var wall = b.GetOrAddObject(
         "wall-1",
         walls,
         new Dictionary<string, object?>
@@ -74,7 +74,7 @@ public sealed class SendReceiveBundleTests : IAsyncLifetime
         }
       ).Material = concrete;
       wall.Level = l1;
-      var door = b.Object("door-1", walls, new Dictionary<string, object?> { ["Width"] = 0.9 }, name: "Door");
+      var door = b.GetOrAddObject("door-1", walls, new Dictionary<string, object?> { ["Width"] = 0.9 }, name: "Door");
       door.Host = wall;
       door.Parent = wall;
       b.ModelProperty("projectInformation.number", 42.0);

--- a/tests/Speckle.Sdk.Tests.Unit/Api/Operations/OperationsSend3Tests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Api/Operations/OperationsSend3Tests.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Speckle.Sdk.Api;
+using Speckle.Sdk.Bundles;
+
+namespace Speckle.Sdk.Tests.Unit.Api.Operations;
+
+/// <summary>What Send3 decides before touching the network. The sign/PUT/complete flow itself is covered by the
+/// server-backed integration test (<c>SendReceiveBundleTests</c>).</summary>
+public sealed class OperationsSend3Tests : IDisposable
+{
+  private static readonly SpeckleApplication s_app = new()
+  {
+    HostApplication = "Test",
+    HostApplicationVersion = "1.0",
+    Slug = "test",
+    SpeckleVersion = "0.0.0",
+  };
+
+  private readonly string _dir = Path.Combine(Path.GetTempPath(), "Send3Tests", Guid.NewGuid().ToString("N"));
+
+  private static (IOperations operations, Mock<IBundleSender> uploads) Build()
+  {
+    var uploads = new Mock<IBundleSender>(MockBehavior.Strict);
+    var services = new ServiceCollection();
+    services.AddSpeckleSdk(new("Tests", "test"), "v3", typeof(OperationsSend3Tests).Assembly);
+    services.AddSingleton(uploads.Object);
+    return (services.BuildServiceProvider().GetRequiredService<IOperations>(), uploads);
+  }
+
+  [Fact]
+  public async Task Send3_ByUrl_PinnedVersion_RejectedBeforeAnyIO()
+  {
+    var (operations, uploads) = Build();
+    using var builder = new BundleBuilder(s_app, "m", _dir);
+
+    var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+      operations.Send3(
+        "https://example.speckle.invalid/projects/p/models/m@v",
+        builder,
+        "tok",
+        null,
+        CancellationToken.None
+      )
+    );
+    Assert.Contains("@versionId", ex.Message, StringComparison.Ordinal);
+    uploads.VerifyNoOtherCalls();
+  }
+
+  [Fact]
+  public async Task Send3_ByUrl_NotAModelUrl_RejectedBeforeAnyIO()
+  {
+    var (operations, uploads) = Build();
+    using var builder = new BundleBuilder(s_app, "m", _dir);
+
+    await Assert.ThrowsAsync<ArgumentException>(() =>
+      operations.Send3("https://example.speckle.invalid/streams/abc", builder, "tok", null, CancellationToken.None)
+    );
+    uploads.VerifyNoOtherCalls();
+  }
+
+  [Fact]
+  public void SendResult_BundleReference_IsTheDispatchForm()
+  {
+    var r = new SendResult("proj", "model", "ver", "ing", 3);
+    Assert.Equal("bundle.proj.model.ver", r.BundleReference);
+  }
+
+  public void Dispose()
+  {
+    if (Directory.Exists(_dir))
+    {
+      Directory.Delete(_dir, true);
+    }
+  }
+}

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTestExtensions.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTestExtensions.cs
@@ -8,7 +8,7 @@ internal static class BundleBuilderTestExtensions
   public static BundleObject GetOrAddObject(
     this BundleBuilder b,
     string applicationId,
-    BundleCollection? collection,
+    BundleContainer? collection,
     IReadOnlyDictionary<string, object?>? properties,
     string? name = null,
     string? speckleType = null,

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTestExtensions.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTestExtensions.cs
@@ -1,0 +1,40 @@
+using Speckle.Sdk.Bundles;
+
+namespace Speckle.Sdk.Tests.Unit.Bundles;
+
+/// <summary>Test sugar: intern + describe + place in one call, the shape most fixture lines want.</summary>
+internal static class BundleBuilderTestExtensions
+{
+  public static BundleObject GetOrAddObject(
+    this BundleBuilder b,
+    string applicationId,
+    BundleCollection? collection,
+    IReadOnlyDictionary<string, object?>? properties,
+    string? name = null,
+    string? speckleType = null,
+    string? sourceType = null,
+    string? units = null,
+    string? typeKey = null,
+    IEnumerable<KeyValuePair<string, object?>>? rootScalars = null
+  )
+  {
+    var obj = b.GetOrAddObject(applicationId);
+    bool describes =
+      properties is not null
+      || name is not null
+      || speckleType is not null
+      || sourceType is not null
+      || units is not null
+      || typeKey is not null
+      || rootScalars is not null;
+    if (describes)
+    {
+      obj.SetProperties(properties, name, speckleType, sourceType, units, typeKey, rootScalars);
+    }
+    if (collection is not null)
+    {
+      obj.Collection = collection;
+    }
+    return obj;
+  }
+}

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
@@ -46,7 +46,7 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var walls = b.GetOrAddCollection(["Level 1", "Walls"], subtype: "Category");
+      var walls = b.GetOrAddContainerPath(["Level 1", "Walls"], subtype: "Category");
       var wall = b.GetOrAddObject(
         "wall-1",
         walls,
@@ -89,7 +89,7 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var layer = b.GetOrAddCollection(["Layer 1"], "Layer");
+      var layer = b.GetOrAddContainerPath(["Layer 1"], "Layer");
       var concrete = b.GetOrAddMaterial("mat-1", "Concrete", unchecked((int)0xFF808080), roughness: 0.8);
       var red = b.GetOrAddColor(unchecked((int)0xFFFF0000));
       var l1 = b.GetOrAddLevel("L1", "Level 1", 3.0);
@@ -143,7 +143,7 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var layer = b.GetOrAddCollection(["Blocks"], "Layer");
+      var layer = b.GetOrAddContainerPath(["Blocks"], "Layer");
       var chairDef = b.GetOrAddDefinition(
         "def-chair",
         "Chair",
@@ -232,7 +232,7 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var layer = b.GetOrAddCollection(["L"]);
+      var layer = b.GetOrAddContainerPath(["L"]);
       // a frame connects to a joint that is only described later (CSi pattern)
       var frame = b.GetOrAddObject("frame-1", layer, null, name: "Frame");
       var joint = b.GetOrAddObject("joint-1", null, null); // reference only
@@ -264,7 +264,7 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var layer = b.GetOrAddCollection(["L"]);
+      var layer = b.GetOrAddContainerPath(["L"]);
       var assembly = b.GetOrAddObject("asm", layer, null, name: "Assembly");
       var c2 = b.GetOrAddObject("c2", layer, null, name: "C2");
       var c0 = b.GetOrAddObject("c0", layer, null, name: "C0");
@@ -285,7 +285,7 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var layer = b.GetOrAddCollection(["Blocks"], "Layer");
+      var layer = b.GetOrAddContainerPath(["Blocks"], "Layer");
       var steel = b.GetOrAddMaterial("steel", "Steel", unchecked((int)0xFF9999AA));
 
       // Rhino-shaped: the block's contents are objects with their own layer + properties + geometry
@@ -331,7 +331,7 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var layer = b.GetOrAddCollection(["L"]);
+      var layer = b.GetOrAddContainerPath(["L"]);
       // Revit-shaped: an element's mesh is written under the element; the family symbol references the same blob
       var element = b.GetOrAddObject("el-1", layer, null, name: "Element");
       element.AddGeometry(Tri(), geometryKey: "mesh-A");
@@ -353,7 +353,7 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var leaf = b.GetOrAddCollection(["Tree", "{0;1}"], "Collection", ghTopology: "{0;1}");
+      var leaf = b.GetOrAddContainerPath(["Tree", "{0;1}"], "Collection", ghTopology: "{0;1}");
       b.GetOrAddObject("o", leaf, null);
     });
 
@@ -381,8 +381,8 @@ public sealed class BundleBuilderTests : IDisposable
   public void Relation_CannotBeRetracted()
   {
     using var b = new BundleBuilder(s_app, "m", _dir);
-    var a = b.GetOrAddCollection(["A"]);
-    var c = b.GetOrAddCollection(["C"]);
+    var a = b.GetOrAddContainerPath(["A"]);
+    var c = b.GetOrAddContainerPath(["C"]);
     var o = b.GetOrAddObject("o", a, null);
     Assert.Throws<InvalidOperationException>(() => o.Collection = c);
     o.Collection = a; // idempotent

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
@@ -159,15 +159,13 @@ public sealed class BundleBuilderTests : IDisposable
 
       // a Rhino-style member object with its own properties, joined to the definition geometry by ordinal
       var tableDef = b.GetOrAddDefinition("def-table", "Table");
-      int ord = tableDef.NextMemberOrdinal();
-      tableDef.AddGeometry(Tri(5), memberOrd: ord);
       var top = b.GetOrAddObject(
         "table-top",
         layer,
         new Dictionary<string, object?> { ["material"] = "oak" },
         name: "Top"
       );
-      tableDef.AddMember(top, ord);
+      tableDef.AddMember(top, [Tri(5)]);
       b.GetOrAddObject("table-1", layer, null, name: "Table 1").Place(tableDef, t);
     });
 
@@ -227,6 +225,127 @@ public sealed class BundleBuilderTests : IDisposable
     Assert.Equal(42.0, model.Properties["projectInformation.number"]);
     Assert.Equal("Front", Assert.Single(model.CameraViews).Name);
     Assert.Contains(model.Files, f => f.EndsWith(".eav.structural_results.parquet", StringComparison.Ordinal));
+  }
+
+  [Fact]
+  public async Task ForwardReference_ThenDescribe_WritesOnce()
+  {
+    using var model = await BuildAndRead(b =>
+    {
+      var layer = b.GetOrAddCollection(["L"]);
+      // a frame connects to a joint that is only described later (CSi pattern)
+      var frame = b.GetOrAddObject("frame-1", layer, null, name: "Frame");
+      var joint = b.GetOrAddObject("joint-1", null, null); // reference only
+      frame.ConnectTo(joint);
+      Assert.False(joint.PropertiesWritten);
+
+      var described = b.GetOrAddObject(
+        "joint-1",
+        layer,
+        new Dictionary<string, object?> { ["z"] = 3.0 },
+        name: "Joint 1"
+      );
+      Assert.Same(joint, described);
+      Assert.True(joint.PropertiesWritten);
+      Assert.Equal("Joint 1", joint.Name);
+      Assert.Throws<InvalidOperationException>(() => b.GetOrAddObject("joint-1", null, null, name: "again"));
+      Assert.Same(joint, b.GetOrAddObject("joint-1", null, null)); // bare reference still fine
+    });
+
+    var joint = model.ObjectByApplicationId("joint-1")!;
+    Assert.Equal("Joint 1", joint.Name);
+    Assert.Equal(3.0, joint.GetDouble("z"));
+    Assert.Equal(["L"], joint.CollectionPath);
+    Assert.Equal([joint], model.ObjectByApplicationId("frame-1")!.ConnectedTo);
+  }
+
+  [Fact]
+  public async Task Children_ExplicitOrdinals()
+  {
+    using var model = await BuildAndRead(b =>
+    {
+      var layer = b.GetOrAddCollection(["L"]);
+      var assembly = b.GetOrAddObject("asm", layer, null, name: "Assembly");
+      var c2 = b.GetOrAddObject("c2", layer, null, name: "C2");
+      var c0 = b.GetOrAddObject("c0", layer, null, name: "C0");
+      var c1 = b.GetOrAddObject("c1", layer, null, name: "C1");
+      assembly.AddChild(c2, ord: 2);
+      assembly.AddChild(c0, ord: 0);
+      c1.Parent = assembly; // next ordinal after the explicit ones → 3; ordering below is by ordinal
+      Assert.Throws<InvalidOperationException>(() => b.GetOrAddObject("other", layer, null).AddChild(c0));
+    });
+
+    var asm = model.ObjectByApplicationId("asm")!;
+    Assert.Equal(["c0", "c2", "c1"], asm.Children.Select(c => c.ApplicationId));
+    Assert.Same(asm, model.ObjectByApplicationId("c1")!.Parent);
+  }
+
+  [Fact]
+  public async Task Definition_MembersOwnGeometry_RenderOnlyThroughPlacements()
+  {
+    using var model = await BuildAndRead(b =>
+    {
+      var layer = b.GetOrAddCollection(["Blocks"], "Layer");
+      var steel = b.GetOrAddMaterial("steel", "Steel", unchecked((int)0xFF9999AA));
+
+      // Rhino-shaped: the block's contents are objects with their own layer + properties + geometry
+      var chairDef = b.GetOrAddDefinition("def-chair", "Chair");
+      var seat = b.GetOrAddObject("seat", layer, new Dictionary<string, object?> { ["part"] = "seat" }, name: "Seat");
+      foreach (var g in chairDef.AddMember(seat, [Tri()]))
+      {
+        g.Material = steel;
+      }
+      var leg = b.GetOrAddObject("leg", layer, new Dictionary<string, object?> { ["part"] = "leg" }, name: "Leg");
+      var legGeometry = chairDef.AddMember(leg, [Tri(1), Tri(2)]);
+      Assert.Equal(legGeometry[0].Ord, legGeometry[1].Ord); // one member, one ordinal, two meshes
+
+      // a block inside the block
+      var boltDef = b.GetOrAddDefinition("def-bolt", "Bolt", d => d.AddGeometry(Tri(9)));
+      var bolt = b.GetOrAddObject("bolt-in-chair", layer, null, name: "Bolt");
+      double[] t = [1, 0, 0, 0.1, 0, 1, 0, 0.2, 0, 0, 1, 0, 0, 0, 0, 1];
+      chairDef.AddMemberPlacement(bolt, boltDef, t);
+
+      double[] place = [1, 0, 0, 10, 0, 1, 0, 20, 0, 0, 1, 0, 0, 0, 0, 1];
+      b.GetOrAddObject("chair-1", layer, null, name: "Chair 1").Place(chairDef, place);
+    });
+
+    var seat = model.ObjectByApplicationId("seat")!;
+    Assert.Empty(seat.Geometries); // no DISPLAY of its own — it renders through the placement
+    Assert.Equal("seat", seat.GetString("part"));
+    Assert.Equal(["Blocks"], seat.CollectionPath);
+
+    var chair = model.ObjectByApplicationId("chair-1")!;
+    var def = chair.Definition!;
+    Assert.Equal(["seat", "leg", "bolt-in-chair"], def.Members.Select(m => m.ApplicationId));
+    Assert.Equal(4, chair.Geometries.Count); // seat + 2 leg + nested bolt, all placed
+    Assert.All(chair.Geometries, g => Assert.NotNull(g.Transform));
+    Assert.Equal("Steel", chair.Geometries[0].Material!.Name);
+
+    var bolt = model.ObjectByApplicationId("bolt-in-chair")!;
+    var placement = Assert.Single(bolt.Placements); // PLACES → its nested INSTANCE
+    Assert.Equal("Bolt", placement.Definition!.Name);
+  }
+
+  [Fact]
+  public async Task Definition_ExistingGeometry_SharedByKey()
+  {
+    using var model = await BuildAndRead(b =>
+    {
+      var layer = b.GetOrAddCollection(["L"]);
+      // Revit-shaped: an element's mesh is written under the element; the family symbol references the same blob
+      var element = b.GetOrAddObject("el-1", layer, null, name: "Element");
+      element.AddGeometry(Tri(), geometryKey: "mesh-A");
+      var symbol = b.GetOrAddDefinition("sym", "Symbol");
+      Assert.True(b.TryGetGeometry("mesh-A", out var shared));
+      symbol.AddExistingGeometry(shared);
+      b.GetOrAddObject("inst-1", layer, null).Place(symbol, [1, 0, 0, 5, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+      Assert.False(b.TryGetGeometry("nope", out _));
+    });
+
+    var element = model.ObjectByApplicationId("el-1")!;
+    var inst = model.ObjectByApplicationId("inst-1")!;
+    Assert.Equal(element.Geometries[0].K, Assert.Single(inst.Geometries).K); // one blob, two routes
+    Assert.Single(model.Geometries);
   }
 
   [Fact]

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
@@ -46,8 +46,8 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var walls = b.Collection(["Level 1", "Walls"], subtype: "Category");
-      var wall = b.Object(
+      var walls = b.GetOrAddCollection(["Level 1", "Walls"], subtype: "Category");
+      var wall = b.GetOrAddObject(
         "wall-1",
         walls,
         new Dictionary<string, object?>
@@ -60,9 +60,9 @@ public sealed class BundleBuilderTests : IDisposable
         sourceType: "Walls"
       );
       wall.AddGeometry(Tri());
-      b.Object("door-1", walls, new Dictionary<string, object?> { ["Width"] = 0.9 }, name: "Door");
+      b.GetOrAddObject("door-1", walls, new Dictionary<string, object?> { ["Width"] = 0.9 }, name: "Door");
       // interning: same id twice is one object
-      Assert.Same(wall, b.Object("wall-1", walls, null));
+      Assert.Same(wall, b.GetOrAddObject("wall-1", walls, null));
     });
 
     Assert.Equal("m", model.Units);
@@ -89,29 +89,30 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var layer = b.Collection(["Layer 1"], "Layer");
-      var concrete = b.Material("mat-1", "Concrete", unchecked((int)0xFF808080), roughness: 0.8);
-      var red = b.Color(unchecked((int)0xFFFF0000));
-      var l1 = b.Level("L1", "Level 1", 3.0);
+      var layer = b.GetOrAddCollection(["Layer 1"], "Layer");
+      var concrete = b.GetOrAddMaterial("mat-1", "Concrete", unchecked((int)0xFF808080), roughness: 0.8);
+      var red = b.GetOrAddColor(unchecked((int)0xFFFF0000));
+      var l1 = b.GetOrAddLevel("L1", "Level 1", 3.0);
       layer.Color = red; // node plane
 
-      var wall = b.Object("wall-1", layer, null, name: "Wall");
+      var wall = b.GetOrAddObject("wall-1", layer, null, name: "Wall");
       wall.AddGeometry(Tri()).Material = concrete; // geometry plane
       wall.Level = l1;
-      var door = b.Object("door-1", layer, null, name: "Door");
+      var door = b.GetOrAddObject("door-1", layer, null, name: "Door");
       door.Parent = wall;
       door.Host = wall;
       door.Color = red; // object plane
       door.Level = l1;
-      var room = b.Object("room-1", layer, null, name: "Office");
+      var room = b.GetOrAddObject("room-1", layer, null, name: "Office");
       wall.Bounds(room);
       door.Room = room;
-      var a = b.Object("pipe-a", layer, null);
-      var c = b.Object("pipe-b", layer, null);
+      var a = b.GetOrAddObject("pipe-a", layer, null);
+      var c = b.GetOrAddObject("pipe-b", layer, null);
       a.ConnectTo(c);
-      var group = b.Container("grp-1", "Group A", null, "Group");
+      var group = b.GetOrAddContainer("grp-1", "Group A", null, "Group");
       wall.AddToGroup(group);
-      Assert.Same(concrete, b.Material("mat-1", "other name", 0)); // interned on key
+      Assert.Same(concrete, b.GetOrAddMaterial("mat-1", "Concrete", unchecked((int)0xFF808080), roughness: 0.8)); // interned on key
+      Assert.Throws<InvalidOperationException>(() => b.GetOrAddMaterial("mat-1", "other name", 0)); // key collision
     });
 
     var wall = model.ObjectByApplicationId("wall-1")!;
@@ -142,26 +143,32 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var layer = b.Collection(["Blocks"], "Layer");
-      var chairDef = b.Definition(
+      var layer = b.GetOrAddCollection(["Blocks"], "Layer");
+      var chairDef = b.GetOrAddDefinition(
         "def-chair",
         "Chair",
-        d => d.AddGeometry(Tri()).Material = b.Material("m", "Fabric", 0)
+        d => d.AddGeometry(Tri()).Material = b.GetOrAddMaterial("m", "Fabric", 0)
       );
       double[] t = [1, 0, 0, 10, 0, 1, 0, 20, 0, 0, 1, 0, 0, 0, 0, 1];
-      var chair1 = b.Object("chair-1", layer, null, name: "Chair 1");
+      var chair1 = b.GetOrAddObject("chair-1", layer, null, name: "Chair 1");
       chair1.Place(chairDef, t);
-      var chair2 = b.Object("chair-2", layer, null, name: "Chair 2");
+      var chair2 = b.GetOrAddObject("chair-2", layer, null, name: "Chair 2");
       chair2.Place(chairDef, t);
-      Assert.Same(chairDef, b.Definition("def-chair", "x")); // populate runs once
+      Assert.Same(chairDef, b.GetOrAddDefinition("def-chair", null)); // a placement knows only the id
+      Assert.Throws<InvalidOperationException>(() => b.GetOrAddDefinition("def-chair", "x")); // key collision
 
       // a Rhino-style member object with its own properties, joined to the definition geometry by ordinal
-      var tableDef = b.Definition("def-table", "Table");
+      var tableDef = b.GetOrAddDefinition("def-table", "Table");
       int ord = tableDef.NextMemberOrdinal();
       tableDef.AddGeometry(Tri(5), memberOrd: ord);
-      var top = b.Object("table-top", layer, new Dictionary<string, object?> { ["material"] = "oak" }, name: "Top");
+      var top = b.GetOrAddObject(
+        "table-top",
+        layer,
+        new Dictionary<string, object?> { ["material"] = "oak" },
+        name: "Top"
+      );
       tableDef.AddMember(top, ord);
-      b.Object("table-1", layer, null, name: "Table 1").Place(tableDef, t);
+      b.GetOrAddObject("table-1", layer, null, name: "Table 1").Place(tableDef, t);
     });
 
     var chair1 = model.ObjectByApplicationId("chair-1")!;
@@ -185,9 +192,15 @@ public sealed class BundleBuilderTests : IDisposable
   {
     using var model = await BuildAndRead(b =>
     {
-      var host = b.Container("model-main", "Main.rvt", null, "Model");
-      var l1 = b.Level("L1", "Level 1", 0);
-      var o = b.Object("w", null, null, name: "W", rootScalars: [new("category", "Walls"), new("family", "Basic")]);
+      var host = b.GetOrAddContainer("model-main", "Main.rvt", null, "Model");
+      var l1 = b.GetOrAddLevel("L1", "Level 1", 0);
+      var o = b.GetOrAddObject(
+        "w",
+        null,
+        null,
+        name: "W",
+        rootScalars: [new("category", "Walls"), new("family", "Basic")]
+      );
       o.Model = host;
       o.Level = l1;
       b.SceneView(
@@ -220,7 +233,7 @@ public sealed class BundleBuilderTests : IDisposable
   public void Build_Twice_Throws_And_RenameTo_RekeysFiles()
   {
     using var b = new BundleBuilder(s_app, "m", _dir);
-    b.Object("o", null, null);
+    b.GetOrAddObject("o", null, null);
     var files = b.Build();
     Assert.Throws<InvalidOperationException>(() => b.Build());
 
@@ -235,9 +248,9 @@ public sealed class BundleBuilderTests : IDisposable
   public void Relation_CannotBeRetracted()
   {
     using var b = new BundleBuilder(s_app, "m", _dir);
-    var a = b.Collection(["A"]);
-    var c = b.Collection(["C"]);
-    var o = b.Object("o", a, null);
+    var a = b.GetOrAddCollection(["A"]);
+    var c = b.GetOrAddCollection(["C"]);
+    var o = b.GetOrAddObject("o", a, null);
     Assert.Throws<InvalidOperationException>(() => o.Collection = c);
     o.Collection = a; // idempotent
   }

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
@@ -1,0 +1,252 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Speckle.Objects.Geometry;
+using Speckle.Sdk.Bundles;
+using Speckle.Sdk.Pipelines;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using Speckle.Sdk.Pipelines.Send.Artifacts;
+
+namespace Speckle.Sdk.Tests.Unit.Bundles;
+
+/// <summary>Write with <see cref="BundleBuilder"/>, read back through the Receive3 façade: the two sides must agree.</summary>
+public sealed class BundleBuilderTests : IDisposable
+{
+  private static readonly SpeckleApplication s_app = new()
+  {
+    HostApplication = "Test",
+    HostApplicationVersion = "1.0",
+    Slug = "test",
+    SpeckleVersion = "0.0.0",
+  };
+
+  private readonly string _dir = Path.Combine(Path.GetTempPath(), "BundleBuilderTests", Guid.NewGuid().ToString("N"));
+
+  private static Mesh Tri(double dx = 0) =>
+    new()
+    {
+      vertices = [dx, 0, 0, dx + 1, 0, 0, dx, 1, 0],
+      faces = [3, 0, 1, 2],
+      units = "m",
+    };
+
+  private async Task<Model> BuildAndRead(Action<BundleBuilder> populate)
+  {
+    BundleFiles files;
+    using (var b = new BundleBuilder(s_app, "m", _dir))
+    {
+      populate(b);
+      files = b.Build();
+    }
+    Assert.All(files.Files, f => Assert.StartsWith("bundle.", Path.GetFileName(f), StringComparison.Ordinal));
+    var bundle = await ArtefactBundleReader.ReadAsync(_dir, ArtefactReadOptions.Columnar, CancellationToken.None);
+    return new Model("p", "m", "v", _dir, files.Files, bundle, geometryDownloaded: true, NullLogger.Instance);
+  }
+
+  [Fact]
+  public async Task Objects_Properties_Collections_RoundTrip()
+  {
+    using var model = await BuildAndRead(b =>
+    {
+      var walls = b.Collection(["Level 1", "Walls"], subtype: "Category");
+      var wall = b.Object(
+        "wall-1",
+        walls,
+        new Dictionary<string, object?>
+        {
+          ["Constraints"] = new Dictionary<string, object?> { ["Base Offset"] = 0.5 },
+          ["Identity Data"] = new Dictionary<string, object?> { ["Mark"] = "W-01" },
+        },
+        name: "Basic Wall",
+        speckleType: "Objects.Data.DataObject",
+        sourceType: "Walls"
+      );
+      wall.AddGeometry(Tri());
+      b.Object("door-1", walls, new Dictionary<string, object?> { ["Width"] = 0.9 }, name: "Door");
+      // interning: same id twice is one object
+      Assert.Same(wall, b.Object("wall-1", walls, null));
+    });
+
+    Assert.Equal("m", model.Units);
+    Assert.Equal(2, model.Objects.Count);
+    var wall = model.ObjectByApplicationId("wall-1")!;
+    Assert.Equal("Basic Wall", wall.Name);
+    Assert.Equal(0.5, wall.GetDouble("Constraints.Base Offset"));
+    Assert.Equal("W-01", wall.GetString("Identity Data.Mark"));
+    Assert.Equal("Objects.Data.DataObject", wall.GetString("speckle_type"));
+    Assert.Equal("Walls", wall.GetString("type"));
+    Assert.Equal(["Level 1", "Walls"], wall.CollectionPath);
+    Assert.Equal("Category", wall.Collection!.Subtype);
+    Assert.Equal("Level 1", wall.Collection.Parent!.Name);
+    var tier = Assert.Single(model.DefaultSceneView); // added by Build() when none declared
+    Assert.Equal(RelKind.InCollection, tier.Relation);
+
+    var g = Assert.Single(wall.Geometries);
+    Assert.Equal(9, g.DecodeMesh()!.Value.Vertices.Length);
+    Assert.Empty(model.ObjectByApplicationId("door-1")!.Geometries);
+  }
+
+  [Fact]
+  public async Task Relations_And_Appearance_RoundTrip()
+  {
+    using var model = await BuildAndRead(b =>
+    {
+      var layer = b.Collection(["Layer 1"], "Layer");
+      var concrete = b.Material("mat-1", "Concrete", unchecked((int)0xFF808080), roughness: 0.8);
+      var red = b.Color(unchecked((int)0xFFFF0000));
+      var l1 = b.Level("L1", "Level 1", 3.0);
+      layer.Color = red; // node plane
+
+      var wall = b.Object("wall-1", layer, null, name: "Wall");
+      wall.AddGeometry(Tri()).Material = concrete; // geometry plane
+      wall.Level = l1;
+      var door = b.Object("door-1", layer, null, name: "Door");
+      door.Parent = wall;
+      door.Host = wall;
+      door.Color = red; // object plane
+      door.Level = l1;
+      var room = b.Object("room-1", layer, null, name: "Office");
+      wall.Bounds(room);
+      door.Room = room;
+      var a = b.Object("pipe-a", layer, null);
+      var c = b.Object("pipe-b", layer, null);
+      a.ConnectTo(c);
+      var group = b.Container("grp-1", "Group A", null, "Group");
+      wall.AddToGroup(group);
+      Assert.Same(concrete, b.Material("mat-1", "other name", 0)); // interned on key
+    });
+
+    var wall = model.ObjectByApplicationId("wall-1")!;
+    var door = model.ObjectByApplicationId("door-1")!;
+    var room = model.ObjectByApplicationId("room-1")!;
+
+    Assert.Equal("Concrete", wall.Geometries[0].Material!.Name);
+    Assert.Equal(0.8, wall.Geometries[0].Material!.Roughness);
+    Assert.Equal("Level 1", wall.Level!.Name);
+    Assert.Equal(3.0, wall.Level.Elevation);
+    Assert.Same(wall, door.Parent);
+    Assert.Same(wall, door.Host);
+    Assert.Equal([door], wall.Children);
+    Assert.Equal(unchecked((int)0xFFFF0000), door.Color!.Argb);
+    Assert.Equal(unchecked((int)0xFFFF0000), wall.Collection!.Color!.Argb);
+    Assert.Equal([room], wall.BoundsRooms);
+    Assert.Same(room, door.Room);
+    Assert.Equal([door], room.Contains);
+    Assert.Equal(["pipe-b"], model.ObjectByApplicationId("pipe-a")!.ConnectedTo.Select(o => o.ApplicationId));
+    Assert.Equal("Group A", Assert.Single(wall.Groups).Name);
+    Assert.Single(model.Materials);
+    Assert.Single(model.Colors);
+    Assert.Single(model.Levels);
+  }
+
+  [Fact]
+  public async Task Definitions_Placements_Members_RoundTrip()
+  {
+    using var model = await BuildAndRead(b =>
+    {
+      var layer = b.Collection(["Blocks"], "Layer");
+      var chairDef = b.Definition(
+        "def-chair",
+        "Chair",
+        d => d.AddGeometry(Tri()).Material = b.Material("m", "Fabric", 0)
+      );
+      double[] t = [1, 0, 0, 10, 0, 1, 0, 20, 0, 0, 1, 0, 0, 0, 0, 1];
+      var chair1 = b.Object("chair-1", layer, null, name: "Chair 1");
+      chair1.Place(chairDef, t);
+      var chair2 = b.Object("chair-2", layer, null, name: "Chair 2");
+      chair2.Place(chairDef, t);
+      Assert.Same(chairDef, b.Definition("def-chair", "x")); // populate runs once
+
+      // a Rhino-style member object with its own properties, joined to the definition geometry by ordinal
+      var tableDef = b.Definition("def-table", "Table");
+      int ord = tableDef.NextMemberOrdinal();
+      tableDef.AddGeometry(Tri(5), memberOrd: ord);
+      var top = b.Object("table-top", layer, new Dictionary<string, object?> { ["material"] = "oak" }, name: "Top");
+      tableDef.AddMember(top, ord);
+      b.Object("table-1", layer, null, name: "Table 1").Place(tableDef, t);
+    });
+
+    var chair1 = model.ObjectByApplicationId("chair-1")!;
+    var placement = Assert.Single(chair1.Placements);
+    Assert.Equal(10, placement.Transform![3]);
+    Assert.Equal("Chair", chair1.Definition!.Name);
+    Assert.Equal(2, chair1.Definition.Placements.Count);
+    Assert.Equal(["chair-1", "chair-2"], chair1.Definition.Objects.Select(o => o.ApplicationId));
+    var g = Assert.Single(chair1.Geometries);
+    Assert.Equal("Fabric", g.Material!.Name);
+    Assert.NotNull(g.Transform);
+
+    var table = model.ObjectByApplicationId("table-1")!;
+    var top = Assert.Single(table.Definition!.Members);
+    Assert.Equal("oak", top.GetString("material"));
+    Assert.Equal(2, model.Definitions.Count);
+  }
+
+  [Fact]
+  public async Task ModelExtras_SceneView_RoundTrip()
+  {
+    using var model = await BuildAndRead(b =>
+    {
+      var host = b.Container("model-main", "Main.rvt", null, "Model");
+      var l1 = b.Level("L1", "Level 1", 0);
+      var o = b.Object("w", null, null, name: "W", rootScalars: [new("category", "Walls"), new("family", "Basic")]);
+      o.Model = host;
+      o.Level = l1;
+      b.SceneView(
+        "Default",
+        isDefault: true,
+        SceneViewKey.Rel(RelKind.InModel),
+        SceneViewKey.Rel(RelKind.OnLevel),
+        SceneViewKey.Eav("category"),
+        SceneViewKey.Eav("family")
+      );
+      b.ModelProperty("modelPlacement.units", "m");
+      b.ModelProperty("projectInformation.number", 42.0);
+      b.StructuralResult(o, "Base", "reaction", "DL", "Fz", value: 12.5);
+      b.CameraView(new CameraView(0, "Front", true, 0, 0, -10, 5, 0, 1, 0, 0, 0, 1));
+    });
+
+    var w = model.ObjectByApplicationId("w")!;
+    Assert.Equal(4, model.DefaultSceneView.Count);
+    Assert.Equal(["Main.rvt", "Level 1", "Walls", "Basic"], w.SceneViewSegments.Select(s => s.Name));
+    Assert.IsType<ModelContainer>(w.SceneViewSegments[0].Node);
+    Assert.IsType<ModelLevel>(w.SceneViewSegments[1].Node);
+    Assert.Null(w.SceneViewSegments[2].Node);
+    Assert.Equal("m", model.Properties["modelPlacement.units"]);
+    Assert.Equal(42.0, model.Properties["projectInformation.number"]);
+    Assert.Equal("Front", Assert.Single(model.CameraViews).Name);
+    Assert.Contains(model.Files, f => f.EndsWith(".eav.structural_results.parquet", StringComparison.Ordinal));
+  }
+
+  [Fact]
+  public void Build_Twice_Throws_And_RenameTo_RekeysFiles()
+  {
+    using var b = new BundleBuilder(s_app, "m", _dir);
+    b.Object("o", null, null);
+    var files = b.Build();
+    Assert.Throws<InvalidOperationException>(() => b.Build());
+
+    var renamed = files.RenameTo("08de6a66ec");
+    Assert.All(renamed.Files, f => Assert.StartsWith("08de6a66ec.", Path.GetFileName(f), StringComparison.Ordinal));
+    Assert.All(renamed.Files, f => Assert.True(File.Exists(f)));
+    Assert.Equal(files.Files.Count, renamed.ByName.Count);
+    Assert.Equal(1, renamed.ObjectCount);
+  }
+
+  [Fact]
+  public void Relation_CannotBeRetracted()
+  {
+    using var b = new BundleBuilder(s_app, "m", _dir);
+    var a = b.Collection(["A"]);
+    var c = b.Collection(["C"]);
+    var o = b.Object("o", a, null);
+    Assert.Throws<InvalidOperationException>(() => o.Collection = c);
+    o.Collection = a; // idempotent
+  }
+
+  public void Dispose()
+  {
+    if (Directory.Exists(_dir))
+    {
+      Directory.Delete(_dir, true);
+    }
+  }
+}

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
@@ -42,6 +42,23 @@ public sealed class BundleBuilderTests : IDisposable
   }
 
   [Fact]
+  public void Solid_And_Display_Ordinals_Count_Per_Relation()
+  {
+    // What the pre-BundleBuilder Rhino pipeline wrote: an object's solid is SOLID ord 0 and its first display mesh is
+    // DISPLAY ord 0 — the two relations never share a counter.
+    using var b = new BundleBuilder(s_app, "m", _dir);
+    var o = b.GetOrAddObject("pipe-1");
+    o.SetProperties(new Dictionary<string, object?>(), "pipe");
+    var solid = o.AddRawGeometry([1, 2, 3], "3dm");
+    var display = o.AddGeometry(Tri());
+    var display2 = o.AddGeometry(Tri(1));
+
+    Assert.Equal(0, solid.Ord);
+    Assert.Equal(0, display.Ord);
+    Assert.Equal(1, display2.Ord);
+  }
+
+  [Fact]
   public async Task Objects_Properties_Collections_RoundTrip()
   {
     using var model = await BuildAndRead(b =>

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
@@ -349,6 +349,20 @@ public sealed class BundleBuilderTests : IDisposable
   }
 
   [Fact]
+  public async Task Collections_CarryGhTopology_OnTheLeaf()
+  {
+    using var model = await BuildAndRead(b =>
+    {
+      var leaf = b.GetOrAddCollection(["Tree", "{0;1}"], "Collection", ghTopology: "{0;1}");
+      b.GetOrAddObject("o", leaf, null);
+    });
+
+    var o = model.ObjectByApplicationId("o")!;
+    Assert.Equal("{0;1}", o.Collection!.GhTopology);
+    Assert.Null(o.Collection.Parent!.GhTopology);
+  }
+
+  [Fact]
   public void Build_Twice_Throws_And_RenameTo_RekeysFiles()
   {
     using var b = new BundleBuilder(s_app, "m", _dir);


### PR DESCRIPTION
Stacked on #558 (base: `oguzhan/dev-utilities`). Part 1 of the send story: port the write + upload phases that every connector send builder re-implements into the SDK, so scripts get a `Send3` symmetrical with `Receive3` and connectors stop carrying the bookkeeping.

## `BundleBuilder` (`Speckle.Sdk.Bundles`)

Typed handles over `ObjectsArtifactPipeline`. Everything streams to parquet as it is added (geometry SGEO-encoded on the spot), so memory doesn't grow with the model.

```csharp
using var b = new BundleBuilder(app, units: "m");
var walls = b.GetOrAddContainerPath(["Level 1", "Walls"], subtype: "Category");
var wall  = b.GetOrAddObject("wall-1");
wall.SetProperties(props, name: "Basic Wall", speckleType: "Objects.Data.DataObject", sourceType: "Walls");
wall.Collection = walls;
wall.AddGeometry(mesh).Material = b.GetOrAddMaterial("concrete", "Concrete", argb, roughness: 0.8);
wall.Level = b.GetOrAddLevel("L1", "Level 1", 0);   door.Host = wall;   wall.AddChild(door, ord: 0);
chair.Place(b.GetOrAddDefinition("def-chair", "Chair", d => d.AddGeometry(chairMesh)), transform);
BundleFiles files = b.Build();   // files.RenameTo(versionId) before upload
```

**Naming rule** — `GetOrAdd…` interns a node by key (same key → same handle; same key with different attributes → throws). `Add…` appends a row every call (geometry, model properties, structural results, camera views). Verbs and property setters (`Place`, `ConnectTo`, `Host =`) emit one edge each; a relation can't be retracted. `SetProperties` writes an object's rows once.

**Coverage** — audited every `pipeline.*` call across the eight `*ArtifactRootObjectBuilder`s (Rhino, Grasshopper, Revit, AutoCAD, Civil3D, CSi, Tekla, TSD); each has a builder equivalent, including the ones that needed new API: definition members that own their geometry (`AddMember` / `AddMemberRawGeometry` / `AddMemberPlacement` — Rhino/AutoCAD block contents, `DEFINES`+`DEFINES_MEMBER`+`PLACES` on one ordinal, no `DISPLAY`), shared geometry by key (`TryGetGeometry` + `AddExistingGeometry` — Revit symbols), forward-referenced objects (CSi joints, group members), explicit `SUBELEMENT` ordinals (`AddChild(child, ord)`), `gh_topology` on collections, containers on the three appearance planes, `IN_MODEL`/`IN_SYSTEM`/`IN_ROOM`/`ON_LEVEL`/`IN_GROUP`/`HOSTED_ON`/`CONNECTS_TO`/`BOUNDS`, model properties, structural results, property-set definitions, camera views, scene views (`IN_COLLECTION` default when none declared).

## `Send3`

```csharp
SendResult r = await operations.Send3(url, projectId, modelId, builder, token, options, ct);
// or Send3("https://…/projects/{p}/models/{m}", builder, token, options, ct) — a pinned @versionId is rejected
```

`Ingestion.Create` (server pre-allocates the version id; throws clearly otherwise) → `Build()` → `RenameTo(versionId)` → sign / PUT / complete over `/api/v2` → `FailWithError` / `FailWithCancel` on the way out. The version's `referencedObject` is the bundle reference `bundle.<p>.<m>.<v>` — the form `Receive2` dispatches on — so the connectors' `"binary-<v>"` root id goes away once they route through this.

Orchestration lives in two DI collaborators, `BundleSender` and `BundleReceiver`; `Operations.Receive3` / `Send3` / the `Receive2` projection delegate to them (keeps `Operations` under the class-coupling ceiling; gives connectors' `SendOperation` something to call directly).

## Also
- `ArtefactEdge` → `RelationRow` (it's a `(src, dst, ord)` row already grouped by rel). One connector file references it — updated with the bump.
- `Model.Properties` (model-scoped) is now flat path-keyed like object properties.
- `ModelContainer.GhTopology` on the read side.

## Tests
`BundleBuilderTests` — every case writes with the builder and reads back through the `Receive3` façade (objects, properties, collections, relations, appearance on three planes, instancing, members, nested placements, shared geometry, forward refs, ordinals, gh_topology, model extras, `RenameTo`). `OperationsSend3Tests` — url validation before any I/O. `SendReceiveBundleTests` `[Server=Internal]` — `BundleBuilder → Send3 → poll version → referencedObject == bundle reference → Receive3 by id and by url`. 1025 unit, migrator 39, objects 213 green.

## Next (separate PR, connectors)
Bump, `RelationRow` rename in GH receive, then the eight builders onto `BundleBuilder` + `IBundleSender`, CSi first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mGdYTzvqTrbws7r8vwMgK