### PR TITLE
fix(send): v2 bundle upload rail reports apollographql-client-version

### DIFF
--- a/src/Speckle.Sdk/Pipelines/Send/Artifacts/ArtifactPipeline.cs
+++ b/src/Speckle.Sdk/Pipelines/Send/Artifacts/ArtifactPipeline.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using System.Reflection;
 using System.Text;
 using Speckle.InterfaceGenerator;
 using Speckle.Newtonsoft.Json;
@@ -9,8 +10,11 @@ using Speckle.Sdk.Logging;
 namespace Speckle.Sdk.Pipelines.Send.Artifacts;
 
 [GenerateAutoInterface]
-public sealed class ArtifactPipelineFactory(ISpeckleHttp httpClientFactory, ISdkActivityFactory activityFactory)
-  : IArtifactPipelineFactory
+public sealed class ArtifactPipelineFactory(
+  ISpeckleApplication application,
+  ISpeckleHttp httpClientFactory,
+  ISdkActivityFactory activityFactory
+) : IArtifactPipelineFactory
 {
   public ArtifactPipeline CreateInstance(
     string projectId,
@@ -20,7 +24,17 @@ public sealed class ArtifactPipelineFactory(ISpeckleHttp httpClientFactory, ISdk
     string outputDir,
     CancellationToken cancellationToken
   ) =>
-    new(projectId, ingestionId, versionId, account, outputDir, httpClientFactory, activityFactory, cancellationToken);
+    new(
+      projectId,
+      ingestionId,
+      versionId,
+      account,
+      outputDir,
+      application,
+      httpClientFactory,
+      activityFactory,
+      cancellationToken
+    );
 }
 
 /// <summary>
@@ -63,6 +77,7 @@ public sealed class ArtifactPipeline : IDisposable
     string versionId,
     Account account,
     string outputDir,
+    ISpeckleApplication application,
     ISpeckleHttp httpClientFactory,
     ISdkActivityFactory activityFactory,
     CancellationToken cancellationToken
@@ -79,7 +94,16 @@ public sealed class ArtifactPipeline : IDisposable
 
     _speckleClient = httpClientFactory.CreateHttpClient(authorizationToken: account.token);
     _speckleClient.BaseAddress = new(new(account.serverInfo.url), "/api/v2/");
+    // ENG-9490: the server reads clientAppVersion for envelope-born versions from these headers on the v2
+    // uploads/complete request (speckle-server-internal#2719); mirror GraphQLClientFactory so bundle sends
+    // report the same client identity as legacy GraphQL sends.
+    _speckleClient.DefaultRequestHeaders.Add("apollographql-client-name", application.ApplicationAndVersion);
+    _speckleClient.DefaultRequestHeaders.Add(
+      "apollographql-client-version",
+      Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+    );
 
+    // No extra default headers here: _s3Client sends presigned PUTs, which must carry only the signed headers.
     _s3Client = httpClientFactory.CreateHttpClient();
   }
 

--- a/tests/Speckle.Sdk.Tests.Unit/Pipelines/Send/Artifacts/ArtifactPipelineTests.cs
+++ b/tests/Speckle.Sdk.Tests.Unit/Pipelines/Send/Artifacts/ArtifactPipelineTests.cs
@@ -1,0 +1,63 @@
+using AwesomeAssertions;
+using RichardSzalay.MockHttp;
+using Speckle.Sdk.Credentials;
+using Speckle.Sdk.Helpers;
+using Speckle.Sdk.Logging;
+using Speckle.Sdk.Pipelines.Send.Artifacts;
+using Speckle.Sdk.Testing;
+
+namespace Speckle.Sdk.Tests.Unit.Pipelines.Send.Artifacts;
+
+public class ArtifactPipelineTests : MoqTest
+{
+  // ENG-9490: the server reads clientAppVersion for envelope-born versions from the
+  // apollographql-client-version header of the v2 uploads/complete request; pin that every
+  // Speckle-bound request of the upload rail carries the apollo client headers.
+  [Fact]
+  public async Task SpeckleBoundRequests_CarryApolloClientHeaders()
+  {
+    var expectedVersion = typeof(ArtifactPipeline).Assembly.GetName().Version?.ToString();
+    expectedVersion.Should().NotBeNullOrEmpty();
+
+    using var mockHttp = new MockHttpMessageHandler();
+    mockHttp
+      .Expect(HttpMethod.Post, "https://example.com/api/v2/projects/proj/modelingestion/ing/uploads/sign")
+      .WithHeaders("apollographql-client-name", "TestHost 1.2.3")
+      .WithHeaders("apollographql-client-version", expectedVersion!)
+      .Respond("application/json", """{"uploads":{}}""");
+    mockHttp
+      .Expect(HttpMethod.Post, "https://example.com/api/v2/projects/proj/modelingestion/ing/uploads/complete")
+      .WithHeaders("apollographql-client-name", "TestHost 1.2.3")
+      .WithHeaders("apollographql-client-version", expectedVersion!)
+      .Respond("application/json", """{"versionId":"ver"}""");
+
+    var speckleHttp = Create<ISpeckleHttp>();
+    speckleHttp
+      .Setup(x => x.CreateHttpClient(null, SpeckleHttp.DEFAULT_TIMEOUT_SECONDS, "token"))
+      .Returns(mockHttp.ToHttpClient());
+    speckleHttp
+      .Setup(x => x.CreateHttpClient(null, SpeckleHttp.DEFAULT_TIMEOUT_SECONDS, null))
+      .Returns(new HttpClient());
+
+    var application = new SpeckleApplication
+    {
+      HostApplication = "TestHost",
+      HostApplicationVersion = "1.2.3",
+      Slug = "testhost",
+      SpeckleVersion = "3.0.0",
+    };
+    var account = new Account
+    {
+      token = "token",
+      serverInfo = new() { url = "https://example.com" },
+    };
+
+    var factory = new ArtifactPipelineFactory(application, speckleHttp.Object, new NullActivityFactory());
+    using var pipeline = factory.CreateInstance("proj", "ing", "ver", account, "out", CancellationToken.None);
+
+    var versionId = await pipeline.UploadFilesAsync(new Dictionary<string, string>(), "root", 0);
+
+    versionId.Should().Be("ver");
+    mockHttp.VerifyNoOutstandingExpectation();
+  }
+}


### PR DESCRIPTION
The `apollographql-client-name` / `apollographql-client-version` headers were only ever set on the GraphQL client (`GraphQLClientFactory`). The v2 bundle upload rail (`ArtifactPipeline`) creates its own Speckle-bound HTTP client with just the Authorization header, so its `uploads/complete` request carried neither. The server reads `clientAppVersion` for envelope-born versions from `apollographql-client-version` on that request and forwards it to the PostHog "Version Created" event, so legacy GraphQL sends populated it while bundle sends silently reported it as null.

This sets both headers on the ArtifactPipeline's Speckle-bound client, mirroring `GraphQLClientFactory` semantics: `apollographql-client-name` = the DI-registered `ISpeckleApplication.ApplicationAndVersion` (now injected into `ArtifactPipelineFactory`), `apollographql-client-version` = the SDK assembly version. The presigned S3 client is deliberately untouched, presigned PUTs must carry only the signed headers.

Client half of speckle-server-internal#2719.

Closes ENG-9490

## Tests

- New `ArtifactPipelineTests.SpeckleBoundRequests_CarryApolloClientHeaders` pins that both the `uploads/sign` and `uploads/complete` requests carry the apollo client headers (MockHttp header-matched expectations).
- Full `Speckle.Sdk.Tests.Unit` suite green on net8.0 and net10.0 (1064 passed each), solution build clean, CSharpier run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReH2YaViKYKboNZXMKNZ6G