### PR TITLE
chore: pin speckle-bundle-spec CI checkout to 72c6a78

### DIFF
--- a/.github/actions/checkout-bundle-spec/action.yml
+++ b/.github/actions/checkout-bundle-spec/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/checkout@v7
       with:
         repository: specklesystems/speckle-bundle-spec
-        ref: e360fcfeeef3354c95c2a3a5554782bae15b783a
+        ref: 72c6a78ef48465f401c8a5ae61517abbf0b8b906
         token: ${{ inputs.token }}
         path: speckle-bundle-spec
         persist-credentials: false


### PR DESCRIPTION
Bumps the CI spec checkout ref (`.github/actions/checkout-bundle-spec/action.yml`) from `e360fcf` to `72c6a78` — the current spec main tip ("align catalog keys with deployed bundles", specklesystems/speckle-bundle-spec#29), matching the pins just taken by speckle-server-internal#2610 and speckle-converters#119.

Generated C# is unchanged in range (spec-SQL renames `rel_types.id`→`rel` / `node_kinds.id`→`kind`, the query conformance suite, and doc edits), so no code changes; `Speckle.Sdk.Parquet` builds clean against a sibling checkout at this ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYbRNzRAErJKGCFEsqYcaG