### PR TITLE
feat(send): [Obsolete] Send2 and Version.Create with a once-per-process runtime warning (ENG-9304, ENG-9418)

### DIFF
--- a/src/Speckle.Automate.Sdk/AutomationContext.cs
+++ b/src/Speckle.Automate.Sdk/AutomationContext.cs
@@ -120,6 +120,7 @@ internal sealed class AutomationContext(IOperations operations, ILogger<Automati
       }
     }
 
+#pragma warning disable CS0618 // legacy publish pair stays until the ingestion-backed helper lands (ENG-9420)
     var (rootObjectId, _) = await operations
       .Send2(
         SpeckleClient.ServerUrl,
@@ -137,6 +138,8 @@ internal sealed class AutomationContext(IOperations operations, ILogger<Automati
         cancellationToken
       )
       .ConfigureAwait(false);
+
+#pragma warning restore CS0618
 
     AutomationResult.ResultVersions.Add(newVersion.id);
 

--- a/src/Speckle.Sdk/Api/GraphQL/Client.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Client.cs
@@ -63,7 +63,7 @@ public sealed class Client : ISpeckleGraphQLClient, IClient
 
     Project = new(this);
     Model = new(this);
-    Version = new(this);
+    Version = new(this, logger);
     ActiveUser = new(this);
     OtherUser = new(this);
     ProjectInvite = new(this);

--- a/src/Speckle.Sdk/Api/GraphQL/Resources/VersionResource.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Resources/VersionResource.cs
@@ -1,4 +1,5 @@
-﻿using GraphQL;
+using GraphQL;
+using Microsoft.Extensions.Logging;
 using Speckle.Sdk.Api.GraphQL.Inputs;
 using Speckle.Sdk.Api.GraphQL.Models;
 using Speckle.Sdk.Api.GraphQL.Models.Responses;
@@ -8,11 +9,14 @@ namespace Speckle.Sdk.Api.GraphQL.Resources;
 
 public sealed class VersionResource
 {
+  private static int s_legacyCreateWarned; // once-per-process runtime deprecation warning (ENG-9418)
   private readonly ISpeckleGraphQLClient _client;
+  private readonly ILogger? _logger;
 
-  internal VersionResource(ISpeckleGraphQLClient client)
+  internal VersionResource(ISpeckleGraphQLClient client, ILogger? logger = null)
   {
     _client = client;
+    _logger = logger;
   }
 
   /// <param name="projectId"></param>
@@ -125,10 +129,25 @@ public sealed class VersionResource
 
   /// <param name="input"></param>
   /// <param name="cancellationToken"></param>
-  /// <returns>The created <see cref="Version"/></returns>
+  /// <returns>The created <see cref="Version"/>. On a 2026.9 server this is a RESERVATION: the id is allocated
+  /// immediately, but the version only becomes queryable when the server finishes ingesting - read it back through
+  /// the model ingestion (see the migration guide).</returns>
   /// <inheritdoc cref="ISpeckleGraphQLClient.ExecuteGraphQLRequest{T}"/>
+  [Obsolete(
+    "Legacy version creation: after server 2026.9 this call reserves an id and the version is born when the server "
+      + "finishes ingesting - the returned Version is a reservation, not yet queryable. Prefer SendPipeline + "
+      + "client.Ingestion (or Send3 with a BundleBuilder). Migration guide: "
+      + "https://docs.speckle.systems/developers/migration/publish-through-ingestions"
+  )]
   public async Task<Version> Create(CreateVersionInput input, CancellationToken cancellationToken = default)
   {
+    if (Interlocked.Exchange(ref s_legacyCreateWarned, 1) == 0)
+    {
+      _logger?.LogWarning(
+        "Version.Create is legacy: on 2026.9 servers the returned Version is a reservation until ingestion "
+          + "completes. Migration guide: https://docs.speckle.systems/developers/migration/publish-through-ingestions"
+      );
+    }
     //language=graphql
     const string QUERY = """
       mutation Create($input: CreateVersionInput!) {

--- a/src/Speckle.Sdk/Api/Operations/Operations.Send.cs
+++ b/src/Speckle.Sdk/Api/Operations/Operations.Send.cs
@@ -14,6 +14,8 @@ namespace Speckle.Sdk.Api;
 
 public partial class Operations
 {
+  private static int s_legacySendWarned; // once-per-process runtime deprecation warning (ENG-9304)
+
   /// <summary>
   /// Publishes a bundle as a new version — the Speckle 2026.9.0 send path. Creates the ingestion (the server
   /// pre-allocates the version id), finishes the <paramref name="builder"/> and re-keys its files to that id, uploads
@@ -92,6 +94,13 @@ public partial class Operations
   /// <exception cref="ArgumentNullException">The <paramref name="value"/> was <see langword="null"/></exception>
   /// <exception cref="SpeckleException">Serialization or Send operation was unsuccessful</exception>
   /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> requested cancellation</exception>
+  [AutoInterfaceIgnore] // declared by hand on IOperations so the [Obsolete] reaches interface callers
+  [Obsolete(
+    "Legacy send: serializes the per-object JSON graph, and after server 2026.9 the follow-up Version.Create only "
+      + "reserves an id - the version is born when the server finishes ingesting. Prefer SendPipeline + "
+      + "client.Ingestion (or Send3 with a BundleBuilder for producer-built bundles). Migration guide: "
+      + "https://docs.speckle.systems/developers/migration/publish-through-ingestions"
+  )]
   public async Task<SerializeProcessResults> Send2(
     Uri url,
     string streamId,
@@ -102,6 +111,13 @@ public partial class Operations
     SerializeProcessOptions? options = null
   )
   {
+    if (Interlocked.Exchange(ref s_legacySendWarned, 1) == 0)
+    {
+      logger.LogWarning(
+        "Send2 is legacy: the version a follow-up Version.Create returns is a reservation on 2026.9 servers. "
+          + "Migration guide: https://docs.speckle.systems/developers/migration/publish-through-ingestions"
+      );
+    }
     using var receiveActivity = activityFactory.Start("Operations.Send");
     receiveActivity?.SetTag("speckle.url", url);
     receiveActivity?.SetTag("speckle.projectId", streamId);
@@ -347,6 +363,23 @@ public partial class Operations
 /// attributes, and the deprecation must reach callers that resolve <c>IOperations</c> from DI.</summary>
 public partial interface IOperations
 {
+  /// <inheritdoc cref="Operations.Send2"/>
+  [Obsolete(
+    "Legacy send: serializes the per-object JSON graph, and after server 2026.9 the follow-up Version.Create only "
+      + "reserves an id - the version is born when the server finishes ingesting. Prefer SendPipeline + "
+      + "client.Ingestion (or Send3 with a BundleBuilder for producer-built bundles). Migration guide: "
+      + "https://docs.speckle.systems/developers/migration/publish-through-ingestions"
+  )]
+  Task<SerializeProcessResults> Send2(
+    Uri url,
+    string streamId,
+    string? authorizationToken,
+    Base value,
+    IProgress<ProgressArgs>? onProgressAction,
+    CancellationToken cancellationToken,
+    SerializeProcessOptions? options = null
+  );
+
   /// <inheritdoc cref="Operations.Send(Base, IServerTransport, bool, IProgress{ProgressArgs}?, CancellationToken)"/>
   [Obsolete(
     "Transport-based Send is frozen legacy surface (Speckle 2026.9.0): it writes the legacy per-object JSON graph and "

--- a/tests/Speckle.Automate.Sdk.Integration/SpeckleAutomate.cs
+++ b/tests/Speckle.Automate.Sdk.Integration/SpeckleAutomate.cs
@@ -12,6 +12,8 @@ using Speckle.Sdk.Models;
 using Speckle.Sdk.Tests.Integration;
 using Utils = Speckle.Automate.Sdk.Integration.TestAutomateUtils;
 
+#pragma warning disable CS0618 // exercises the legacy publish pair on purpose
+
 namespace Speckle.Automate.Sdk.Integration;
 
 public sealed class AutomationContextTest : IAsyncLifetime

--- a/tests/Speckle.Sdk.Tests.Integration/SendReceiveTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/SendReceiveTests.cs
@@ -4,6 +4,8 @@ using Speckle.Sdk.Api;
 using Speckle.Sdk.Api.GraphQL.Enums;
 using Speckle.Sdk.Api.GraphQL.Models;
 
+#pragma warning disable CS0618 // exercises the legacy send on purpose
+
 namespace Speckle.Sdk.Tests.Integration;
 
 public sealed class SendReceiveTests : IAsyncLifetime

--- a/tests/Speckle.Sdk.Tests.Unit/Api/Operations/LegacySendObsoleteTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Api/Operations/LegacySendObsoleteTests.cs
@@ -1,0 +1,99 @@
+using System.Reflection;
+using GraphQL;
+using Microsoft.Extensions.Logging;
+using Speckle.Sdk.Api;
+using Speckle.Sdk.Api.GraphQL;
+using Speckle.Sdk.Api.GraphQL.Resources;
+
+namespace Speckle.Sdk.Tests.Unit.Api.Operations;
+
+/// <summary>ENG-9304 / ENG-9418: the legacy publish pair carries [Obsolete] pointing at the migration guide, and
+/// warns once per process at runtime.</summary>
+public sealed class LegacySendObsoleteTests
+{
+  private const string GUIDE_URL = "https://docs.speckle.systems/developers/migration/publish-through-ingestions";
+
+  [Theory]
+  [InlineData(typeof(Speckle.Sdk.Api.Operations))]
+  [InlineData(typeof(IOperations))] // DI callers see the interface, not the class
+  public void Send2_IsObsolete_PointingAtTheMigrationGuide(Type type)
+  {
+    var attr = type.GetMethod("Send2")!
+      .GetCustomAttributes(typeof(ObsoleteAttribute), false)
+      .Cast<ObsoleteAttribute>()
+      .Single();
+    Assert.False(attr.IsError);
+    Assert.Contains(GUIDE_URL, attr.Message, StringComparison.Ordinal);
+    Assert.Contains("SendPipeline", attr.Message, StringComparison.Ordinal);
+  }
+
+  [Fact]
+  public void VersionCreate_IsObsolete_PointingAtTheMigrationGuide()
+  {
+    var attr = typeof(VersionResource)
+      .GetMethod(
+        nameof(VersionResource.Create),
+        [typeof(Speckle.Sdk.Api.GraphQL.Inputs.CreateVersionInput), typeof(CancellationToken)]
+      )!
+      .GetCustomAttributes(typeof(ObsoleteAttribute), false)
+      .Cast<ObsoleteAttribute>()
+      .Single();
+    Assert.False(attr.IsError);
+    Assert.Contains(GUIDE_URL, attr.Message, StringComparison.Ordinal);
+    Assert.Contains("reserves an id", attr.Message, StringComparison.Ordinal);
+  }
+
+  [Fact]
+  public async Task VersionCreate_Warns_OncePerProcess()
+  {
+    // reset the process-wide flag so this test is order-independent
+    typeof(VersionResource)
+      .GetField("s_legacyCreateWarned", BindingFlags.NonPublic | BindingFlags.Static)!
+      .SetValue(null, 0);
+    var logger = new CountingLogger();
+    var resource = new VersionResource(new ThrowingGraphQLClient(), logger);
+
+#pragma warning disable CS0618 // the obsolete surface is exactly what this test covers
+    await Assert.ThrowsAsync<NotSupportedException>(() => resource.Create(new("obj", "model", "proj")));
+    await Assert.ThrowsAsync<NotSupportedException>(() => resource.Create(new("obj", "model", "proj")));
+#pragma warning restore CS0618
+
+    Assert.Equal(1, logger.Warnings);
+    Assert.Contains(GUIDE_URL, logger.LastMessage, StringComparison.Ordinal);
+  }
+
+  private sealed class ThrowingGraphQLClient : ISpeckleGraphQLClient
+  {
+    Task<T> ISpeckleGraphQLClient.ExecuteGraphQLRequest<T>(GraphQLRequest request, CancellationToken ct) =>
+      throw new NotSupportedException("no network in unit tests");
+
+    IDisposable ISpeckleGraphQLClient.SubscribeTo<T>(GraphQLRequest request, Action<object, T> callback) =>
+      throw new NotSupportedException();
+  }
+
+  private sealed class CountingLogger : ILogger
+  {
+    public int Warnings;
+    public string LastMessage = "";
+
+    public IDisposable? BeginScope<TState>(TState state)
+      where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+      LogLevel logLevel,
+      EventId eventId,
+      TState state,
+      Exception? exception,
+      Func<TState, Exception?, string> formatter
+    )
+    {
+      if (logLevel == LogLevel.Warning)
+      {
+        Warnings++;
+        LastMessage = formatter(state, exception);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

The deprecation posture from the dev-compat spec §4 for the .NET legacy publish pair — now that the migration guide the warnings link to is live (speckle-docs-NEW #367).

- `Operations.Send2`: `[Obsolete]` (class + hand-declared on `IOperations`), message naming `SendPipeline` + `client.Ingestion`, `Send3` + `BundleBuilder` for producer-built bundles, and `https://docs.speckle.systems/developers/migration/publish-through-ingestions`. One `LogWarning` per process on first call.
- `VersionResource.Create(CreateVersionInput, ct)`: `[Obsolete]` with the reservation semantics spelled out (id allocated immediately, version born at ingestion success); XML doc updated; one warning per process. The resource takes the `Client`'s logger through its internal ctor (optional parameter — not a breaking change).
- Internal call sites get `#pragma CS0618` with justifications: `AutomationContext.CreateNewVersionInProject` (stays on the legacy pair until the ingestion-backed helper, ENG-9420) and the tests/benchmarks that exercise the legacy surface on purpose.

No behaviour change anywhere; sends keep working; no removal date (retirement is criteria-driven per the spec).

## Tests
- Attribute + message assertions for `Send2` (on `Operations` **and** `IOperations`) and `Version.Create`.
- Once-per-process: two `Create` calls against a throwing GraphQL fake → exactly one warning, containing the guide URL (process-wide flag reset via reflection for order independence).
- 1056 unit tests green on net8/net10; Automate SDK builds (AC of ENG-9418).

## Acceptance criteria mapping
- ENG-9304: obsolete on the legacy send surface ✓ · one runtime warning per process with the stable guide URL ✓ · behaviour unchanged ✓
- ENG-9418: compile warning with guide URL ✓ · first call logs once, later calls silent ✓ · Automate .NET SDK build passes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mGdYTzvqTrbws7r8vwMgK