### PR TITLE
fix(eav): stop dropping Type Parameters.Structure — compound layers reach type_eav (ENG-9355)

### DIFF
--- a/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactPipeline.cs
@@ -95,11 +95,10 @@ public sealed class ObjectsArtifactPipeline : IDisposable
 
     // Instance-scoped props → eav; Type/System params deduped into type_eav (flattened once per type,
     // via the lazy factory) with an object_type weak ref. See notes/topology-envelope-SOT.md §6.
-    // A compound element's layer buildup rides along as `Type Parameters.Structure.{ordinal}.*` — a type fact,
-    // stored once per type like every other type parameter (ENG-9338/ENG-9355).
     var instanceRows = new List<EavRow>();
     EavExtraction.FlattenProperties(applicationId, instanceProps, rootScalars, _excludedProperties, instanceRows);
     _eavWriter.AddRows(applicationId, instanceRows);
+
     _eavWriter.AddType(
       applicationId,
       typeKey,
@@ -122,10 +121,12 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   {
     instanceProps = properties;
     typeSubtree = s_emptyDict;
+
     if (!properties.TryGetValue("Parameters", out var pv) || pv is not IReadOnlyDictionary<string, object?> paramsDict)
     {
       return false;
     }
+
     var typeParams = new Dictionary<string, object?>(StringComparer.Ordinal);
     var instanceParams = new Dictionary<string, object?>(StringComparer.Ordinal);
     foreach (var kv in paramsDict)
@@ -139,10 +140,12 @@ public sealed class ObjectsArtifactPipeline : IDisposable
         instanceParams[kv.Key] = kv.Value;
       }
     }
+
     if (typeParams.Count == 0)
     {
       return false;
     }
+
     // Copy via foreach (the Dictionary(IEnumerable<KVP>, comparer) ctor is net5+; netstandard2.0 only has the
     // IDictionary ctor, and `properties` is an IReadOnlyDictionary).
     var merged = new Dictionary<string, object?>(StringComparer.Ordinal);
@@ -434,13 +437,8 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   public void HasMaterial(int srcK, int materialK, bool srcIsInstance = false) =>
     _envelopeWriter.AddRelation(RelKind.HasMaterial, srcK, materialK, srcIsInstance ? 1 : 0);
 
-  /// <summary>geometry | object → node(COLOR): display colour. The two source namespaces overlap numerically
-  /// (both are dense int spaces from 0), so <paramref name="srcIsObject"/> tags which one <paramref name="srcK"/>
-  /// belongs to in the edge's <c>ord</c> column: 0 = geometry (the default, and what every pre-tag bundle wrote),
-  /// 1 = object. Without the tag a consumer cannot tell an object-sourced instance colour from a geometry-sourced
-  /// one and must guess — dropping colours or applying them to the wrong element [ENG-8822].</summary>
-  public void HasColor(int srcK, int colorK, bool srcIsObject = false) =>
-    _envelopeWriter.AddRelation(RelKind.HasColor, srcK, colorK, srcIsObject ? 1 : 0);
+  /// <summary>geometry → node(COLOR): display colour.</summary>
+  public void HasColor(int srcK, int colorK) => _envelopeWriter.AddRelation(RelKind.HasColor, srcK, colorK, 0);
 
   /// <summary>object → node(LEVEL): level membership.</summary>
   public void OnLevel(int objectK, int levelK) => _envelopeWriter.AddRelation(RelKind.OnLevel, objectK, levelK, 0);

--- a/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactPipeline.cs
@@ -93,9 +93,10 @@ public sealed class ObjectsArtifactPipeline : IDisposable
       return;
     }
 
-    // Instance-scoped props → eav; type-scoped ones (Type/System Parameters, the compound Structure) deduped into
-    // type_eav (flattened once per type, via the lazy factory) with an object_type weak ref. See
-    // notes/topology-envelope-SOT.md §6.
+    // Instance-scoped props → eav; Type/System params deduped into type_eav (flattened once per type,
+    // via the lazy factory) with an object_type weak ref. See notes/topology-envelope-SOT.md §6.
+    // A compound element's layer buildup rides along as `Type Parameters.Structure.{ordinal}.*` — a type fact,
+    // stored once per type like every other type parameter (ENG-9338/ENG-9355).
     var instanceRows = new List<EavRow>();
     EavExtraction.FlattenProperties(applicationId, instanceProps, rootScalars, _excludedProperties, instanceRows);
     _eavWriter.AddRows(applicationId, instanceRows);
