### PR TITLE
feat(eav): parameter/quantity leaves rebuild as v3 records in the nested projection (ENG-9300)

### DIFF
--- a/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
+++ b/src/Speckle.Sdk.Parquet/Pipelines/Receive/Artifacts/ArtefactBundle.cs
@@ -729,6 +729,8 @@ public static class ArtefactBundleReader
     var vStr = t.Strings("value_string");
     var vDbl = t.NullableDoubles("value_double");
     var vBool = t.NullableBools("value_boolean");
+    var units = t.Has("unit") ? t.Strings("unit") : null;
+    var idns = t.Has("internal_definition_name") ? t.Strings("internal_definition_name") : null;
     for (int i = 0; i < keyIdx.Length; i++)
     {
       object? value =
@@ -749,9 +751,38 @@ public static class ArtefactBundleReader
         dict = new Dictionary<string, object?>();
         byKey[keyIdx[i]] = dict;
       }
-      SetNested(dict, path, value);
+      SetNested(dict, path, WrapV3RecordLeaf(path, value, units?[i], idns?[i]));
     }
     return byKey;
+  }
+
+  // ENG-9300: v3 scripts read parameter/quantity leaves as {name, value, units} records — the flatten collapsed
+  // those records into a row (value + unit/idn columns), so the nested rebuild restores them, but ONLY in the
+  // subtrees that were records in the v3 shape (per producer convention). Everything else (user text, GH props,
+  // root scalars) was scalar in v3 and stays scalar. The record's name equals the leaf key, as it did in v3.
+  private const string ParametersRecordPrefix = "properties.Parameters.";
+  private const string QuantitiesRecordPrefix = "properties.Material Quantities.";
+
+  private static object? WrapV3RecordLeaf(string path, object? value, string? unit, string? idn)
+  {
+    if (
+      !path.StartsWith(ParametersRecordPrefix, StringComparison.Ordinal)
+      && !path.StartsWith(QuantitiesRecordPrefix, StringComparison.Ordinal)
+    )
+    {
+      return value;
+    }
+    int lastDot = path.LastIndexOf('.');
+    var record = new Dictionary<string, object?> { ["name"] = path.Substring(lastDot + 1), ["value"] = value };
+    if (unit is { Length: > 0 })
+    {
+      record["units"] = unit;
+    }
+    if (idn is { Length: > 0 })
+    {
+      record["internalDefinitionName"] = idn;
+    }
+    return record;
   }
 
   private static void SetNested(Dictionary<string, object?> root, string path, object? value)

--- a/tests/Speckle.Objects.Tests.Unit/Utils/TypeScopedProjectionTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Utils/TypeScopedProjectionTests.cs
@@ -23,6 +23,9 @@ public class TypeScopedProjectionTests
     SpeckleVersion = "999.1.0-alpha.1",
   };
 
+  private static Dictionary<string, object?> Record(Dictionary<string, object?> group, string child, string leaf) =>
+    (Dictionary<string, object?>)((Dictionary<string, object?>)group[child]!)[leaf]!;
+
   private static Mesh UnitTriangle() =>
     new()
     {
@@ -42,7 +45,16 @@ public class TypeScopedProjectionTests
           ["Construction"] = new Dictionary<string, object?> { ["Width"] = 265.0 },
           ["Structure"] = new Dictionary<string, object?>
           {
-            ["0"] = new Dictionary<string, object?> { ["material"] = "White Concrete", ["thickness"] = 65.0 },
+            ["0"] = new Dictionary<string, object?>
+            {
+              ["material"] = "White Concrete",
+              ["thickness"] = new Dictionary<string, object?>
+              {
+                ["name"] = "Thickness",
+                ["value"] = 65.0,
+                ["units"] = "mm",
+              },
+            },
           },
         },
       },
@@ -76,16 +88,16 @@ public class TypeScopedProjectionTests
       {
         var properties = (Dictionary<string, object?>)wall.properties["properties"]!;
         var parameters = (Dictionary<string, object?>)properties["Parameters"]!;
-        // instance-scoped stays put
-        ((Dictionary<string, object?>)parameters["Constraints"]!)["Base Offset"]
-          .Should()
-          .Be(0.5);
-        // type-scoped merged back — the v3 shape
+        // instance-scoped stays put — as a v3 record leaf (ENG-9300)
+        Record(parameters, "Constraints", "Base Offset")["value"].Should().Be(0.5);
+        // type-scoped merged back — the v3 shape, record leaves included
         var typeParams = (Dictionary<string, object?>)parameters["Type Parameters"]!;
-        ((Dictionary<string, object?>)typeParams["Construction"]!)["Width"].Should().Be(265.0);
+        Record(typeParams, "Construction", "Width")["value"].Should().Be(265.0);
         var layer0 = (Dictionary<string, object?>)((Dictionary<string, object?>)typeParams["Structure"]!)["0"]!;
-        layer0["material"].Should().Be("White Concrete");
-        layer0["thickness"].Should().Be(65.0);
+        ((Dictionary<string, object?>)layer0["material"]!)["value"].Should().Be("White Concrete");
+        var thickness = (Dictionary<string, object?>)layer0["thickness"]!;
+        thickness["value"].Should().Be(65.0);
+        thickness["units"].Should().Be("mm");
       }
 
       // one-parse-per-type: the type-only subtree is the SAME dictionary instance on both walls (copy-on-write

--- a/tests/Speckle.Objects.Tests.Unit/Utils/V3RecordLeafTests.cs
+++ b/tests/Speckle.Objects.Tests.Unit/Utils/V3RecordLeafTests.cs
@@ -1,0 +1,108 @@
+using AwesomeAssertions;
+using Speckle.Objects.Data;
+using Speckle.Objects.Geometry;
+using Speckle.Objects.Utils;
+using Speckle.Sdk;
+using Speckle.Sdk.Models.Collections;
+using Speckle.Sdk.Pipelines.Receive.Artifacts;
+
+namespace Speckle.Objects.Tests.Unit.Utils;
+
+/// <summary>
+/// ENG-9300: a v3 script reads parameter and quantity leaves as <c>{name, value, units}</c> records — the flatten
+/// collapses those into rows (value + unit/idn columns), so the Base projection rebuilds them, but ONLY in the
+/// subtrees that were records in v3 (<c>Parameters.*</c>, <c>Material Quantities.*</c>). Everything else stays
+/// scalar, reproducing v3's mixed shape. Receive3/PropertyView is untouched (flat, scalar).
+/// </summary>
+public class V3RecordLeafTests
+{
+  private static readonly SpeckleApplication TestProducer = new()
+  {
+    HostApplication = "Test",
+    HostApplicationVersion = "1.2.3",
+    Slug = "test-connector",
+    SpeckleVersion = "999.1.0-alpha.1",
+  };
+
+  private static Mesh Triangle() =>
+    new()
+    {
+      vertices = new List<double> { 0, 0, 0, 1, 0, 0, 1, 1, 0 },
+      faces = new List<int> { 3, 0, 1, 2 },
+      units = "m",
+    };
+
+  private static Dictionary<string, object?> Field(string name, object? value, string? units = null, string? idn = null)
+  {
+    var field = new Dictionary<string, object?> { ["name"] = name, ["value"] = value };
+    if (units is not null)
+    {
+      field["units"] = units;
+    }
+    if (idn is not null)
+    {
+      field["internalDefinitionName"] = idn;
+    }
+    return field;
+  }
+
+  [Fact]
+  public async Task ParameterLeaves_ComeBackAsV3Records_ScalarsStayScalar()
+  {
+    var dir = Path.Combine(Path.GetTempPath(), "SpeckleV3Records", Guid.NewGuid().ToString("N"));
+    try
+    {
+      using (var pipeline = new ObjectsArtifactPipeline(dir, "v3r", TestProducer))
+      {
+        int objK = pipeline.InternObject("wall-1");
+        pipeline.AddProperties(
+          "wall-1",
+          new Dictionary<string, object?>
+          {
+            ["Parameters"] = new Dictionary<string, object?>
+            {
+              ["Constraints"] = new Dictionary<string, object?>
+              {
+                ["Base Offset"] = Field("Base Offset", 0.5, "mm", "WALL_BASE_OFFSET"),
+              },
+              ["Identity Data"] = new Dictionary<string, object?> { ["Mark"] = Field("Mark", "W-01") },
+            },
+            ["myUserNote"] = "check this wall",
+          }
+        );
+        int gK = pipeline.AddGeometry("wall-1:g0", Triangle());
+        pipeline.Display(objK, gK, 0);
+        pipeline.Complete();
+      }
+
+      var bundle = await ArtefactBundleReader.ReadAsync(dir, default);
+      var root = (Collection)new ObjectsArtifactReader().Build(bundle, new(PreferSolids: false), default);
+      var wall = root.elements.OfType<DataObject>().Single(b => b.applicationId == "wall-1");
+      var props = (Dictionary<string, object?>)wall.properties["properties"]!;
+      var parameters = (Dictionary<string, object?>)props["Parameters"]!;
+
+      // the exact v3 access pattern works again: ["value"], ["units"], ["name"], ["internalDefinitionName"]
+      var baseOffset =
+        (Dictionary<string, object?>)((Dictionary<string, object?>)parameters["Constraints"]!)["Base Offset"]!;
+      baseOffset["name"].Should().Be("Base Offset");
+      baseOffset["value"].Should().Be(0.5);
+      baseOffset["units"].Should().Be("mm");
+      baseOffset["internalDefinitionName"].Should().Be("WALL_BASE_OFFSET");
+
+      // a unit-less parameter is a record without a units key — v3's shape for text params
+      var mark = (Dictionary<string, object?>)((Dictionary<string, object?>)parameters["Identity Data"]!)["Mark"]!;
+      mark["value"].Should().Be("W-01");
+      mark.Should().NotContainKey("units");
+
+      // outside the record subtrees, v3 was scalar and stays scalar
+      props["myUserNote"].Should().Be("check this wall");
+    }
+    finally
+    {
+      if (Directory.Exists(dir))
+      {
+        Directory.Delete(dir, true);
+      }
+    }
+  }
+}

