### PR TITLE
feat(ingestion): optional connectorVersion on SourceDataInput

### DIFF
--- a/src/Speckle.Sdk/Api/GraphQL/Inputs/ModelIngestionInputs.cs
+++ b/src/Speckle.Sdk/Api/GraphQL/Inputs/ModelIngestionInputs.cs
@@ -3,11 +3,15 @@ using Speckle.Sdk.Api.GraphQL.Enums;
 
 namespace Speckle.Sdk.Api.GraphQL.Inputs;
 
+/// <param name="sourceApplicationVersion">Release of the host application (Revit 2024 -> "2024"), not of the connector.</param>
+/// <param name="connectorVersion">Version of the Speckle connector / client running the ingestion (<see cref="Speckle.Sdk.ISpeckleApplication.SpeckleVersion"/>).
+/// Defaults to <see langword="null"/>, which is not serialized, so callers stay compatible with servers that predate the field.</param>
 public record SourceDataInput(
   string sourceApplicationSlug,
   string sourceApplicationVersion,
   string? fileName,
-  long? fileSizeBytes
+  long? fileSizeBytes,
+  string? connectorVersion = null
 );
 
 public record ModelIngestionCreateInput(


### PR DESCRIPTION
## What

`SourceDataInput` gains a defaulted trailing `string? connectorVersion = null`.

## Why

speckle-server-internal #2815 adds an optional `connectorVersion` to the ingestion `SourceDataInput` so the web app's Ingestion Details can show the connector build next to the host-app release (`sourceApplicationVersion`, e.g. "2024"). Today the connector version is nowhere on the wire; the only copy is `sdk_version` in the bundle's `meta.parquet`, which the server never reads.

Defaulted so every existing caller compiles unchanged. A `null` is not serialized (`GraphQLClientFactory` sets `NullValueHandling.Ignore`), so callers that leave it unset keep working against servers that predate the field. A caller that does set it needs a server with #2815.

## Follow-up

sharp-connectors: pass `speckleApplication.SpeckleVersion` at the three `Ingestion.Create` call sites in `SendOperation.cs` (separate PR, after this ships in a package).

## Testing

`dotnet build src/Speckle.Sdk` succeeds; csharpier clean. No behaviour change without a caller opting in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUhU8RM42XgXbWLXeLgD7D