@@ -105,20 +106,14 @@ public sealed class ObjectsArtifactPipeline : IDisposable
       () =>
       {
         var typeRows = new List<EavRow>();
-        EavExtraction.FlattenSubtree(typeSubtree, "properties", typeRows);
+        EavExtraction.FlattenSubtree(typeSubtree, "properties.Parameters", typeRows);
         return typeRows;
       }
     );
   }
 
-  /// <summary>The top-level property that is a fact of the element's TYPE, not the instance: a compound
-  /// element's layer buildup (<c>properties.Structure.{ordinal}.{material|function|thickness}</c>, ENG-9338/9355).
-  /// Every wall of one type shares one buildup, so it lives in <c>type_eav</c> once, beside the type parameters.</summary>
-  private const string STRUCTURE_KEY = "Structure";
-
-  // Splits the type-scoped part of `properties` out of the instance-scoped part: `Parameters.Type Parameters`,
-  // `Parameters.System Type Parameters` and the top-level `Structure` go to type_eav (deduped per type) under
-  // the same `properties.` paths; everything else stays on the object. False if there's nothing type-scoped.
+  // Splits `properties.Parameters` into instance-scoped (kept on the object) and type-scoped (Type +
+  // System Parameters, deduped per type). False if there's nothing type-scoped to split out.
   private static bool TrySplitTypeParameters(
     IReadOnlyDictionary<string, object?> properties,
     out IReadOnlyDictionary<string, object?> instanceProps,
@@ -127,38 +122,27 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   {
     instanceProps = properties;
     typeSubtree = s_emptyDict;
-
-    var typeScoped = new Dictionary<string, object?>(StringComparer.Ordinal);
-    Dictionary<string, object?>? instanceParams = null;
-    if (properties.TryGetValue("Parameters", out var pv) && pv is IReadOnlyDictionary<string, object?> paramsDict)
-    {
-      var typeParams = new Dictionary<string, object?>(StringComparer.Ordinal);
-      instanceParams = new Dictionary<string, object?>(StringComparer.Ordinal);
-      foreach (var kv in paramsDict)
-      {
-        if (kv.Key is "Type Parameters" or "System Type Parameters")
-        {
-          typeParams[kv.Key] = kv.Value;
-        }
-        else
-        {
-          instanceParams[kv.Key] = kv.Value;
-        }
-      }
-      if (typeParams.Count > 0)
-      {
-        typeScoped["Parameters"] = typeParams;
-      }
-    }
-    if (properties.TryGetValue(STRUCTURE_KEY, out var structure) && structure is IReadOnlyDictionary<string, object?>)
-    {
-      typeScoped[STRUCTURE_KEY] = structure;
-    }
-    if (typeScoped.Count == 0)
+    if (!properties.TryGetValue("Parameters", out var pv) || pv is not IReadOnlyDictionary<string, object?> paramsDict)
     {
       return false;
     }
-
+    var typeParams = new Dictionary<string, object?>(StringComparer.Ordinal);
+    var instanceParams = new Dictionary<string, object?>(StringComparer.Ordinal);
+    foreach (var kv in paramsDict)
+    {
+      if (kv.Key is "Type Parameters" or "System Type Parameters")
+      {
+        typeParams[kv.Key] = kv.Value;
+      }
+      else
+      {
+        instanceParams[kv.Key] = kv.Value;
+      }
+    }
+    if (typeParams.Count == 0)
+    {
+      return false;
+    }
     // Copy via foreach (the Dictionary(IEnumerable<KVP>, comparer) ctor is net5+; netstandard2.0 only has the
     // IDictionary ctor, and `properties` is an IReadOnlyDictionary).
     var merged = new Dictionary<string, object?>(StringComparer.Ordinal);
@@ -166,13 +150,9 @@ public sealed class ObjectsArtifactPipeline : IDisposable
     {
       merged[kv.Key] = kv.Value;
     }
-    if (typeScoped.ContainsKey("Parameters"))
-    {
-      merged["Parameters"] = instanceParams;
-    }
-    merged.Remove(STRUCTURE_KEY);
+    merged["Parameters"] = instanceParams;
     instanceProps = merged;
-    typeSubtree = typeScoped;
+    typeSubtree = typeParams;
     return true;
   }
 
@@ -454,8 +434,13 @@ public sealed class ObjectsArtifactPipeline : IDisposable
   public void HasMaterial(int srcK, int materialK, bool srcIsInstance = false) =>
     _envelopeWriter.AddRelation(RelKind.HasMaterial, srcK, materialK, srcIsInstance ? 1 : 0);
 
-  /// <summary>geometry → node(COLOR): display colour.</summary>
-  public void HasColor(int srcK, int colorK) => _envelopeWriter.AddRelation(RelKind.HasColor, srcK, colorK, 0);
+  /// <summary>geometry | object → node(COLOR): display colour. The two source namespaces overlap numerically
+  /// (both are dense int spaces from 0), so <paramref name="srcIsObject"/> tags which one <paramref name="srcK"/>
+  /// belongs to in the edge's <c>ord</c> column: 0 = geometry (the default, and what every pre-tag bundle wrote),
+  /// 1 = object. Without the tag a consumer cannot tell an object-sourced instance colour from a geometry-sourced
+  /// one and must guess — dropping colours or applying them to the wrong element [ENG-8822].</summary>
+  public void HasColor(int srcK, int colorK, bool srcIsObject = false) =>
+    _envelopeWriter.AddRelation(RelKind.HasColor, srcK, colorK, srcIsObject ? 1 : 0);
 
   /// <summary>object → node(LEVEL): level membership.</summary>
   public void OnLevel(int objectK, int levelK) => _envelopeWriter.AddRelation(RelKind.OnLevel, objectK, levelK, 0);

--- a/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactPipeline.cs
+++ b/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactPipeline.cs
@@ -93,26 +93,32 @@ public sealed class ObjectsArtifactPipeline : IDisposable
       return;
     }
 
