### PR TITLE
feat(bundles): Model.Meta (bundle provenance) + Receive2 playground

### DIFF
--- a/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
@@ -23,6 +23,22 @@ public readonly record struct ArtefactGeometry(byte[] Content, string Type)
 /// <c>"category"</c>, <c>"family"</c>). Tiers are ordered outermost→innermost.</summary>
 public readonly record struct SceneViewTier(string Source, string Ref);
 
+/// <summary>Provenance from <c>envelope.meta.parquet</c> (single row): which spec vocabulary the bundle speaks and
+/// who wrote it. <see cref="MigratedFromSchemaVersion"/> is non-null only for bundles the server converted from a
+/// legacy (v2/v3) object graph.</summary>
+public sealed record BundleMeta(
+  string? SchemaVersion,
+  string? ProducedBy,
+  string? ProducerVersion,
+  string? SdkName,
+  string? SdkVersion,
+  int? MigratedFromSchemaVersion
+)
+{
+  /// <summary>True when this bundle was converted from a legacy object graph rather than natively published.</summary>
+  public bool IsMigrated => MigratedFromSchemaVersion is not null;
+}
+
 /// <summary>A named camera viewpoint from <c>envelope.camera_views.parquet</c> (Rhino named view, Revit 3D view,
 /// SketchUp scene). Position/target/ortho-height are in <see cref="Units"/> (model units); forward/up are unitless
 /// UNIT vectors; <see cref="Fov"/> is the VERTICAL field of view in DEGREES (perspective only, null for ortho).</summary>
@@ -258,6 +274,10 @@ public sealed record ArtefactReadOptions(bool LoadGeometry = true, bool Columnar
 
 public sealed class ArtefactBundle
 {
+  /// <summary>Bundle provenance (<c>envelope.meta</c>); null when the file is absent or unreadable (a pre-release
+  /// vintage) — never a reason to fail the read.</summary>
+  public BundleMeta? Meta { get; init; }
+
   /// <summary>Instance properties as columns (see <see cref="ArtefactReadOptions.ColumnarProperties"/>); null in
   /// nested mode.</summary>
   public PropertyTable? PropertyTable { get; init; }
@@ -375,6 +395,7 @@ public static class ArtefactBundleReader
     var modelT = await TryReadTableAsync(bundleDir, ".eav.model.parquet", cancellationToken).ConfigureAwait(false);
     var psetDefsT = await TryReadTableAsync(bundleDir, ".eav.property_set_definitions.parquet", cancellationToken)
       .ConfigureAwait(false);
+    var metaT = await TryReadTableAsync(bundleDir, ".envelope.meta.parquet", cancellationToken).ConfigureAwait(false);
 
     var objIdToApp = BuildObjectIds(objectsT);
     var pathById = BuildPaths(pathsT);
@@ -405,7 +426,34 @@ public static class ArtefactBundleReader
         : LoadTypeProperties(typeEavT, objectTypeT, pathById),
       ModelProperties = LoadModelProperties(modelT),
       PropertySetDefinitions = LoadPropertySetDefinitions(psetDefsT),
+      Meta = LoadMeta(metaT),
     };
+  }
+
+  // Single-row provenance. Deliberately forgiving: schema_version was an int before the semver renumber and the
+  // whole table is informational, so any shape surprise yields null rather than failing the read.
+  private static BundleMeta? LoadMeta(ParquetTable? t)
+  {
+    if (t is null || t.RowCount == 0)
+    {
+      return null;
+    }
+    try
+    {
+      string? Str(string col) => t.Has(col) ? t.Strings(col)[0] : null;
+      return new BundleMeta(
+        Str("schema_version"),
+        Str("produced_by"),
+        Str("producer_version"),
+        Str("sdk_name"),
+        Str("sdk_version"),
+        t.Has("migrated_from_schema_version") ? t.NullableInts("migrated_from_schema_version")[0] : null
+      );
+    }
+    catch (InvalidCastException)
+    {
+      return null;
+    }
   }
 
   // ENG-9136: type_eav has the identical (index, path_index, value_*) row shape as eav, keyed by type_index

--- a/src/Speckle.Sdk/Bundles/Model.cs
+++ b/src/Speckle.Sdk/Bundles/Model.cs
@@ -175,6 +175,10 @@ public sealed class Model : IDisposable
   /// <summary>The parsed bundle: dense-int object / geometry / node ids, relations, scene views. NB
   /// <see cref="ArtefactBundle.Geometries"/> on this instance is empty — geometry is deferred; use
   /// <see cref="Geometries"/>.</summary>
+  /// <summary>Bundle provenance (<c>envelope.meta</c>): spec vocabulary version, producing application and SDK, and
+  /// whether the bundle was migrated from a legacy object graph. Null when the bundle predates the meta table.</summary>
+  public BundleMeta? Meta => Bundle.Meta;
+
   public ArtefactBundle Bundle { get; }
 
   // ── internals shared by the façade types ──────────────────────────────────────────────────────────────

--- a/tests/Speckle.Sdk.Tests.Integration/Bundles/Receive2Playground.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Bundles/Receive2Playground.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.DependencyInjection;
+using Speckle.Sdk.Api;
+using Speckle.Sdk.Bundles;
+using Speckle.Sdk.Credentials;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Models.Collections;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+using Xunit.Abstractions;
+
+namespace Speckle.Sdk.Tests.Integration.Bundles;
+
+/// <summary>
+/// Manual playground for the legacy <see cref="Operations.Receive2"/> surface against a real server — the path an
+/// old script takes. Point it at any vintage and compare what comes back:
+/// <list type="bullet">
+///   <item>a v3 version (hash in <c>referencedObject</c>) → the legacy object graph, downloaded as-is</item>
+///   <item>a migrated bundle (server converted a v2/v3 graph; <c>bundle.…</c> reference) → the Base projection</item>
+///   <item>a natively published bundle → the Base projection</item>
+/// </list>
+/// Set <see cref="MODEL_URL"/> and <see cref="TOKEN"/> below (don't commit them), then run/debug. Left empty, the
+/// test returns immediately (green in CI).
+/// <code>
+///   MODEL_URL: https://app.speckle.systems/projects/{projectId}/models/{modelId}[@{versionId}]   (no @ ⇒ latest)
+/// </code>
+/// </summary>
+[Trait("Category", "Playground")]
+public sealed class Receive2Playground(ITestOutputHelper output)
+{
+  // ── fill these in locally ─────────────────────────────────────────────────────────────────────────────
+  private const string MODEL_URL = "";
+  private const string TOKEN = "";
+
+  [Fact]
+  public async Task Receive2_FromModelUrl()
+  {
+    if (string.IsNullOrWhiteSpace(MODEL_URL) || string.IsNullOrWhiteSpace(TOKEN))
+    {
+      output.WriteLine("Skipped: set MODEL_URL and TOKEN at the top of Receive2Playground to run it.");
+      return;
+    }
+
+    var services = new ServiceCollection();
+    services.AddSpeckleSdk(new("Playground", "playground"), "v3");
+    await using var provider = services.BuildServiceProvider();
+
+    var url = ModelUrl.Parse(MODEL_URL);
+    var account = new Account
+    {
+      token = TOKEN,
+      serverInfo = new() { url = url.Server.ToString() },
+      userInfo = new(),
+    };
+
+    // ── resolve the version + its referencedObject (what Receive2 dispatches on) ────────────────────────
+    using var client = provider.GetRequiredService<IClientFactory>().Create(account);
+    string versionId;
+    string? referencedObject;
+    if (url.VersionId is { } pinned)
+    {
+      var version = await client.Version.Get(pinned, url.ProjectId);
+      versionId = version.id;
+      referencedObject = version.referencedObject;
+    }
+    else
+    {
+      var model = await client.Model.GetWithVersions(url.ModelId, url.ProjectId, versionsLimit: 1);
+      var latest = model.versions.items[0];
+      versionId = latest.id;
+      referencedObject = latest.referencedObject;
+    }
+    bool isBundle = BundleReference.IsBundleReference(referencedObject);
+    output.WriteLine($"version={versionId}  referencedObject={referencedObject}");
+    output.WriteLine(
+      isBundle
+        ? "→ bundle reference: Receive2 projects the bundle to a Base tree"
+        : "→ object hash: Receive2 downloads the legacy graph"
+    );
+
+    // ── the legacy receive (obsolete on purpose — this playground exercises exactly that surface) ───────
+#pragma warning disable CS0618
+    Base root = await provider
+      .GetRequiredService<IOperations>()
+      .Receive2(url.Server, url.ProjectId, referencedObject!, TOKEN, null, CancellationToken.None);
+#pragma warning restore CS0618
+
+    // ── what an old script sees — good place for a breakpoint ───────────────────────────────────────────
+    output.WriteLine($"root: {root.speckle_type}  units={root["units"]}  version-marker={root["version"] ?? "(none)"}");
+    output.WriteLine($"root members: {string.Join(", ", root.GetMembers(DynamicBaseMemberType.All).Keys.Take(12))}");
+
+    var byType = new Dictionary<string, int>();
+    int total = 0;
+    void Walk(Base b)
+    {
+      total++;
+      byType[b.speckle_type] = byType.GetValueOrDefault(b.speckle_type) + 1;
+      if (b is Collection c)
+      {
+        foreach (var child in c.elements)
+        {
+          Walk(child);
+        }
+      }
+    }
+    Walk(root);
+    output.WriteLine($"tree objects (via Collection.elements): {total}");
+    foreach (var kv in byType.OrderByDescending(kv => kv.Value).Take(10))
+    {
+      output.WriteLine($"    {kv.Value, 6}  {kv.Key}");
+    }
+
+    Assert.NotNull(root);
+  }
+}

