### PR TITLE
feat(eav): complete-data-carriage floor on the Base projection (ENG-9301)

### DIFF
--- a/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactReader.cs
+++ b/src/Speckle.Sdk/Objects/Utils/ObjectsArtifactReader.cs
@@ -15,7 +15,13 @@ namespace Speckle.Objects.Utils;
 /// <param name="PreferSolids">When true (Rhino), an object that carries a raw 3dm <c>SOLID</c> blob is rebuilt as a
 /// <see cref="RhinoObject"/> with <c>rawEncoding</c> set, so the connector bakes the real solid. When false (Revit,
 /// which can't import 3dm), the solid is ignored and the object is rebuilt from its <c>DISPLAY</c> meshes only.</param>
-public sealed record ArtifactReceiveOptions(bool PreferSolids);
+/// <param name="CompleteCarriage">The complete-data-carriage floor (ENG-9301), the SDK default: objects without
+/// their own DISPLAY geometry — definition members, placement carriers, non-geometric property carriers — surface
+/// in the tree with their properties (members with their DEFINES geometry as <c>displayValue</c>, joined via the
+/// (definition, member-ordinal) vocabulary), and a geometry decode failure throws instead of silently dropping the
+/// mesh. <see langword="false"/> is the connector-bake profile: the v1 hosts' shape, where such carriers are
+/// skipped and decode is best-effort.</param>
+public sealed record ArtifactReceiveOptions(bool PreferSolids, bool CompleteCarriage = true);
 
 /// <summary>
 /// Maps a parsed Speckle 4.0 artefact <see cref="ArtefactBundle"/> back into a <see cref="Base"/>/<see
@@ -68,6 +74,10 @@ public sealed class ObjectsArtifactReader
     // yields one InstanceProxy per edge instead of the last one winning (DisplayInstanceByObject is a last-wins map).
     var placementsByObject = rels.DisplayInstanceEdges.GroupBy(e => e.Src).ToDictionary(g => g.Key, g => g.ToList());
 
+    // ENG-9301: the (definition, member-ordinal) join — a member object's geometry hangs on DEFINES with the same
+    // ordinal its DEFINES_MEMBER edge carries, never on DISPLAY.
+    var memberGeomsByObject = BuildMemberGeometryJoin(rels);
+
     // ── build each object, wiring DISPLAY/SOLID/IN_COLLECTION/DISPLAY_INSTANCE ─────────────────────────
     foreach (var kv in bundle.ObjectAppIds)
     {
@@ -106,13 +116,23 @@ public sealed class ObjectsArtifactReader
         props = MergeTypeScoped(typeProps, props);
       }
       var built = BuildGeometryObject(appId, objK, props, bundle.Geometries, rels, options);
+      if (built is null && options.CompleteCarriage)
+      {
+        if (rels.PlacesByObject.ContainsKey(objK))
+        {
+          // a nested-placement member: it surfaces as the InstanceProxy AttachInstanceDefinitions emits under its
+          // real applicationId — building a DataObject here too would duplicate it.
+          continue;
+        }
+        // ENG-9301 complete carriage: a definition member (geometry via the member-ordinal join) or a pure property
+        // carrier (Level/Room/no-DISPLAY element). Both carry the data layer a script reads; the v1 unpacker pulls
+        // members out of atomic baking via the definition proxies' member lists, so nothing bakes twice.
+        built = BuildCarrierObject(appId, objK, props, memberGeomsByObject, bundle.Geometries, options);
+      }
       if (built is null)
       {
-        // Non-geometric object (no DISPLAY edges, no accepted SOLID) — e.g. a Level/Room emitted only for its
-        // properties + ON_LEVEL/IN_ROOM edges (RevitArtifactRootObjectBuilder.EmitObject's early-return for
-        // conversions that aren't a DataObject). The non-artefact v1 path never hands these to the converter either
-        // — they travel as LevelProxy/room metadata, not tree objects — so skip instead of fabricating an
-        // empty-displayValue DataObject the v1 converter has no path for.
+        // Connector-bake profile: non-geometric objects (no DISPLAY edges, no accepted SOLID) are skipped — the v1
+        // host builders have no path for an empty-displayValue DataObject (Levels/Rooms travel as proxies there).
         continue;
       }
 