-    // Instance-scoped props → eav; Type/System params deduped into type_eav (flattened once per type,
-    // via the lazy factory) with an object_type weak ref. See notes/topology-envelope-SOT.md §6.
+    // Instance-scoped props → eav; type-scoped ones (Type/System Parameters, the compound Structure) deduped into
+    // type_eav (flattened once per type, via the lazy factory) with an object_type weak ref. See
+    // notes/topology-envelope-SOT.md §6.
     var instanceRows = new List<EavRow>();
     EavExtraction.FlattenProperties(applicationId, instanceProps, rootScalars, _excludedProperties, instanceRows);
     _eavWriter.AddRows(applicationId, instanceRows);
-
     _eavWriter.AddType(
       applicationId,
       typeKey,
       () =>
       {
         var typeRows = new List<EavRow>();
-        EavExtraction.FlattenSubtree(typeSubtree, "properties.Parameters", typeRows);
+        EavExtraction.FlattenSubtree(typeSubtree, "properties", typeRows);
         return typeRows;
       }
     );
   }
 
-  // Splits `properties.Parameters` into instance-scoped (kept on the object) and type-scoped (Type +
-  // System Parameters, deduped per type). False if there's nothing type-scoped to split out.
+  /// <summary>The top-level property that is a fact of the element's TYPE, not the instance: a compound
+  /// element's layer buildup (<c>properties.Structure.{ordinal}.{material|function|thickness}</c>, ENG-9338/9355).
+  /// Every wall of one type shares one buildup, so it lives in <c>type_eav</c> once, beside the type parameters.</summary>
+  private const string STRUCTURE_KEY = "Structure";
+
+  // Splits the type-scoped part of `properties` out of the instance-scoped part: `Parameters.Type Parameters`,
+  // `Parameters.System Type Parameters` and the top-level `Structure` go to type_eav (deduped per type) under
+  // the same `properties.` paths; everything else stays on the object. False if there's nothing type-scoped.
   private static bool TrySplitTypeParameters(
     IReadOnlyDictionary<string, object?> properties,
     out IReadOnlyDictionary<string, object?> instanceProps,
@@ -122,26 +128,33 @@ public sealed class ObjectsArtifactPipeline : IDisposable
     instanceProps = properties;
     typeSubtree = s_emptyDict;
 
-    if (!properties.TryGetValue("Parameters", out var pv) || pv is not IReadOnlyDictionary<string, object?> paramsDict)
+    var typeScoped = new Dictionary<string, object?>(StringComparer.Ordinal);
+    Dictionary<string, object?>? instanceParams = null;
+    if (properties.TryGetValue("Parameters", out var pv) && pv is IReadOnlyDictionary<string, object?> paramsDict)
     {
-      return false;
+      var typeParams = new Dictionary<string, object?>(StringComparer.Ordinal);
+      instanceParams = new Dictionary<string, object?>(StringComparer.Ordinal);
+      foreach (var kv in paramsDict)
+      {
+        if (kv.Key is "Type Parameters" or "System Type Parameters")
+        {
+          typeParams[kv.Key] = kv.Value;
+        }
+        else
+        {
+          instanceParams[kv.Key] = kv.Value;
+        }
+      }
+      if (typeParams.Count > 0)
+      {
+        typeScoped["Parameters"] = typeParams;
+      }
     }
-
-    var typeParams = new Dictionary<string, object?>(StringComparer.Ordinal);
-    var instanceParams = new Dictionary<string, object?>(StringComparer.Ordinal);
-    foreach (var kv in paramsDict)
+    if (properties.TryGetValue(STRUCTURE_KEY, out var structure) && structure is IReadOnlyDictionary<string, object?>)
     {
-      if (kv.Key is "Type Parameters" or "System Type Parameters")
-      {
-        typeParams[kv.Key] = kv.Value;
-      }
-      else
-      {
-        instanceParams[kv.Key] = kv.Value;
-      }
+      typeScoped[STRUCTURE_KEY] = structure;
     }
-
-    if (typeParams.Count == 0)
+    if (typeScoped.Count == 0)
     {
       return false;
     }
@@ -153,9 +166,13 @@ public sealed class ObjectsArtifactPipeline : IDisposable
     {
       merged[kv.Key] = kv.Value;
     }
-    merged["Parameters"] = instanceParams;
+    if (typeScoped.ContainsKey("Parameters"))
+    {
+      merged["Parameters"] = instanceParams;
+    }
+    merged.Remove(STRUCTURE_KEY);
     instanceProps = merged;
-    typeSubtree = typeParams;
+    typeSubtree = typeScoped;
     return true;
   }
 

