### PR TITLE
feat(eav): Base projection merges type-scoped params back onto elements (ENG-9302)

### DIFF
--- a/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactReader.cs
+++ b/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactReader.cs
@@ -99,6 +99,12 @@ public sealed class ObjectsArtifactReader
 
       bundle.Properties.TryGetValue(objK, out var props);
       props ??= new Dictionary<string, object?>();
+      // ENG-9302: type-scoped params (Parameters.Type/System Type Parameters, the compound Structure) live once per
+      // type in type_eav; the v3 tree carried them on every element, so merge them back for the legacy consumers.
+      if (bundle.TypePropertiesByObject.TryGetValue(objK, out var typeProps))
+      {
+        props = MergeTypeScoped(typeProps, props);
+      }
       var built = BuildGeometryObject(appId, objK, props, bundle.Geometries, rels, options);
       if (built is null)
       {
@@ -531,6 +537,31 @@ public sealed class ObjectsArtifactReader
       applicationId = appId,
       id = appId,
     };
+  }
+
+  // Deep-merges the shared per-type dictionary under the instance one, INSTANCE winning on a leaf collision (the
+  // same precedence the hosts apply, ENG-9136). Copy-on-write: the result is a fresh dictionary per object, but
+  // subtrees that exist only on the type side are shared by reference across every object of the type — the
+  // one-parse-per-type property (ENG-9136) survives, and the shared type dictionaries are never mutated.
+  internal static Dictionary<string, object?> MergeTypeScoped(
+    Dictionary<string, object?> typeProps,
+    Dictionary<string, object?> instanceProps
+  )
+  {
+    var merged = new Dictionary<string, object?>(instanceProps);
+    foreach (var kv in typeProps)
+    {
+      if (!merged.TryGetValue(kv.Key, out var existing))
+      {
+        merged[kv.Key] = kv.Value; // type-only subtree: share the per-type instance
+      }
+      else if (existing is Dictionary<string, object?> instChild && kv.Value is Dictionary<string, object?> typeChild)
+      {
+        merged[kv.Key] = MergeTypeScoped(typeChild, instChild);
+      }
+      // scalar (or shape) conflict: instance value stays
+    }
+    return merged;
   }
 
   private static string Scalar(Dictionary<string, object?> props, string key, string fallback) =>

