### PR TITLE
feat(bundles): IN_ASSEMBLY on the write side (pipeline InAssembly + BundleObject.AddAssemblyMember)

### DIFF
--- a/src/Speckle.Sdk/Bundles/BundleHandles.cs
+++ b/src/Speckle.Sdk/Bundles/BundleHandles.cs
@@ -319,6 +319,7 @@ public sealed class BundleObject
   private BundleMaterial? _material;
   private BundleColor? _color;
   private BundleObject? _parent;
+  private int _assemblyMemberOrd;
   private BundleObject? _host;
   private BundleObject? _room;
 
@@ -506,6 +507,31 @@ public sealed class BundleObject
     child._parent = this;
     _builder.Pipeline.Subelement(K, child.K, o);
   }
+
+  /// <summary>Declares <paramref name="member"/> a member of this assembly (<c>IN_ASSEMBLY</c>): authored fabrication
+  /// membership, separate from <see cref="AddChild"/> ownership. <paramref name="ord"/> is the member's position —
+  /// 0 is the main member, ≥1 orders secondary or nested-assembly members; null = next. A member belongs to one
+  /// assembly.</summary>
+  public void AddAssemblyMember(BundleObject member, int? ord = null)
+  {
+    if (member.Assembly is not null)
+    {
+      if (ReferenceEquals(member.Assembly, this))
+      {
+        return;
+      }
+      throw new InvalidOperationException(
+        $"Object '{member.ApplicationId}' is already a member of assembly '{member.Assembly.ApplicationId}'; a bundle edge cannot be retracted."
+      );
+    }
+    int o = ord ?? _assemblyMemberOrd;
+    _assemblyMemberOrd = Math.Max(_assemblyMemberOrd, o + 1);
+    member.Assembly = this;
+    _builder.Pipeline.InAssembly(member.K, K, o);
+  }
+
+  /// <summary>The assembly this object is a member of, once <see cref="AddAssemblyMember"/> declared it.</summary>
+  public BundleObject? Assembly { get; private set; }
 
   /// <summary>Host (<c>HOSTED_ON</c>): the wall a door is placed on. Not ownership.</summary>
   public BundleObject? Host

--- a/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactPipeline.cs
@@ -497,6 +497,13 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   public void Bounds(int boundingObjectK, int roomObjectK, int ord) =>
     _envelopeWriter.AddRelation(RelKind.Bounds, boundingObjectK, roomObjectK, ord);
 
+  /// <summary>object(member) → object(assembly): authored fabrication membership (<c>IN_ASSEMBLY</c>, rel 18), separate
+  /// from <see cref="Subelement"/> ownership — a Tekla/CSi assembly groups members it does not own. <paramref name="ord"/>
+  /// is the member's position: 0 is the main member, ≥1 orders secondary or nested-assembly members. Both endpoints
+  /// are interned objects. Direction and ordinal semantics match specklepy's <c>in_assembly</c>.</summary>
+  public void InAssembly(int memberObjectK, int assemblyObjectK, int ord) =>
+    _envelopeWriter.AddRelation(RelKind.InAssembly, memberObjectK, assemblyObjectK, ord);
+
   /// <summary>object(definition member) → node(INSTANCE): the association-only object↔placement map (rel 24
   /// PLACES). Ties a render-edge-less definition-member object to its nested placement so its properties and
   /// <see cref="InCollection"/> membership stay reachable — replaces the <c>@speckle.instance_k</c> eav stamp.

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
@@ -414,6 +414,40 @@ public sealed class BundleBuilderTests : IDisposable
   }
 
   [Fact]
+  public async Task Assemblies_RoundTrip_MemberOrderAndReverseLookup()
+  {
+    using var model = await BuildAndRead(b =>
+    {
+      var assembly = b.GetOrAddObject("asm", null, null);
+      var plate = b.GetOrAddObject("plate", null, null);
+      var boltA = b.GetOrAddObject("bolt-a", null, null);
+      var boltB = b.GetOrAddObject("bolt-b", null, null);
+      assembly.AddAssemblyMember(plate); // ord 0 = main member
+      assembly.AddAssemblyMember(boltB, ord: 2);
+      assembly.AddAssemblyMember(boltA, ord: 1);
+      assembly.AddAssemblyMember(plate); // idempotent
+      Assert.Same(assembly, plate.Assembly);
+    });
+
+    var asm = model.ObjectByApplicationId("asm")!;
+    Assert.Equal(["plate", "bolt-a", "bolt-b"], asm.AssemblyMembers.Select(m => m.ApplicationId));
+    Assert.Same(asm, model.ObjectByApplicationId("bolt-a")!.Assembly);
+    Assert.Null(asm.Assembly);
+    Assert.Empty(asm.Children); // membership is not ownership
+  }
+
+  [Fact]
+  public void AssemblyMembership_CannotBeRetracted()
+  {
+    using var b = new BundleBuilder(s_app, "m", _dir);
+    var a1 = b.GetOrAddObject("a1", null, null);
+    var a2 = b.GetOrAddObject("a2", null, null);
+    var member = b.GetOrAddObject("m", null, null);
+    a1.AddAssemblyMember(member);
+    Assert.Throws<InvalidOperationException>(() => a2.AddAssemblyMember(member));
+  }
+
+  [Fact]
   public void Relation_CannotBeRetracted()
   {
     using var b = new BundleBuilder(s_app, "m", _dir);


### PR DESCRIPTION
## What

`IN_ASSEMBLY` (rel 18, member object → assembly object, `ord 0` = main member) was readable since Receive3 (`ModelObject.Assembly` / `AssemblyMembers`) but no SDK producer could write it. Found while aligning with specklepy #517, whose `in_assembly` had no .NET counterpart.

- `ObjectsArtifactPipeline.InAssembly(memberObjectK, assemblyObjectK, ord)`
- `BundleObject.AddAssemblyMember(member, ord = null)` + `BundleObject.Assembly` — same contract as `AddChild`: explicit or next ordinal, single-valued, no retraction. Membership is not ownership (no `SUBELEMENT` emitted).

Direction and ordinal semantics per `bundle-spec.sql` row 18 and specklepy's `in_assembly`.

## Tests
`BundleBuilderTests`: write two-level member ordinals → read back through the `Receive3` façade (`AssemblyMembers` ordered, reverse lookup, `Children` empty); retraction throws. 1045+2 unit tests green on net8/net10.

## Consumers
None yet — Tekla/CSi senders are still on their own builders; they pick this up with their `BundleBuilder` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mGdYTzvqTrbws7r8vwMgK