@@ -123,7 +143,16 @@ public sealed class ObjectsArtifactReader
     AttachMaterials(rels, objByGeom, bundle.ObjectAppIds, materialByNode, root);
 
     // ── instance definitions (DEFINITION nodes + DEFINES/DEFINES_INSTANCE) ────────────────────────────
-    AttachInstanceDefinitions(nodes, rels, objByGeom, bundle.ObjectAppIds, bundle.Geometries, root);
+    AttachInstanceDefinitions(
+      nodes,
+      rels,
+      objByGeom,
+      bundle.ObjectAppIds,
+      bundle.Geometries,
+      root,
+      options,
+      layerByNode
+    );
 
     // ENG-8947/8808: rebuild the reference-point transform from the bundle meta offset and lift it onto the root so
     // the v1 Revit host builder can undo/redo it (translation kinds only; the offset is in display units).
@@ -328,9 +357,28 @@ public sealed class ObjectsArtifactReader
     Dictionary<int, int> objByGeom,
     Dictionary<int, string> objIdToApp,
     Dictionary<int, ArtefactGeometry> geometries,
-    Collection root
+    Collection root,
+    ArtifactReceiveOptions options,
+    Dictionary<int, Collection> layerByNode
   )
   {
+    // ENG-9301: under complete carriage, real member objects (DEFINES_MEMBER) already sit in the tree with their
+    // geometry and properties — the proxies reference them by applicationId instead of synthesizing wrappers.
+    var memberByDefOrd = new Dictionary<(int def, int ord), int>();
+    foreach (var kv in rels.MemberObjectsByDefinition)
+    {
+      var ords = rels.MemberOrdByDefinition[kv.Key];
+      for (int m = 0; m < kv.Value.Count; m++)
+      {
+        memberByDefOrd[(kv.Key, ords[m])] = kv.Value[m];
+      }
+    }
+    var placesMemberByInstNode = new Dictionary<int, int>();
+    foreach (var kv in rels.PlacesByObject)
+    {
+      placesMemberByInstNode[kv.Value] = kv.Key;
+    }
+
     // RevitFamilyBaker bakes definitions deepest-first (OrderByDescending(maxDepth)) so a parent can reference an
     // already-baked child via PlaceNestedInstance — mirrors RhinoInstanceUnpacker/GrasshopperBlockPacker's send-side
     // depth tracking. A definition reachable via multiple nesting paths takes the deepest (never bake a shared child
@@ -351,8 +399,24 @@ public sealed class ObjectsArtifactReader
       // decoded geometry directly.
       if (rels.DefinesByDefinition.TryGetValue(defNodeK, out var geomKs))
       {
-        foreach (var geomK in geomKs)
+        var geomOrds = rels.DefinesOrdByDefinition[defNodeK];
+        for (int gi = 0; gi < geomKs.Count; gi++)
         {
+          int geomK = geomKs[gi];
+          // complete carriage: the (definition, ordinal) join names the owning member — the real object is already
+          // in the tree (BuildCarrierObject) with this geometry as its displayValue.
+          if (
+            options.CompleteCarriage
+            && memberByDefOrd.TryGetValue((defNodeK, geomOrds[gi]), out int memberObjK)
+            && objIdToApp.TryGetValue(memberObjK, out var memberAppId)
+          )
+          {
+            if (!members.Contains(memberAppId))
+            {
+              members.Add(memberAppId);
+            }
+            continue;
+          }
           if (objByGeom.TryGetValue(geomK, out int objK) && objIdToApp.TryGetValue(objK, out var appId))
           {
             if (!members.Contains(appId))
@@ -361,7 +425,7 @@ public sealed class ObjectsArtifactReader
             }
             continue;
           }
-          if (geometries.TryGetValue(geomK, out var g) && TryDecode(g) is { } geom)
+          if (geometries.TryGetValue(geomK, out var g) && TryDecode(g, options.CompleteCarriage) is { } geom)
           {
             string geoAppId = "def-geo-" + geomK.ToString(CultureInfo.InvariantCulture);
             if (!members.Contains(geoAppId))
@@ -391,8 +455,30 @@ public sealed class ObjectsArtifactReader
           {
             continue;
           }
-          string nestedAppId = "nested-inst-" + instNodeK.ToString(CultureInfo.InvariantCulture);
-          root.elements.Add(BuildInstanceProxy(nestedAppId, nestedInstNode));
+          // complete carriage: the PLACES member names this nested placement — surface the proxy under the member's
+          // real applicationId, in the member's own collection, instead of a synthetic root entry.
+          string nestedAppId;
+          var nestedHost = root.elements;
+          if (
+            options.CompleteCarriage
+            && placesMemberByInstNode.TryGetValue(instNodeK, out int placesMemberK)
+            && objIdToApp.TryGetValue(placesMemberK, out var placesAppId)
+          )
+          {
+            nestedAppId = placesAppId;
+            if (
+              rels.CollectionByObject.TryGetValue(placesMemberK, out int collNodeK)
+              && layerByNode.TryGetValue(collNodeK, out var memberLayer)
+            )
+            {
+              nestedHost = memberLayer.elements;
+            }
+          }
+          else
+          {
+            nestedAppId = "nested-inst-" + instNodeK.ToString(CultureInfo.InvariantCulture);
+          }
+          nestedHost.Add(BuildInstanceProxy(nestedAppId, nestedInstNode));
           if (!members.Contains(nestedAppId))
           {
             members.Add(nestedAppId);
@@ -483,7 +569,7 @@ public sealed class ObjectsArtifactReader
     {
       foreach (var e in displayEdges.OrderBy(x => x.Ord))
       {
-        if (geometries.TryGetValue(e.Dst, out var g) && TryDecode(g) is { } geom)
+        if (geometries.TryGetValue(e.Dst, out var g) && TryDecode(g, options.CompleteCarriage) is { } geom)
         {
           // Stamp the display geometry with the owning object's applicationId so the host material baker
           // (which keys per displayValue item on the mesh path) can resolve HAS_MATERIAL → object → material.
@@ -564,17 +650,89 @@ public sealed class ObjectsArtifactReader
     return merged;
   }
 
+  // objK → the geometry Ks its DEFINES_MEMBER ordinal claims via DEFINES on the same (definition, ordinal).
+  private static Dictionary<int, List<int>> BuildMemberGeometryJoin(ArtefactRelations rels)
+  {
+    var byObject = new Dictionary<int, List<int>>();
+    foreach (var kv in rels.MemberObjectsByDefinition)
+    {
+      int def = kv.Key;
+      var ords = rels.MemberOrdByDefinition[def];
+      if (!rels.DefinesByDefinition.TryGetValue(def, out var geomKs))
+      {
+        continue;
+      }
+      var geomOrds = rels.DefinesOrdByDefinition[def];
+      for (int m = 0; m < kv.Value.Count; m++)
+      {
+        for (int g = 0; g < geomKs.Count; g++)
+        {
+          if (geomOrds[g] != ords[m])
+          {
+            continue;
+          }
+          if (!byObject.TryGetValue(kv.Value[m], out var list))
+          {
+            byObject[kv.Value[m]] = list = new List<int>();
+          }
+          list.Add(geomKs[g]);
+        }
+      }
+    }
+    return byObject;
+  }
+
+  // ENG-9301: a no-DISPLAY carrier under complete carriage — a definition member (its DEFINES geometry becomes
+  // displayValue; raw solids stay out, they are the connector profile's concern) or a pure property carrier
+  // (empty displayValue, the properties are the payload).
+  private static DataObject BuildCarrierObject(
+    string appId,
+    int objK,
+    Dictionary<string, object?> props,
+    Dictionary<int, List<int>> memberGeomsByObject,
+    Dictionary<int, ArtefactGeometry> geometries,
+    ArtifactReceiveOptions options
+  )
+  {
+    var displays = new List<Base>();
+    if (memberGeomsByObject.TryGetValue(objK, out var geomKs))
+    {
+      foreach (var geomK in geomKs)
+      {
+        if (geometries.TryGetValue(geomK, out var g) && TryDecode(g, options.CompleteCarriage) is { } geom)
+        {
+          geom.applicationId = appId;
+          displays.Add(geom);
+        }
+      }
+    }
+    return new DataObject
+    {
+      name = Scalar(props, "name", appId),
+      displayValue = displays,
+      properties = props,
+      applicationId = appId,
+      id = appId,
+    };
+  }
+
   private static string Scalar(Dictionary<string, object?> props, string key, string fallback) =>
     props.TryGetValue(key, out var v) && v is string s && s.Length > 0 ? s : fallback;
 
-  private static Base? TryDecode(ArtefactGeometry entry)
+  private static Base? TryDecode(ArtefactGeometry entry, bool loud = false)
   {
     try
     {
+      // a non-SGEO blob (raw 3dm) in a display lane is simply not display geometry — never an error
       return entry.IsSgeo ? SgeoDecoder.Decode(entry.Content) : null;
     }
     catch (Exception ex) when (ex is not OperationCanceledException)
     {
+      if (loud)
+      {
+        // ENG-9301: under the SDK profile a decode failure is data loss the caller must see, never a silent drop.
+        throw new Speckle.Sdk.SpeckleException($"SGEO geometry failed to decode ({entry.Content.Length} bytes).", ex);
+      }
       return null;
     }
   }

--- a/tests/Speckle.Objects.Tests.Unit/Utils/ArtifactRoundTripTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Utils/ArtifactRoundTripTests.cs
@@ -131,13 +131,20 @@ public class ArtifactRoundTripTests
       rhinoObj.rawEncoding!.format.Should().Be("3dm");
       Convert.FromBase64String(rhinoObj.rawEncoding.contents).Should().Equal(solidBytes);
 
-      // Revit (PreferSolids = false): the 3dm blob is not accepted and the object has no DISPLAY meshes — since
-      // #520 the reader skips such objects entirely rather than fabricating an empty-displayValue DataObject the
-      // v1 converter pipeline has no path for (see BuildGeometryObject's null return).
+      // Connector-bake profile (PreferSolids = false, CompleteCarriage = false): the 3dm blob is not accepted and
+      // the object has no DISPLAY meshes — since #520 the v1 profile skips such objects entirely rather than
+      // fabricating an empty-displayValue DataObject the v1 converter pipeline has no path for.
       var rootMeshes = (Collection)
-        await reader.ReadAsync(dir, new ArtifactReceiveOptions(PreferSolids: false), default);
+        await reader.ReadAsync(dir, new ArtifactReceiveOptions(PreferSolids: false, CompleteCarriage: false), default);
       Flatten(rootMeshes).OfType<RhinoObject>().Should().BeEmpty();
       Flatten(rootMeshes).Where(b => b.applicationId == "solid-1").Should().BeEmpty();
+
+      // SDK default (complete carriage, ENG-9301): the same object surfaces as a property carrier — its data layer
+      // is the payload even when its geometry isn't consumable in this profile.
+      var rootComplete = (Collection)
+        await reader.ReadAsync(dir, new ArtifactReceiveOptions(PreferSolids: false), default);
+      var carrier = Flatten(rootComplete).OfType<DataObject>().Single(b => b.applicationId == "solid-1");
+      carrier.displayValue.Should().BeEmpty();
     }
     finally
     {
@@ -212,11 +219,13 @@ public class ArtifactRoundTripTests
       bundle.Relations.CollectionByObject[memberObjK].Should().Be(layerBK);
       SceneViewResolver.Segments(bundle, memberObjK).Should().Equal("Layer B");
 
-      // 3. the carrier has no render edge, so the v1 reader drops it rather than emitting a phantom scene object.
-      //    This is the invariant the whole approach depends on (see DefinitionMemberStamps in the connectors repo).
+      // 3. the carrier has no render edge, so the CONNECTOR-BAKE profile drops it rather than emitting a phantom
+      //    scene object (see DefinitionMemberStamps in the connectors repo). Under the SDK default (complete
+      //    carriage, ENG-9301) it surfaces with its properties instead — covered in CompleteCarriageTests.
       bundle.Relations.DisplayByObject(memberObjK).Should().BeNull();
       var reader = new ObjectsArtifactReader();
-      var root = (Collection)await reader.ReadAsync(dir, new ArtifactReceiveOptions(PreferSolids: true), default);
+      var root = (Collection)
+        await reader.ReadAsync(dir, new ArtifactReceiveOptions(PreferSolids: true, CompleteCarriage: false), default);
       Flatten(root).Where(b => b.applicationId == "member-1").Should().BeEmpty();
     }
     finally

--- a/tests/Speckle.Objects.Tests.Unit/Utils/CompleteCarriageTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Utils/CompleteCarriageTests.cs
@@ -1,0 +1,209 @@
+using AwesomeAssertions;
+using Speckle.Objects.Data;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Utils;
+using Speckle.Sdk;
+using Speckle.Sdk.Models;
+using Speckle.Sdk.Models.Collections;
+using Speckle.Sdk.Models.Instances;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+namespace Speckle.Objects.Tests.Unit.Utils;
+
+/// <summary>
+/// ENG-9301, the complete-data-carriage floor (the SDK default of <see cref="ArtifactReceiveOptions"/>): objects
+/// without their own DISPLAY geometry — definition members, nested-placement carriers, pure property carriers —
+/// surface in the tree with their data, joined through the (definition, member-ordinal) vocabulary; decode
+/// failures are loud. The connector-bake profile (<c>CompleteCarriage: false</c>) keeps the v1 shape.
+/// </summary>
+public class CompleteCarriageTests
+{
+  private static readonly SpeckleApplication TestProducer = new()
+  {
+    HostApplication = "Test",
+    HostApplicationVersion = "1.2.3",
+    Slug = "test-connector",
+    SpeckleVersion = "999.1.0-alpha.1",
+  };
+
+  private static Mesh Triangle() =>
+    new()
+    {
+      vertices = new List<double> { 0, 0, 0, 1, 0, 0, 1, 1, 0 },
+      faces = new List<int> { 3, 0, 1, 2 },
+      units = "m",
+    };
+
+  private static double[] Identity() => [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+  private static IEnumerable<Base> Flatten(Base b)
+  {
+    yield return b;
+    if (b is Collection c)
+    {
+      foreach (var child in c.elements.SelectMany(Flatten))
+      {
+        yield return child;
+      }
+    }
+  }
+
+  private static async Task<T> WithBundle<T>(Action<ObjectsArtifactPipeline> populate, Func<ArtefactBundle, T> use)
+  {
+    var dir = Path.Combine(Path.GetTempPath(), "SpeckleCompleteCarriage", Guid.NewGuid().ToString("N"));
+    try
+    {
+      using (var pipeline = new ObjectsArtifactPipeline(dir, "cc", TestProducer))
+      {
+        populate(pipeline);
+        pipeline.Complete();
+      }
+      return use(await ArtefactBundleReader.ReadAsync(dir, default));
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+
+  /// <summary>A fully-instanced graph: a definition with a geometry member (DEFINES_MEMBER join) and a nested
+  /// placement member (PLACES), one scene placement. The shape file imports (IFC/Nwd) and Revit families produce —
+  /// where the old projection wiped the whole data layer.</summary>
+  private static void FullyInstancedGraph(ObjectsArtifactPipeline pipeline)
+  {
+    int layerK = pipeline.AddCollection("layer-a", "Layer A", null, "Layer");
+    int defK = pipeline.AddDefinition("def-chair", "Chair");
+
+    // geometry member: properties + IN_COLLECTION + geometry via the member-ordinal join (no DISPLAY of its own)
+    int seatK = pipeline.InternObject("seat-1");
+    pipeline.AddProperties("seat-1", new Dictionary<string, object?> { ["Mark"] = "SEAT-01" });
+    pipeline.InCollection(seatK, layerK, 0);
+    int gK = pipeline.AddGeometry("seat-1:g0", Triangle());
+    pipeline.Defines(defK, gK, 0);
+    pipeline.DefinesMember(defK, seatK, 0);
+
+    // nested placement member: PLACES + IN_COLLECTION, no geometry of its own
+    int cushionDefK = pipeline.AddDefinition("def-cushion", "Cushion");
+    int nestedInstK = pipeline.AddInstance("chair/cushion-0", cushionDefK, Identity(), "m");
+    pipeline.DefinesInstance(defK, nestedInstK, 1);
+    int cushionMemberK = pipeline.InternObject("cushion-1");
+    pipeline.AddProperties("cushion-1", new Dictionary<string, object?> { ["Mark"] = "CUSH-01" });
+    pipeline.InCollection(cushionMemberK, layerK, 0);
+    pipeline.Places(cushionMemberK, nestedInstK);
+    pipeline.DefinesMember(defK, cushionMemberK, 1);
+
+    // the scene placement
+    int placementK = pipeline.InternObject("chair-placed-1");
+    pipeline.AddProperties("chair-placed-1", new Dictionary<string, object?>());
+    pipeline.DisplayInstance(placementK, pipeline.AddInstance("chair-placed-1", defK, Identity(), "m"), 0);
+    pipeline.InCollection(placementK, layerK, 0);
+  }
+
+  [Fact]
+  public async Task Members_SurfaceWithDataAndGeometry_ProxiesReferenceThem()
+  {
+    var root = await WithBundle(
+      FullyInstancedGraph,
+      bundle => (Collection)new ObjectsArtifactReader().Build(bundle, new(PreferSolids: false), default)
+    );
+
+    var all = Flatten(root).ToList();
+
+    // the geometry member is a real object: its properties and its DEFINES geometry, in its own layer
+    var seat = all.OfType<DataObject>().Single(b => b.applicationId == "seat-1");
+    ((Dictionary<string, object?>)seat.properties["properties"]!)["Mark"].Should().Be("SEAT-01");
+    seat.displayValue.Should().HaveCount(1);
+    var layer = all.OfType<Collection>().Single(c => c.name == "Layer A");
+    layer.elements.Should().Contain(seat);
+
+    // the nested placement surfaces as an InstanceProxy under the member's REAL applicationId, in its layer
+    var cushion = all.OfType<InstanceProxy>().Single(p => p.applicationId == "cushion-1");
+    layer.elements.Should().Contain(cushion);
+
+    // the definition proxy references the real members — no synthetic def-geo/nested-inst entries anywhere
+    var proxies = (List<object>)root["instanceDefinitionProxies"]!;
+    var chairDef = proxies.OfType<InstanceDefinitionProxy>().Single(p => p.name == "Chair");
+    chairDef.objects.Should().Contain("seat-1");
+    chairDef.objects.Should().Contain("cushion-1");
+    all.Where(b => b.applicationId?.StartsWith("def-geo-", StringComparison.Ordinal) == true).Should().BeEmpty();
+    all.Where(b => b.applicationId?.StartsWith("nested-inst-", StringComparison.Ordinal) == true).Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task ConnectorProfile_KeepsTheV1Shape()
+  {
+    var root = await WithBundle(
+      FullyInstancedGraph,
+      bundle =>
+        (Collection)
+          new ObjectsArtifactReader().Build(bundle, new(PreferSolids: false, CompleteCarriage: false), default)
+    );
+
+    var all = Flatten(root).ToList();
+    all.Where(b => b.applicationId == "seat-1").Should().BeEmpty(); // members dropped, as v1 expects
+    all.Where(b => b.applicationId == "cushion-1").Should().BeEmpty();
+    // the definition still works through synthesized wrappers
+    all.Where(b => b.applicationId?.StartsWith("def-geo-", StringComparison.Ordinal) == true).Should().HaveCount(1);
+    all.OfType<InstanceProxy>()
+      .Where(p => p.applicationId?.StartsWith("nested-inst-", StringComparison.Ordinal) == true)
+      .Should()
+      .HaveCount(1);
+  }
+
+  [Fact]
+  public async Task PurePropertyCarrier_SurfacesByDefault_SkippedOnConnectorProfile()
+  {
+    static void Populate(ObjectsArtifactPipeline pipeline)
+    {
+      int k = pipeline.InternObject("level-1");
+      pipeline.AddProperties("level-1", new Dictionary<string, object?> { ["Elevation"] = 3.2 });
+    }
+
+    var complete = await WithBundle(
+      Populate,
+      bundle => (Collection)new ObjectsArtifactReader().Build(bundle, new(PreferSolids: false), default)
+    );
+    var carrier = Flatten(complete).OfType<DataObject>().Single(b => b.applicationId == "level-1");
+    carrier.displayValue.Should().BeEmpty();
+    ((Dictionary<string, object?>)carrier.properties["properties"]!)["Elevation"].Should().Be(3.2);
+
+    var legacy = await WithBundle(
+      Populate,
+      bundle =>
+        (Collection)
+          new ObjectsArtifactReader().Build(bundle, new(PreferSolids: false, CompleteCarriage: false), default)
+    );
+    Flatten(legacy).Where(b => b.applicationId == "level-1").Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task DecodeFailure_IsLoudByDefault_SilentOnConnectorProfile()
+  {
+    static void Populate(ObjectsArtifactPipeline pipeline)
+    {
+      int k = pipeline.InternObject("broken-1");
+      pipeline.AddProperties("broken-1", new Dictionary<string, object?>());
+      // SGEO magic + garbage: IsSgeo says yes, the decoder throws
+      int gK = pipeline.AddRawGeometry("broken-1:g0", [0x53, 0x47, 0x45, 0x4F, 9, 9, 9, 9], "sgeo");
+      pipeline.Display(k, gK, 0);
+    }
+
+    await Assert.ThrowsAsync<SpeckleException>(() =>
+      WithBundle(
+        Populate,
+        bundle => (Collection)new ObjectsArtifactReader().Build(bundle, new(PreferSolids: false), default)
+      )
+    );
+
+    var legacy = await WithBundle(
+      Populate,
+      bundle =>
+        (Collection)
+          new ObjectsArtifactReader().Build(bundle, new(PreferSolids: false, CompleteCarriage: false), default)
+    );
+    Flatten(legacy).Where(b => b.applicationId == "broken-1").Should().BeEmpty(); // silently dropped, v1 behaviour
+  }
+}


### PR DESCRIPTION
## What

[ENG-9301](https://linear.app/speckle/issue/ENG-9301): the `Base` projection (`Receive2` on bundles, the migrator's `TreeMaterializer`) dropped every object without its own DISPLAY geometry — definition members, nested-placement carriers, non-geometric property carriers. In instanced models that's most of the data: fully-instanced IFC/Nwd imports lose the whole data layer (the ticket's measured 13.4M property rows → 0), and a migrated Revit model shows property-less `def-geo-*` wrappers flat at root instead of its family members.

`ArtifactReceiveOptions` gains the second axis the spec asks for — `CompleteCarriage`, **SDK default `true`**; `false` is the connector-bake profile, byte-for-byte the old v1 shape:

- **Members**: `DEFINES_MEMBER` (def→object, ord) joined with `DEFINES` (def→geometry, ord) — the same vocabulary the connectors' `DefinitionMemberIndexes` uses. Members surface as real `DataObject`s (properties + definition geometry as `displayValue`) in their `IN_COLLECTION` layer, and the `InstanceDefinitionProxy` member lists carry their **real applicationIds**. The v1 unpacker pulls proxy-referenced objects out of atomic baking, so nothing bakes twice.
- **Nested placements**: a `PLACES` member becomes the nested `InstanceProxy` itself — real appId, member's layer — no more synthetic `nested-inst-*` root entries.
- **Pure property carriers** (Levels/Rooms/no-geometry elements) surface with empty `displayValue`.
- **Loud decode**: an SGEO decode failure throws `SpeckleException` under the SDK profile instead of silently dropping the mesh. Non-SGEO blobs (raw 3dm) in display lanes are never errors in either profile.

`Receive3`/`Model` and the connector host builders are untouched (they never used this projection's member handling).

## Verified on real data

Migrated Snowdon Towers bundle (BundleMigrator, `migrated_from = 3`), before → after:

| | before | after |
|---|---|---|
| root elements | 1428 (36 layers + **1392 property-less wrappers**) | **36 — layers only** |
| objects under a layer | 9316 | **11380** (members + carriers, in their collections, with properties) |

## Acceptance criteria (ticket)
- Fully-instanced graphs receive with their data layer intact under the complete-carriage profile ✓ (`Members_SurfaceWithDataAndGeometry_ProxiesReferenceThem`)
- Instanced objects carry their properties; definition members stay reachable ✓
- Decode failure raises a clear error under the SDK profile ✓
- Existing reader round-trip tests (connector-bake profile) stay green ✓ — the two that pinned the v1 skip now pin it explicitly via `CompleteCarriage: false`

## Scope note
Top-level placements still project as `InstanceProxy`, which has no `properties` in the v3 shape — their params stay unreachable in the `Base` tree (fine in `Receive3`). That's a v3-shape limitation, noted rather than solved here.

## Tests
`CompleteCarriageTests` ×4 (fully-instanced round-trip, connector-profile v1 shape, pure carrier, loud/silent decode). Suites: 1064 unit, 217 objects, 40 migrator — net8/net10 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mGdYTzvqTrbws7r8vwMgK