--- a/tests/Speckle.Sdk.BundleMigrator.Tests/V3GraphArtifactProducerTypeParameterTests.cs
+++ b/tests/Speckle.Sdk.BundleMigrator.Tests/V3GraphArtifactProducerTypeParameterTests.cs
@@ -144,15 +144,23 @@ public class V3GraphArtifactProducerTypeParameterTests
       // Same type ⇒ literally the same parsed dictionary; different type ⇒ a different one.
       typeProps[a1].Should().BeSameAs(typeProps[a2]);
       typeProps[b1].Should().NotBeSameAs(typeProps[a1]);
-      Nested(typeProps[a1], "properties", "Parameters", "Type Parameters", "Identity Data", "Type Mark")
+      Nested(typeProps[a1], "properties", "Parameters", "Type Parameters", "Identity Data", "Type Mark", "value")
         .Should()
         .Be("W1");
-      Nested(typeProps[b1], "properties", "Parameters", "Type Parameters", "Identity Data", "Type Mark")
+      Nested(typeProps[b1], "properties", "Parameters", "Type Parameters", "Identity Data", "Type Mark", "value")
         .Should()
         .Be("W2");
 
       // Instance eav keeps instance params but no longer carries the type subtree.
-      Nested(bundle.Properties[a1], "properties", "Parameters", "Instance Parameters", "Constraints", "Base Offset")
+      Nested(
+          bundle.Properties[a1],
+          "properties",
+          "Parameters",
+          "Instance Parameters",
+          "Constraints",
+          "Base Offset",
+          "value"
+        )
         .Should()
         .Be(0.5);
       Nested(bundle.Properties[a1], "properties", "Parameters", "Type Parameters").Should().BeNull();
