### PR TITLE
feat(ingestion): WaitForCompletionAsync + Operations.WaitForVersion; Automate publishes via Send3

### DIFF
--- a/src/Speckle.Automate.Sdk/AutomationContext.cs
+++ b/src/Speckle.Automate.Sdk/AutomationContext.cs
@@ -9,9 +9,10 @@ using Speckle.Newtonsoft.Json;
 using Speckle.Sdk;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Api.GraphQL.Inputs;
-using Speckle.Sdk.Api.GraphQL.Models;
+using Speckle.Sdk.Bundles;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Models;
+using Model = Speckle.Sdk.Api.GraphQL.Models.Model;
 using Version = Speckle.Sdk.Api.GraphQL.Models.Version;
 
 namespace Speckle.Automate.Sdk;
@@ -106,19 +107,7 @@ internal sealed class AutomationContext(IOperations operations, ILogger<Automati
   )
   {
     // Confirm target branch is not the same as source branch
-    foreach (var trigger in AutomationRunData.Triggers)
-    {
-      if (trigger.Payload.ModelId == model.id)
-      {
-        throw new SpeckleException(
-          $"""
-          The target model: {model.name} ({model.id}) cannot match the model
-           that triggered this automation:
-           {trigger.Payload.ModelId}
-          """
-        );
-      }
-    }
+    GuardAgainstCircularTrigger(model);
 
 #pragma warning disable CS0618 // legacy publish pair stays until the ingestion-backed helper lands (ENG-9420)
     var (rootObjectId, _) = await operations
@@ -144,6 +133,66 @@ internal sealed class AutomationContext(IOperations operations, ILogger<Automati
     AutomationResult.ResultVersions.Add(newVersion.id);
 
     return newVersion;
+  }
+
+  /// <summary>
+  /// Publishes a producer-built bundle as a new version over the ingestion rail (Speckle 2026.9.0 send path).
+  /// Returns as soon as the upload completes: the <see cref="SendResult.VersionId"/> is allocated, the version
+  /// itself is born when the server finishes ingesting — call <see cref="WaitForVersion"/> if the function needs
+  /// to read it back or link it. Requires a server with the v2 data endpoints (the call throws otherwise).
+  /// </summary>
+  /// <exception cref="SpeckleException">The target model matches a triggering model (circular run), or the server
+  /// did not pre-allocate a version id.</exception>
+  public async Task<SendResult> CreateNewVersionInProject(
+    BundleBuilder bundle,
+    Model model,
+    string versionMessage = "",
+    CancellationToken cancellationToken = default
+  )
+  {
+    GuardAgainstCircularTrigger(model);
+
+    var sent = await operations
+      .Send3(
+        SpeckleClient.Account,
+        AutomationRunData.ProjectId,
+        model.id,
+        bundle,
+        new SendOptions(Message: versionMessage),
+        cancellationToken
+      )
+      .ConfigureAwait(false);
+
+    AutomationResult.ResultVersions.Add(sent.VersionId);
+
+    return sent;
+  }
+
+  /// <summary>Waits for the server to finish ingesting a <see cref="CreateNewVersionInProject(BundleBuilder, Model, string, CancellationToken)"/>
+  /// publish and returns the materialized version.</summary>
+  /// <exception cref="SpeckleException">The ingestion ended in a non-success terminal status.</exception>
+  /// <exception cref="TimeoutException"><paramref name="timeout"/> elapsed first.</exception>
+  public Task<Version> WaitForVersion(
+    SendResult sent,
+    TimeSpan? timeout = null,
+    CancellationToken cancellationToken = default
+  ) => operations.WaitForVersion(SpeckleClient.Account, sent, timeout, cancellationToken);
+
+  private void GuardAgainstCircularTrigger(Model model)
+  {
+    foreach (var trigger in AutomationRunData.Triggers)
+    {
+      if (trigger.Payload.ModelId == model.id)
+      {
+        throw new SpeckleException(
+          $"""
+          The target model: {model.name} ({model.id}) cannot match the model
+           that triggered this automation:
+           {trigger.Payload.ModelId}
+          """
+        );
+      }
+    }
   }
 
   /// <summary>

--- a/src/Speckle.Automate.Sdk/AutomationContext.cs
+++ b/src/Speckle.Automate.Sdk/AutomationContext.cs
@@ -137,9 +137,18 @@ internal sealed class AutomationContext(IOperations operations, ILogger<Automati
 
   /// <summary>
   /// Publishes a producer-built bundle as a new version over the ingestion rail (Speckle 2026.9.0 send path).
-  /// Returns as soon as the upload completes: the <see cref="SendResult.VersionId"/> is allocated, the version
-  /// itself is born when the server finishes ingesting — call <see cref="WaitForVersion"/> if the function needs
-  /// to read it back or link it. Requires a server with the v2 data endpoints (the call throws otherwise).
+  /// Returns as soon as the upload completes: the <see cref="SendResult.VersionId"/> is allocated and recorded in
+  /// <see cref="AutomationResult.ResultVersions"/> immediately, but the version itself is born when the server
+  /// finishes ingesting.
+  /// <para><b>Finish the wait before you finish the run.</b> If your function returns while the ingestion is still
+  /// processing, the run's result links point at a version that does not exist yet (a viewer link 404s until the
+  /// server completes it — usually seconds). Unless your function is fire-and-forget, end with:</para>
+  /// <code>
+  /// var sent = await context.CreateNewVersionInProject(bundle, model, "Analysis results");
+  /// await context.WaitForVersion(sent);   // version exists before the run reports success
+  /// </code>
+  /// <para>Requires a server with the v2 data endpoints (the call throws a clear <see cref="SpeckleException"/>
+  /// otherwise).</para>
   /// </summary>
   /// <exception cref="SpeckleException">The target model matches a triggering model (circular run), or the server
   /// did not pre-allocate a version id.</exception>
@@ -168,8 +177,9 @@ internal sealed class AutomationContext(IOperations operations, ILogger<Automati
     return sent;
   }
 
-  /// <summary>Waits for the server to finish ingesting a <see cref="CreateNewVersionInProject(BundleBuilder, Model, string, CancellationToken)"/>
-  /// publish and returns the materialized version.</summary>
+  /// <summary>Waits for the server to finish ingesting a publish and returns the materialized version. Call this
+  /// before your function returns (see <see cref="CreateNewVersionInProject(BundleBuilder, Model, string, CancellationToken)"/>)
+  /// so the run's result versions exist by the time the run reports success.</summary>
   /// <exception cref="SpeckleException">The ingestion ended in a non-success terminal status.</exception>
   /// <exception cref="TimeoutException"><paramref name="timeout"/> elapsed first.</exception>
   public Task<Version> WaitForVersion(

--- a/src/Speckle.Sdk/Api/GraphQL/Resources/ModelIngestionResource.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Resources/ModelIngestionResource.cs
@@ -1,4 +1,5 @@
 ﻿using GraphQL;
+using Speckle.Sdk.Api.GraphQL.Enums;
 using Speckle.Sdk.Api.GraphQL.Inputs;
 using Speckle.Sdk.Api.GraphQL.Models;
 using Speckle.Sdk.Api.GraphQL.Models.Responses;
@@ -125,6 +126,52 @@ public sealed class ModelIngestionResource
 
     return res.data.data;
   }
+
+  /// <summary>
+  /// Polls <see cref="Get"/> until the ingestion reaches a terminal status (success, failed, invalidInput,
+  /// cancelled or timeout) and returns it. This is the readiness step after a version-creating call: the version
+  /// exists once the returned ingestion's status is <see cref="ModelIngestionStatus.success"/> (its
+  /// <c>statusData.versionId</c> is then set). See the migration guide:
+  /// https://docs.speckle.systems/developers/migration/publish-through-ingestions
+  /// </summary>
+  /// <param name="timeout">Client-side ceiling; <see langword="null"/> = wait until <paramref name="cancellationToken"/>.</param>
+  /// <param name="pollInterval">Delay between polls; default 1 second.</param>
+  /// <exception cref="TimeoutException"><paramref name="timeout"/> elapsed before a terminal status.</exception>
+  public async Task<ModelIngestion> WaitForCompletionAsync(
+    string modelIngestionId,
+    string projectId,
+    TimeSpan? timeout = null,
+    TimeSpan? pollInterval = null,
+    CancellationToken cancellationToken = default
+  )
+  {
+    var interval = pollInterval ?? TimeSpan.FromSeconds(1);
+    var deadline = timeout is { } t ? DateTime.UtcNow + t : (DateTime?)null;
+    while (true)
+    {
+      var ingestion = await Get(modelIngestionId, projectId, cancellationToken).ConfigureAwait(false);
+      if (IsTerminal(ingestion.statusData.status))
+      {
+        return ingestion;
+      }
+      if (deadline is { } d && DateTime.UtcNow + interval > d)
+      {
+        throw new TimeoutException(
+          $"Ingestion '{modelIngestionId}' (project '{projectId}') did not reach a terminal status within {timeout}: "
+            + $"last status was '{ingestion.statusData.status}'."
+        );
+      }
+      await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+    }
+  }
+
+  private static bool IsTerminal(ModelIngestionStatus status) =>
+    status
+      is ModelIngestionStatus.success
+        or ModelIngestionStatus.failed
+        or ModelIngestionStatus.invalidInput
+        or ModelIngestionStatus.cancelled
+        or ModelIngestionStatus.timeout;
 
   /// <summary>
   /// For File Import / Cloud integrations only

--- a/src/Speckle.Sdk/Api/Operations/Operations.Send.cs
+++ b/src/Speckle.Sdk/Api/Operations/Operations.Send.cs
@@ -9,6 +9,7 @@ using Speckle.Sdk.Models;
 using Speckle.Sdk.Serialisation;
 using Speckle.Sdk.Serialisation.V2.Send;
 using Speckle.Sdk.Transports;
+using Version = Speckle.Sdk.Api.GraphQL.Models.Version;
 
 namespace Speckle.Sdk.Api;
 
@@ -85,6 +86,21 @@ public partial class Operations
     }
     return Send3(account, url.ProjectId, url.ModelId, builder, options, cancellationToken);
   }
+
+  /// <summary>
+  /// The readiness step after <see cref="Send3(Account, string, string, BundleBuilder, SendOptions?, CancellationToken)"/>:
+  /// waits for the server to finish ingesting and returns the materialized <see cref="Version"/>. Optional — the
+  /// <see cref="SendResult"/> already carries the allocated version id; call this only when you need the version to
+  /// exist (to link it, read it back, or hand it to another system).
+  /// </summary>
+  /// <exception cref="SpeckleException">The ingestion ended in a non-success terminal status.</exception>
+  /// <exception cref="TimeoutException"><paramref name="timeout"/> elapsed first.</exception>
+  public Task<Version> WaitForVersion(
+    Account account,
+    SendResult sent,
+    TimeSpan? timeout = null,
+    CancellationToken cancellationToken = default
+  ) => bundleSender.WaitForVersionAsync(account, sent, timeout, cancellationToken);
 
   /// <summary>
   /// Sends a Speckle Object to the provided URL and Caches the results

--- a/src/Speckle.Sdk/Bundles/BundleSender.cs
+++ b/src/Speckle.Sdk/Bundles/BundleSender.cs
@@ -1,11 +1,13 @@
 using Microsoft.Extensions.Logging;
 using Speckle.InterfaceGenerator;
 using Speckle.Sdk.Api;
+using Speckle.Sdk.Api.GraphQL.Enums;
 using Speckle.Sdk.Api.GraphQL.Inputs;
 using Speckle.Sdk.Credentials;
 using Speckle.Sdk.Logging;
 using Speckle.Sdk.Pipelines.Receive.Artifacts;
 using Speckle.Sdk.Pipelines.Send.Artifacts;
+using Version = Speckle.Sdk.Api.GraphQL.Models.Version;
 
 namespace Speckle.Sdk.Bundles;
 
@@ -109,6 +111,40 @@ public sealed class BundleSender(
         .ConfigureAwait(false);
       throw;
     }
+  }
+
+  /// <summary>
+  /// The readiness step after <see cref="SendAsync"/>: waits for the ingestion to finish server-side and returns
+  /// the materialized <see cref="Version"/>. Separate from the send on purpose — the upload returns in seconds,
+  /// ingestion can take as long as the server needs.
+  /// </summary>
+  /// <exception cref="SpeckleException">The ingestion ended in a non-success terminal status.</exception>
+  /// <exception cref="TimeoutException"><paramref name="timeout"/> elapsed first.</exception>
+  public async Task<Version> WaitForVersionAsync(
+    Account account,
+    SendResult sent,
+    TimeSpan? timeout,
+    CancellationToken cancellationToken
+  )
+  {
+    using var client = clientFactory.Create(account);
+    var ingestion = await client
+      .Ingestion.WaitForCompletionAsync(
+        sent.IngestionId,
+        sent.ProjectId,
+        timeout,
+        pollInterval: null,
+        cancellationToken
+      )
+      .ConfigureAwait(false);
+    if (ingestion.statusData.status != ModelIngestionStatus.success)
+    {
+      throw new SpeckleException(
+        $"Ingestion '{sent.IngestionId}' for version '{sent.VersionId}' ended '{ingestion.statusData.status}'"
+          + (ingestion.statusData.progressMessage is { Length: > 0 } m ? $": {m}" : ".")
+      );
+    }
+    return await client.Version.Get(sent.VersionId, sent.ProjectId, cancellationToken).ConfigureAwait(false);
   }
 
   private void TryDeleteDirectory(string dir)