--- a/src/Speckle.Sdk/Pipelines/Send/Artifacts/EavExtraction.cs
+++ b/src/Speckle.Sdk/Pipelines/Send/Artifacts/EavExtraction.cs
@@ -375,12 +375,6 @@ public static class EavExtraction
         continue;
       }
 
-      // Skip Structure layer definitions under Type Parameters
-      if (key == "Structure" && prefix.EndsWith(".Type Parameters"))
-      {
-        continue;
-      }
-
       // Skip Material Quantities — handled separately
       if (key == "Material Quantities")
       {
@@ -694,10 +688,6 @@ public static class EavExtraction
         }
 
         // Parity with the JObject walk's special-cases.
-        if (key == "Structure" && prefix.EndsWith(".Type Parameters", StringComparison.Ordinal))
-        {
-          continue;
-        }
         if (key == "Material Quantities")
         {
           continue; // handled separately

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
@@ -414,6 +414,57 @@ public sealed class BundleBuilderTests : IDisposable
   }
 
   [Fact]
+  public async Task Structure_IsTypeScoped_OnceForAllInstancesOfTheType()
+  {
+    // A compound element's layer buildup is a fact of its type: two walls of one type carry one Structure in
+    // type_eav (properties.Structure.{ordinal}.*), none on the object rows [ENG-9338/ENG-9355].
+    static Dictionary<string, object?> Layer(string material, string function, double thickness) =>
+      new()
+      {
+        ["material"] = new Dictionary<string, object?> { ["name"] = "Material", ["value"] = material },
+        ["function"] = new Dictionary<string, object?> { ["name"] = "Function", ["value"] = function },
+        ["thickness"] = new Dictionary<string, object?>
+        {
+          ["name"] = "Thickness",
+          ["value"] = thickness,
+          ["units"] = "mm",
+        },
+      };
+    static Dictionary<string, object?> WallProps() =>
+      new()
+      {
+        ["Parameters"] = new Dictionary<string, object?>
+        {
+          ["Constraints"] = new Dictionary<string, object?> { ["Base Offset"] = 0.5 },
+        },
+        ["Structure"] = new Dictionary<string, object?>
+        {
+          ["0"] = Layer("White Concrete", "Finish1", 65),
+          ["1"] = Layer("Concrete", "Structure", 200),
+        },
+      };
+
+    using var model = await BuildAndRead(b =>
+    {
+      b.GetOrAddObject("wall-1").SetProperties(WallProps(), "Basic Wall", typeKey: "type-basic-wall");
+      b.GetOrAddObject("wall-2").SetProperties(WallProps(), "Basic Wall", typeKey: "type-basic-wall");
+    });
+
+    foreach (var id in new[] { "wall-1", "wall-2" })
+    {
+      var wall = model.ObjectByApplicationId(id)!;
+      Assert.Equal(0.5, wall.GetDouble("Parameters.Constraints.Base Offset")); // instance-scoped stays put
+      Assert.Equal("White Concrete", wall.TypeProperties["Structure.0.material"]);
+      Assert.Equal("Finish1", wall.TypeProperties["Structure.0.function"]);
+      Assert.Equal(65.0, wall.TypeProperties["Structure.0.thickness"]);
+      Assert.Equal(200.0, wall.TypeProperties["Structure.1.thickness"]);
+      Assert.Equal(65.0, wall.GetDouble("Structure.0.thickness")); // the merged lookup sees type scope too
+      Assert.DoesNotContain(wall.Properties.Keys, k => k.StartsWith("Structure", StringComparison.Ordinal));
+    }
+    Assert.Single(model.Bundle.TypeIndexByObject!.Values.Distinct()); // one type row shared by both walls
+  }
+
+  [Fact]
   public void Relation_CannotBeRetracted()
   {
     using var b = new BundleBuilder(s_app, "m", _dir);

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
@@ -414,10 +414,11 @@ public sealed class BundleBuilderTests : IDisposable
   }
 
   [Fact]