--- a/tests/Speckle.Objects.Tests.Unit/Utils/TypeScopedProjectionTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Utils/TypeScopedProjectionTests.cs
@@ -1,0 +1,107 @@
+using AwesomeAssertions;
+using Speckle.Objects.Data;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Utils;
+using Speckle.Sdk;
+using Speckle.Sdk.Models.Collections;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+namespace Speckle.Objects.Tests.Unit.Utils;
+
+/// <summary>
+/// ENG-9302: the Base projection merges type-scoped params (deduped into <c>type_eav</c>) back onto every element,
+/// restoring the v3 shape legacy scripts read (<c>properties.Parameters.Type Parameters.*</c>, the compound
+/// <c>Structure</c>) — while keeping the one-parse-per-type sharing.
+/// </summary>
+public class TypeScopedProjectionTests
+{
+  private static readonly SpeckleApplication TestProducer = new()
+  {
+    HostApplication = "Test",
+    HostApplicationVersion = "1.2.3",
+    Slug = "test-connector",
+    SpeckleVersion = "999.1.0-alpha.1",
+  };
+
+  private static Mesh UnitTriangle() =>
+    new()
+    {
+      vertices = new List<double> { 0, 0, 0, 1, 0, 0, 1, 1, 0 },
+      faces = new List<int> { 3, 0, 1, 2 },
+      units = "m",
+    };
+
+  private static Dictionary<string, object?> WallProps() =>
+    new()
+    {
+      ["Parameters"] = new Dictionary<string, object?>
+      {
+        ["Constraints"] = new Dictionary<string, object?> { ["Base Offset"] = 0.5 },
+        ["Type Parameters"] = new Dictionary<string, object?>
+        {
+          ["Construction"] = new Dictionary<string, object?> { ["Width"] = 265.0 },
+          ["Structure"] = new Dictionary<string, object?>
+          {
+            ["0"] = new Dictionary<string, object?> { ["material"] = "White Concrete", ["thickness"] = 65.0 },
+          },
+        },
+      },
+    };
+
+  [Fact]
+  public async Task TypeParams_MergeBackOntoEveryElement_SharedPerType()
+  {
+    var dir = Path.Combine(Path.GetTempPath(), "SpeckleTypeProjection", Guid.NewGuid().ToString("N"));
+    try
+    {
+      using (var pipeline = new ObjectsArtifactPipeline(dir, "tp", TestProducer))
+      {
+        foreach (var id in new[] { "wall-1", "wall-2" })
+        {
+          int objK = pipeline.InternObject(id);
+          pipeline.AddProperties(id, WallProps(), null, typeKey: "type-basic-wall");
+          int gK = pipeline.AddGeometry($"{id}:g0", UnitTriangle());
+          pipeline.Display(objK, gK, 0);
+        }
+        pipeline.Complete();
+      }
+
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+      var root = (Collection)new ObjectsArtifactReader().Build(bundle, new(false), default);
+
+      var walls = root.elements.OfType<DataObject>().OrderBy(o => o.applicationId).ToList();
+      walls.Should().HaveCount(2);
+
+      foreach (var wall in walls)
+      {
+        var properties = (Dictionary<string, object?>)wall.properties["properties"]!;
+        var parameters = (Dictionary<string, object?>)properties["Parameters"]!;
+        // instance-scoped stays put
+        ((Dictionary<string, object?>)parameters["Constraints"]!)["Base Offset"]
+          .Should()
+          .Be(0.5);
+        // type-scoped merged back — the v3 shape
+        var typeParams = (Dictionary<string, object?>)parameters["Type Parameters"]!;
+        ((Dictionary<string, object?>)typeParams["Construction"]!)["Width"].Should().Be(265.0);
+        var layer0 = (Dictionary<string, object?>)((Dictionary<string, object?>)typeParams["Structure"]!)["0"]!;
+        layer0["material"].Should().Be("White Concrete");
+        layer0["thickness"].Should().Be(65.0);
+      }
+
+      // one-parse-per-type: the type-only subtree is the SAME dictionary instance on both walls (copy-on-write
+      // merge shares what has no instance-side counterpart).
+      static object? TypeParamsOf(DataObject o) =>
+        ((Dictionary<string, object?>)((Dictionary<string, object?>)o.properties["properties"]!)["Parameters"]!)[
+          "Type Parameters"
+        ];
+      TypeParamsOf(walls[0]).Should().BeSameAs(TypeParamsOf(walls[1]));
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+}

--- a/tests/Speckle.Sdk.Tests.Unit/Objects/Utils/MergeTypeScopedTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Objects/Utils/MergeTypeScopedTests.cs
@@ -1,0 +1,40 @@
+using Speckle.Objects.Utils;
+
+namespace Speckle.Sdk.Tests.Unit.Objects.Utils;
+
+/// <summary>The merge underneath the ENG-9302 projection: instance wins on collision, type-only subtrees are
+/// shared by reference, and the shared type dictionary is never mutated.</summary>
+public sealed class MergeTypeScopedTests
+{
+  [Fact]
+  public void InstanceWins_TypeOnlyShared_TypeDictNeverMutated()
+  {
+    var typeOnly = new Dictionary<string, object?> { ["Width"] = 265.0 };
+    var typeProps = new Dictionary<string, object?>
+    {
+      ["shared"] = typeOnly,
+      ["both"] = new Dictionary<string, object?> { ["a"] = "type", ["typeOnlyKey"] = 1.0 },
+      ["scalar"] = "type",
+    };
+    var instanceProps = new Dictionary<string, object?>
+    {
+      ["both"] = new Dictionary<string, object?> { ["a"] = "instance" },
+      ["scalar"] = "instance",
+      ["instOnly"] = true,
+    };
+
+    var merged = ObjectsArtifactReader.MergeTypeScoped(typeProps, instanceProps);
+
+    Assert.Same(typeOnly, merged["shared"]); // type-only subtree shared by reference
+    var both = (Dictionary<string, object?>)merged["both"]!;
+    Assert.Equal("instance", both["a"]); // leaf collision: instance wins
+    Assert.Equal(1.0, both["typeOnlyKey"]); // type-side sibling still arrives
+    Assert.Equal("instance", merged["scalar"]);
+    Assert.Equal(true, merged["instOnly"]);
+
+    // copy-on-write: inputs untouched
+    Assert.Equal("type", ((Dictionary<string, object?>)typeProps["both"]!)["a"]);
+    Assert.DoesNotContain("instOnly", (IDictionary<string, object?>)typeProps);
+    Assert.DoesNotContain("shared", (IDictionary<string, object?>)instanceProps);
+  }
+}


### PR DESCRIPTION

<img width="873" height="637" alt="Screenshot 2026-08-31 at 19 32 31" src="https://github.com/user-attachments/assets/f9a56c6a-e710-4879-a579-ad8eb3e951ee" />


## What

Closes the remaining half of [ENG-9302](https://linear.app/speckle/issue/ENG-9302). The `Receive3` half (type params first-class on `Model`: `TypeProperties`, one parse per type) shipped in #558; this is the **`Base` projection** half — the surface legacy scripts and the migrator's `TreeMaterializer` consume.

Type-scoped params (`Parameters.Type Parameters`, `System Type Parameters`, and since #564 the compound `Structure`) live once per type in `type_eav`. The v3 tree carried them on every element, so a legacy script receiving a bundle through `Receive2` lost them entirely — the ticket's measured gap ("Type Parameters gone for 78–92% of elements, System Type Parameters 100% gone"), hitting every migrated Revit model.

`ObjectsArtifactReader.Build` now merges each object's shared per-type dictionary under its instance dictionary:
- **instance wins** on a leaf collision (the host precedence, ENG-9136);
- **type-only subtrees are shared by reference** across every object of the type — the one-parse-per-type sharing survives, and the shared per-type dictionaries are never mutated (copy-on-write only where both sides carry a group).

`Receive3` untouched (type scope stays first-class on `Model`). `TreeMaterializer` picks this up for free — it delegates to the same reader.

## Acceptance criteria (ticket)
- Elements in received trees carry type-level params merged into `properties` ✓
- One-parse-per-type sharing preserved (no per-instance re-parse) ✓ — proven by reference-equality in the test
- Covered by reader tests on a typed fixture ✓

## Tests
- `TypeScopedProjectionTests` (end-to-end): two walls, one `typeKey`, written through the real pipeline → eager read → projection. Asserts `Parameters.Type Parameters.Construction.Width`, the `Structure` layer, instance `Constraints` untouched, and that both walls' `Type Parameters` subtree is the *same dictionary instance*.
- `MergeTypeScopedTests` (internal): instance-wins collision, type-only sharing, both inputs unmutated.
- Suites: 1064 unit (net8/net10), 213 objects, 40 migrator — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mGdYTzvqTrbws7r8vwMgK