### PR TITLE
Fix: Remove redundant color ord relationship

### DIFF
--- a/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactPipeline.cs
@@ -437,13 +437,8 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   public void HasMaterial(int srcK, int materialK, bool srcIsInstance = false) =>
     _envelopeWriter.AddRelation(RelKind.HasMaterial, srcK, materialK, srcIsInstance ? 1 : 0);
 
-  /// <summary>geometry | object → node(COLOR): display colour. The two source namespaces overlap numerically
-  /// (both are dense int spaces from 0), so <paramref name="srcIsObject"/> tags which one <paramref name="srcK"/>
-  /// belongs to in the edge's <c>ord</c> column: 0 = geometry (the default, and what every pre-tag bundle wrote),
-  /// 1 = object. Without the tag a consumer cannot tell an object-sourced instance colour from a geometry-sourced
-  /// one and must guess — dropping colours or applying them to the wrong element [ENG-8822].</summary>
-  public void HasColor(int srcK, int colorK, bool srcIsObject = false) =>
-    _envelopeWriter.AddRelation(RelKind.HasColor, srcK, colorK, srcIsObject ? 1 : 0);
+  /// <summary>geometry → node(COLOR): display colour.</summary>
+  public void HasColor(int srcK, int colorK) => _envelopeWriter.AddRelation(RelKind.HasColor, srcK, colorK, 0);
 
   /// <summary>object → node(LEVEL): level membership.</summary>
   public void OnLevel(int objectK, int levelK) => _envelopeWriter.AddRelation(RelKind.OnLevel, objectK, levelK, 0);


### PR DESCRIPTION
`HasColor` is just geometry now, not union to include objects. Thus `srcIsObject` is old and redundent, and ord value 1 should not be used