@@ -208,7 +216,15 @@ public class V3GraphArtifactProducerTypeParameterTests
 
       bundle.TypePropertiesByObject.Should().BeEmpty();
       var c1 = ObjIdx(bundle, "c1");
-      Nested(bundle.Properties[c1], "properties", "Parameters", "Type Parameters", "Identity Data", "Type Mark")
+      Nested(
+          bundle.Properties[c1],
+          "properties",
+          "Parameters",
+          "Type Parameters",
+          "Identity Data",
+          "Type Mark",
+          "value"
+        )
         .Should()
         .Be("W1");
       stats.RevitTypeKeys.Should().Be(0);
@@ -233,7 +249,15 @@ public class V3GraphArtifactProducerTypeParameterTests
 
       bundle.TypePropertiesByObject.Should().BeEmpty();
       var d1 = ObjIdx(bundle, "d1");
-      Nested(bundle.Properties[d1], "properties", "Parameters", "Instance Parameters", "Constraints", "Base Offset")
+      Nested(
+          bundle.Properties[d1],
+          "properties",
+          "Parameters",
+          "Instance Parameters",
+          "Constraints",
+          "Base Offset",
+          "value"
+        )
         .Should()
         .Be(0.5);
       stats.RevitTypeKeys.Should().Be(1); // candidate count: the key was derived even though no type row was emitted


### PR DESCRIPTION
## What

The last piece of the [ENG-9300](https://linear.app/speckle/issue/ENG-9300) receive-shape contract, driven by the Automate-script requirement: a v3 script reads parameter leaves as `{name, value, units}` records —

```csharp
var offset = ((Dictionary<string,object>)props["Parameters"]["Constraints"]["Base Offset"])["value"];  // 0.5
```

— but the flatten collapses those records into rows (value + `unit`/`internal_definition_name` columns) and the nested rebuild returned bare scalars, so **every parameter-reading legacy script broke** on a bundle version received through `Receive2`/`TreeMaterializer`.

`BuildProperties` now rebuilds the record from the row's columns, **only in the subtrees that were records in the v3 shape** (`properties.Parameters.*`, `properties.Material Quantities.*`):
- `name` = the leaf key (v3 used the human label as both key and `name`)
- `value` = the row value
- `units` / `internalDefinitionName` only when the columns carry them — so a text parameter is a record *without* a `units` key, exactly as v3 emitted it

Everything outside those subtrees (user text, GH props, root scalars like `elementId`/`builtInCategory`) was scalar in v3 and stays scalar — the v3 *mixed* shape reproduced by producer convention, not a heuristic. One shared rebuild serves both scopes, so the type params merged by #570 carry records too. Works identically for connector-era, migrated, and rvextract bundles (rvextract writes the same records on the way in).

**Untouched:** `Receive3` / `PropertyView` / `ToNested()` — flat paths, scalar values; the bundle-native contract stays clean.

## Contract statement (for the ENG-9300 sign-off)
Nesting rebuilt from dotted EAV path segments, uniformly across object/type/model scopes; leaves under `Parameters`/`Material Quantities` are v3 records rebuilt from row columns; all other leaves scalar; ordinal keys are strings; no dot-escaping in the path grammar.

## Tests
- `V3RecordLeafTests` (new): the exact v3 access pattern end-to-end (`["value"]`, `["units"]`, `["name"]`, `["internalDefinitionName"]`), unit-less record without a `units` key, scalar-outside-subtree untouched.
- `TypeScopedProjectionTests` flipped to record leaves (fixture made v3-faithful).
- Migrator `V3GraphArtifactProducerTypeParameterTests`: `Nested(...)` paths gained the `"value"` hop.
- Suites: 218 objects, 40 migrator, 1064 unit — net8/net10 green. Verified live in the debugger on an rvextract bundle (record with idn, no units; root scalars untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mGdYTzvqTrbws7r8vwMgK