--- a/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Bundles/BundleBuilderTests.cs
@@ -505,6 +505,21 @@ public sealed class BundleBuilderTests : IDisposable
   }
 
   [Fact]
+  public async Task Meta_SurfacesProvenance_OnTheModel()
+  {
+    using var model = await BuildAndRead(b => b.GetOrAddObject("o", null, null));
+
+    Assert.NotNull(model.Meta);
+    Assert.Equal("test", model.Meta!.ProducedBy); // s_app.Slug
+    Assert.Equal("1.0", model.Meta.ProducerVersion);
+    Assert.Equal("Speckle.Sdk (.NET)", model.Meta.SdkName);
+    Assert.Equal(ObjectsArtifactPipeline.SdkVersion, model.Meta.SdkVersion);
+    Assert.False(string.IsNullOrEmpty(model.Meta.SchemaVersion));
+    Assert.Null(model.Meta.MigratedFromSchemaVersion);
+    Assert.False(model.Meta.IsMigrated);
+  }
+
+  [Fact]
   public void Relation_CannotBeRetracted()
   {
     using var b = new BundleBuilder(s_app, "m", _dir);


### PR DESCRIPTION
- envelope.meta is now parsed (both profiles) into BundleMeta: schema version, producing application + version, SDK name + version, and migrated_from_schema_version (IsMigrated). Forgiving loader — a pre-release meta shape yields null, never a failed read. Exposed as Model.Meta on the Receive3 facade.
- Receive2Playground: manual harness for the legacy surface against a real server — resolves the version, says whether referencedObject is a hash (legacy graph) or a bundle reference (Base projection), walks the returned tree. For comparing v3 / migrated / native vintages.


Claude-Session: https://claude.ai/code/session_019mGdYTzvqTrbws7r8vwMgK