-  public async Task Structure_IsTypeScoped_OnceForAllInstancesOfTheType()
+  public async Task Structure_UnderTypeParameters_IsWrittenOncePerType()
   {
-    // A compound element's layer buildup is a fact of its type: two walls of one type carry one Structure in
-    // type_eav (properties.Structure.{ordinal}.*), none on the object rows [ENG-9338/ENG-9355].
+    // A compound element's layer buildup sits in Parameters.Type Parameters.Structure.{ordinal}.* and rides the
+    // type split: two walls of one type carry one Structure in type_eav, none on the object rows. The legacy
+    // flatten rule that dropped it is gone [ENG-9338/ENG-9355].
     static Dictionary<string, object?> Layer(string material, string function, double thickness) =>
       new()
       {
@@ -436,11 +437,15 @@ public sealed class BundleBuilderTests : IDisposable
         ["Parameters"] = new Dictionary<string, object?>
         {
           ["Constraints"] = new Dictionary<string, object?> { ["Base Offset"] = 0.5 },
-        },
-        ["Structure"] = new Dictionary<string, object?>
-        {
-          ["0"] = Layer("White Concrete", "Finish1", 65),
-          ["1"] = Layer("Concrete", "Structure", 200),
+          ["Type Parameters"] = new Dictionary<string, object?>
+          {
+            ["Construction"] = new Dictionary<string, object?> { ["Width"] = 265.0 },
+            ["Structure"] = new Dictionary<string, object?>
+            {
+              ["0"] = Layer("White Concrete", "Finish1", 65),
+              ["1"] = Layer("Concrete", "Structure", 200),
+            },
+          },
         },
       };
 
@@ -454,12 +459,13 @@ public sealed class BundleBuilderTests : IDisposable
     {
       var wall = model.ObjectByApplicationId(id)!;
       Assert.Equal(0.5, wall.GetDouble("Parameters.Constraints.Base Offset")); // instance-scoped stays put
-      Assert.Equal("White Concrete", wall.TypeProperties["Structure.0.material"]);
-      Assert.Equal("Finish1", wall.TypeProperties["Structure.0.function"]);
-      Assert.Equal(65.0, wall.TypeProperties["Structure.0.thickness"]);
-      Assert.Equal(200.0, wall.TypeProperties["Structure.1.thickness"]);
-      Assert.Equal(65.0, wall.GetDouble("Structure.0.thickness")); // the merged lookup sees type scope too
-      Assert.DoesNotContain(wall.Properties.Keys, k => k.StartsWith("Structure", StringComparison.Ordinal));
+      Assert.Equal(265.0, wall.TypeProperties["Parameters.Type Parameters.Construction.Width"]);
+      Assert.Equal("White Concrete", wall.TypeProperties["Parameters.Type Parameters.Structure.0.material"]);
+      Assert.Equal("Finish1", wall.TypeProperties["Parameters.Type Parameters.Structure.0.function"]);
+      Assert.Equal(65.0, wall.TypeProperties["Parameters.Type Parameters.Structure.0.thickness"]);
+      Assert.Equal(200.0, wall.TypeProperties["Parameters.Type Parameters.Structure.1.thickness"]);
+      Assert.Equal(65.0, wall.GetDouble("Parameters.Type Parameters.Structure.0.thickness")); // merged lookup
+      Assert.DoesNotContain(wall.Properties.Keys, k => k.Contains("Structure"));
     }
     Assert.Single(model.Bundle.TypeIndexByObject!.Values.Distinct()); // one type row shared by both walls
   }