--- a/tests/Speckle.Sdk.Tests.Integration/Bundles/SendReceiveBundleTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Bundles/SendReceiveBundleTests.cs
@@ -86,20 +86,8 @@ public sealed class SendReceiveBundleTests : IAsyncLifetime
     Assert.Equal(2, sent.ObjectCount);
     Assert.False(string.IsNullOrEmpty(sent.VersionId));
 
-    // ── the version exists once the ingestion completes; poll briefly ──────────────────────────────────
-    Speckle.Sdk.Api.GraphQL.Models.Version? version = null;
-    for (int i = 0; i < 60 && version is null; i++)
-    {
-      try
-      {
-        version = await _client.Version.Get(sent.VersionId, _projectId);
-      }
-      catch (SpeckleException)
-      {
-        await Task.Delay(500);
-      }
-    }
-    Assert.NotNull(version);
+    // ── the version exists once the ingestion completes ────────────────────────────────────────────────
+    var version = await operations.WaitForVersion(account, sent, TimeSpan.FromSeconds(30), CancellationToken.None);
     Assert.Equal(sent.BundleReference, version.referencedObject); // what Receive2 dispatches on
     Assert.True(BundleReference.TryParse(version.referencedObject, out _));
 

--- a/tests/Speckle.Sdk.Tests.Unit/Api/GraphQL/ModelIngestionWaitTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Api/GraphQL/ModelIngestionWaitTests.cs
@@ -1,0 +1,142 @@
+using GraphQL;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Speckle.Sdk.Api;
+using Speckle.Sdk.Api.GraphQL;
+using Speckle.Sdk.Api.GraphQL.Enums;
+using Speckle.Sdk.Api.GraphQL.Models;
+using Speckle.Sdk.Api.GraphQL.Models.Responses;
+using Speckle.Sdk.Api.GraphQL.Resources;
+using Speckle.Sdk.Bundles;
+using Speckle.Sdk.Credentials;
+using Version = Speckle.Sdk.Api.GraphQL.Models.Version;
+
+namespace Speckle.Sdk.Tests.Unit.Api.GraphQL;
+
+/// <summary>The readiness step after a version-creating call: poll the ingestion to a terminal status.</summary>
+public sealed class ModelIngestionWaitTests
+{
+  private static ModelIngestion Ingestion(ModelIngestionStatus status, string? versionId = null) =>
+    new()
+    {
+      id = "ing-1",
+      createdAt = DateTime.UtcNow,
+      updatedAt = DateTime.UtcNow,
+      modelId = "model",
+      projectId = "proj",
+      userId = "user",
+      cancellationRequested = false,
+      versionId = "ver",
+      statusData = new()
+      {
+        status = status,
+        progressMessage = status == ModelIngestionStatus.failed ? "boom" : null,
+        versionId = versionId,
+      },
+    };
+
+  /// <summary>Serves a scripted sequence of ingestion states, one per Get.</summary>
+  private sealed class SequencedGraphQLClient(params ModelIngestion[] states) : ISpeckleGraphQLClient
+  {
+    public int Calls { get; private set; }
+
+    Task<T> ISpeckleGraphQLClient.ExecuteGraphQLRequest<T>(GraphQLRequest request, CancellationToken ct)
+    {
+      var state = states[Math.Min(Calls, states.Length - 1)];
+      Calls++;
+      object response = new RequiredResponse<RequiredResponse<ModelIngestion>>(new(state));
+      return Task.FromResult((T)response);
+    }
+
+    IDisposable ISpeckleGraphQLClient.SubscribeTo<T>(GraphQLRequest request, Action<object, T> callback) =>
+      throw new NotSupportedException();
+  }
+
+  [Fact]
+  public async Task WaitForCompletion_PollsUntilTerminal()
+  {
+    var gql = new SequencedGraphQLClient(
+      Ingestion(ModelIngestionStatus.queued),
+      Ingestion(ModelIngestionStatus.processing),
+      Ingestion(ModelIngestionStatus.success, "ver")
+    );
+    var resource = new ModelIngestionResource(gql);
+
+    var result = await resource.WaitForCompletionAsync(
+      "ing-1",
+      "proj",
+      timeout: TimeSpan.FromSeconds(30),
+      pollInterval: TimeSpan.FromMilliseconds(1)
+    );
+
+    Assert.Equal(ModelIngestionStatus.success, result.statusData.status);
+    Assert.Equal("ver", result.statusData.versionId);
+    Assert.Equal(3, gql.Calls);
+  }
+
+  [Theory]
+  [InlineData(ModelIngestionStatus.failed)]
+  [InlineData(ModelIngestionStatus.cancelled)]
+  [InlineData(ModelIngestionStatus.invalidInput)]
+  [InlineData(ModelIngestionStatus.timeout)]
+  public async Task WaitForCompletion_ReturnsNonSuccessTerminals_ForTheCallerToInspect(ModelIngestionStatus terminal)
+  {
+    var resource = new ModelIngestionResource(new SequencedGraphQLClient(Ingestion(terminal)));
+
+    var result = await resource.WaitForCompletionAsync("ing-1", "proj", pollInterval: TimeSpan.FromMilliseconds(1));
+
+    Assert.Equal(terminal, result.statusData.status);
+  }
+
+  [Fact]
+  public async Task WaitForCompletion_Timeout_ThrowsWithLastStatus()
+  {
+    var resource = new ModelIngestionResource(new SequencedGraphQLClient(Ingestion(ModelIngestionStatus.processing)));
+
+    var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
+      resource.WaitForCompletionAsync(
+        "ing-1",
+        "proj",
+        timeout: TimeSpan.FromMilliseconds(20),
+        pollInterval: TimeSpan.FromMilliseconds(10)
+      )
+    );
+    Assert.Contains("processing", ex.Message, StringComparison.Ordinal);
+  }
+
+  [Fact]
+  public async Task Operations_WaitForVersion_DelegatesToTheBundleSender()
+  {
+    var sender = new Mock<IBundleSender>(MockBehavior.Strict);
+    var services = new ServiceCollection();
+    services.AddSpeckleSdk(new("Tests", "test"), "v3", typeof(ModelIngestionWaitTests).Assembly);
+    services.AddSingleton(sender.Object);
+    var operations = services.BuildServiceProvider().GetRequiredService<IOperations>();
+
+    var account = new Account
+    {
+      token = "tok",
+      serverInfo = new() { url = "https://example.speckle.invalid/" },
+      userInfo = new(),
+    };
+    var sent = new SendResult("proj", "model", "ver", "ing-1", 1);
+    var version = new Version
+    {
+      id = "ver",
+      referencedObject = "bundle.proj.model.ver",
+      message = null,
+      sourceApplication = null,
+      createdAt = DateTime.UtcNow,
+      previewUrl = new Uri("https://example.speckle.invalid/preview"),
+      authorUser = null,
+    };
+    sender
+      .Setup(s => s.WaitForVersionAsync(account, sent, TimeSpan.FromSeconds(5), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(version);
+
+    var result = await operations.WaitForVersion(account, sent, TimeSpan.FromSeconds(5), CancellationToken.None);
+
+    Assert.Same(version, result);
+    sender.VerifyAll();
+  }
+}


### PR DESCRIPTION
## What

The readiness step after a version-creating call — the flow the [migration guide](https://docs.speckle.systems/developers/migration/publish-through-ingestions) documents with raw GraphQL — as first-class SDK API, and the first consumer: an ingestion-backed Automate publish (the "helper is coming" the guide promises, ENG-9420's SDK half).

### Readiness
- `ModelIngestionResource.WaitForCompletionAsync(ingestionId, projectId, timeout?, pollInterval?, ct)` — polls `Get` until a terminal status and **returns** the ingestion (non-success terminals are for the caller to inspect, not exceptions at this level). `timeout: null` waits until the token cancels; expiry throws `TimeoutException` naming the last status. Poll default 1 s; the `projectModelIngestionUpdated` subscription can replace the poll later behind the same signature.
- `BundleSender.WaitForVersionAsync(Account, SendResult, timeout, ct)` — wait → `Version.Get(sent.VersionId)` on success; `SpeckleException` with status + `progressMessage` otherwise.
- `Operations.WaitForVersion(...)` — pure delegation, keeping `Operations` a façade. The canonical script is three honest steps: `Send3` → *(optional)* `WaitForVersion` → use. Deliberately **not** a `SendOptions` flag: an option that turns a seconds-long call into a server-length wait is a trap.

### Automate on the ingestion rail
- `AutomationContext.CreateNewVersionInProject(BundleBuilder, model, versionMessage, ct) → SendResult` — same circular-trigger guard (extracted, shared with the legacy overload), publishes via `Send3`, records `ResultVersions.Add(sent.VersionId)` immediately (the id is pre-allocated at `Ingestion.Create`). Returns at upload complete; the XML doc states the v2-data-endpoints server requirement.
- `AutomationContext.WaitForVersion(sent, timeout?, ct)` for functions that read back or link the version they created.
- The legacy `Base` overload is untouched (it stays the path for `Base`-producing functions until the ENG-9313 successor).

### Tests
`ModelIngestionWaitTests` (new): poll-until-terminal over a scripted GraphQL fake (3 polls asserted), all four non-success terminals returned not thrown, timeout message carries the last status, `Operations.WaitForVersion` delegation via mocked `IBundleSender`. `SendReceiveBundleTests`' 60×500 ms hand-rolled poll replaced by one `WaitForVersion` call. 1063 unit tests green on net8/net10.

## Live verification (latest.speckle.systems)

Ran the full rail against a real server — [project 030e3f6522, model c5c053658d](https://latest.speckle.systems/projects/030e3f6522/models/c5c053658d/versions), test version [32de791d76](https://latest.speckle.systems/projects/030e3f6522/models/c5c053658d@32de791d76):

```
Send3            → version 32de791d76 pre-allocated, ingestion 988c3b9d1f, 1 object uploaded
WaitForVersion   → returned in 5.3 s; Version.id == sent.VersionId
                   referencedObject == bundle.030e3f6522.c5c053658d.32de791d76  ✓
Receive3         → 1 object back; Identity Data.Mark == "WFV-01"; geometry present
Model.Meta       → SchemaVersion 1.0.0, ProducedBy playground, IsMigrated false
```

Covers what the unit fakes cannot: `Ingestion.Create` returning a pre-allocated `versionId` (the v2 data endpoints are live on latest), the real `WaitForCompletionAsync` poll through actual GraphQL deserialization, `WaitForVersionAsync`'s success path into `Version.Get`, and the `Receive3` round-trip. (`Meta.SdkVersion` reads 1.0.0 because the run used a local Debug build with no version stamped.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mGdYTzvqTrbws7r8vwMgK