--- a/tests/Speckle.Sdk.Tests.Unit/Pipelines/Send/Artifacts/EavExtractionTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Pipelines/Send/Artifacts/EavExtractionTests.cs
@@ -166,7 +166,7 @@ public class EavExtractionTests
   }
 
   [Fact]
-  public void StructureUnderTypeParameters_AndMaterialQuantities_AreSkippedInWalk()
+  public void StructureUnderTypeParameters_IsFlattened_AndMaterialQuantitiesHandledSpecially()
   {
     var obj = JObject.Parse(
       """
@@ -190,8 +190,8 @@ public class EavExtractionTests
 
     var rows = EavExtraction.FlattenObjectProperties("o", obj);
 
-    // Structure skipped in walk
-    rows.Should().NotContain(r => r.Path.Contains("Structure"));
+    // Structure is data like any other (the legacy skip that dropped a wall's layer buildup is gone, ENG-9338)
+    rows.Should().ContainSingle(r => r.Path == "properties.Type Parameters.Structure.layerCount" && r.ValueNum == 3);
 
     // Material Quantities handled via the special extraction with category in path
     rows.Should()


### PR DESCRIPTION
## What

The compound-layer shape stays where `main`, rvextract and the legacy tree put it — `properties.Parameters.Type Parameters.Structure.*` — and the SDK stops dropping it ([ENG-9355](https://linear.app/speckle/issue/ENG-9355)).

- `EavExtraction`: the two `if (key == "Structure" && prefix.EndsWith(".Type Parameters")) continue;` skips are removed (JObject + native walks). That rule is the ENG-9338 data loss; nothing else depended on it.
- No pipeline change: `TrySplitTypeParameters` already routes the whole `Type Parameters` subtree to `type_eav`, so a type's layers are written **once per type** and every instance reaches them through `object_type`.

## Agreed shape
```
type_eav  properties.Parameters.Type Parameters.Structure.0.material   = "White Concrete"
          properties.Parameters.Type Parameters.Structure.0.function   = "Finish1"
          properties.Parameters.Type Parameters.Structure.0.thickness  = 65   unit = "mm"
```
ordinal key = `GetLayers()` order, exterior → interior; fields are `{name,value[,units]}` records (unit lands in the unit column); unit is the unit id, not the localized label.

## Consumers
- **Revit connector: follow-up on the next bump** — #1543 moved `Structure` to the top of `properties` to dodge the skip; it goes back under the type-parameter dictionary (`CompoundStructureExtractor` output → `Type Parameters["Structure"]`), keeping its ordinal keys + records. Until that bump the connector's top-level `Structure` keeps working per object as today.
- **rvextract**: already at this path and scope; remaining deltas are ordinal keys (instead of `{material} (layerId)`) and the unit id (instead of `getLabelForUnit`). Separate change in speckle-converters.
- **Migrated legacy Revit versions**: regain their layers (legacy key shape).
- Receive3: `wall.TypeProperties["Parameters.Type Parameters.Structure.0.thickness"]`.

## Tests
`Structure_UnderTypeParameters_IsWrittenOncePerType` (two walls, one type row, instance params untouched, nothing on object rows) and the old skip test inverted. 1048 unit tests green on net8/net10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mGdYTzvqTrbws7r8vwMgK