### PR TITLE
ci(integration): run a bundle-migration worker next to the internal server

### DIFF
--- a/.github/workflows/integration-test-callable-from-server-repo.yml
+++ b/.github/workflows/integration-test-callable-from-server-repo.yml
@@ -74,5 +74,5 @@ jobs:
         working-directory: ${{ env.CLIENT_DIR }}
         
       - name: 🔨 Run .NET Integration Tests 
-        run: dotnet test ${{ env.SOLUTION }} --filter "(Category=Integration)&(Server!=Public)" --configuration Release --no-build --no-restore --verbosity=normal
+        run: dotnet test ${{ env.SOLUTION }} --filter "(Category=Integration)&(Server!=Public)&(Requires!=DatGen)" --configuration Release --no-build --no-restore --verbosity=normal
         working-directory: ${{ env.CLIENT_DIR }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: 🔨 Integration Tests against Internal Server
         if: ${{ inputs.use-internal-image }}
-        run: dotnet test ${{ env.Solution }} --filter "(Category=Integration)&(Server!=Public)" --configuration Release --no-build --no-restore --verbosity=normal /p:AltCover=true /p:AltCoverAttributeFilter=ExcludeFromCodeCoverage
+        run: dotnet test ${{ env.Solution }} --filter "(Category=Integration)&(Server!=Public)&(Requires!=DatGen)" --configuration Release --no-build --no-restore --verbosity=normal /p:AltCover=true /p:AltCoverAttributeFilter=ExcludeFromCodeCoverage
 
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v7

--- a/docker-compose-internal.yml
+++ b/docker-compose-internal.yml
@@ -26,6 +26,9 @@ services:
     restart: always
     volumes:
       - ./.volumes/redis-data:/data
+    # Published for the host-networked bundle-migration worker below.
+    ports:
+      - '127.0.0.1:6379:6379'
     healthcheck:
       test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
       interval: 5s
@@ -104,6 +107,42 @@ services:
       LOG_PRETTY: "true"
 
       FF_DATA_MODULE_ENABLED: 'true'
+
+      # The legacy-send switch (server ADR-0003): unset, versionMutations.create and the
+      # v1 uploads/process rail answer LEGACY_SEND_UNSUPPORTED. Any value works, the
+      # worker below never sees it (the server mints per-job tokens from it).
+      BUNDLE_MIGRATION_TOKEN_SECRET: "integration-tests-bundle-migration-token-secret"
+
+  # Since server ADR-0003 a legacy send only reserves a version; this worker packs the
+  # bundle (+ viewer .dat) and completes it, which is when the version is born. It runs
+  # on the host network because the server hands it its own CANONICAL_URL and presigned
+  # S3_PUBLIC_ENDPOINT urls, both 127.0.0.1 from the runner's point of view.
+  bundle-migration-service:
+    image: ${SPECKLE_BUNDLE_MIGRATION_IMAGE:-ghcr.io/specklesystems/speckle-bundle-migration-service:latest}
+    restart: always
+    network_mode: host
+    depends_on:
+      speckle-server:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "require('node:http').get({ port: 3031, hostname: '127.0.0.1', path: '/readiness', timeout: 2000 }, (res) => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
+      interval: 10s
+      timeout: 10s
+      retries: 6
+      start_period: 30s
+    environment:
+      HOST: "127.0.0.1"
+      PORT: 3031
+      REDIS_URL: "redis://127.0.0.1:6379"
+      BUNDLE_MIGRATION_LANE: "standard"
+      # Fixed DuckDB memory limit for datgen: unset sizes from the cgroup, which is
+      # unbounded in a plain docker container.
+      DATGEN_MEM: "2GB"
+      LOG_PRETTY: "true"
 
 networks:
   default:

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/FileUploadResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/FileUploadResourceTests.cs
@@ -7,6 +7,12 @@ using Speckle.Sdk.Api.GraphQL.Resources;
 
 namespace Speckle.Sdk.Tests.Integration.API.GraphQL.Resources;
 
+/// <summary>
+/// Exercises the retired file-import rail (generateUploadUrl / startFileImport / finishFileImport). A 2026.9
+/// server accepts no file type on it (uploads go through startFileIngestion, converted by the in-cluster
+/// job runner), so this only runs against the public image.
+/// </summary>
+[Trait("Server", "Public")]
 public class FileUploadResourceTests : IAsyncLifetime
 {
   private FileImportResource Sut => _client.FileImport;

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ModelIngestionResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/ModelIngestionResourceTests.cs
@@ -150,7 +150,7 @@ public sealed class ModelIngestionResourceTests : IAsyncLifetime
 #pragma warning disable CS0618 // deliberately exercising the obsolete completeWithVersion path (ENG-9221)
     string versionId = await Sut.Complete(finish);
 #pragma warning restore CS0618
-    Version version = await _testUser.Version.Get(versionId, _project.id);
+    Version version = await Fixtures.WaitForVersion(_testUser, _project.id, versionId);
     ModelIngestion finalIngestion = await _testUser.Ingestion.Get(ingest.id, _project.id);
     Assert.Equal(version.id, versionId);
     Assert.Equal(sendResult.RootId, version.referencedObject);

--- a/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/SubscriptionResourceTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Api/GraphQL/Resources/SubscriptionResourceTests.cs
@@ -102,7 +102,8 @@ public class SubscriptionResourceTests : IAsyncLifetime
   {
     TaskCompletionSource<ProjectVersionsUpdatedMessage> tcs = new();
     using var sub = Sut.CreateProjectVersionsUpdatedSubscription(_testProject.id);
-    sub.Listeners += (_, message) => tcs.SetResult(message);
+    // A 2026.9 server also emits UPDATED once the worker stamps the bundle onto the born version
+    sub.Listeners += (_, message) => tcs.TrySetResult(message);
 
     await Task.Delay(WAIT_PERIOD); // Give time to subscription to be setup
 

--- a/tests/Speckle.Sdk.Tests.Integration/Bundles/SendReceiveBundleTests.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Bundles/SendReceiveBundleTests.cs
@@ -14,6 +14,9 @@ namespace Speckle.Sdk.Tests.Integration.Bundles;
 /// and the version's <c>referencedObject</c> is the bundle reference Receive2 dispatches on.
 /// </summary>
 [Trait("Server", "Internal")]
+// A bundle without its viewer .dat is completed by a one-shot Kubernetes datgen Job, which docker compose cannot
+// stand in for; the CI internal job filters this trait out. Run it against a cluster-backed server.
+[Trait("Requires", "DatGen")]
 public sealed class SendReceiveBundleTests : IAsyncLifetime
 {
   private static readonly SpeckleApplication s_app = new()

--- a/tests/Speckle.Sdk.Tests.Integration/Fixtures.cs
+++ b/tests/Speckle.Sdk.Tests.Integration/Fixtures.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using Speckle.Sdk.Api;
 using Speckle.Sdk.Api.GraphQL.Inputs;
 using Speckle.Sdk.Api.GraphQL.Models;
+using Speckle.Sdk.Api.GraphQL.Resources;
 using Speckle.Sdk.Common;
 using Speckle.Sdk.Credentials;
 using Speckle.Sdk.Host;
@@ -61,7 +62,37 @@ public static class Fixtures
       .GetRequiredService<IOperations>()
       .Send(new() { applicationId = "ASDF" }, remote, false);
     CreateVersionInput input = new(objectId, modelId, projectId);
-    return await client.Version.Create(input);
+    var reserved = await client.Version.Create(input);
+    return await WaitForVersion(client, projectId, reserved.id);
+  }
+
+  /// <summary>
+  /// On 2026.9 servers <see cref="VersionResource.Create"/> only reserves an id: the version is born when the
+  /// bundle-migration worker completes the ingestion (docker-compose-internal.yml runs one). Pre-2026.9 servers
+  /// create the version inline, so the first poll returns.
+  /// </summary>
+  public static async Task<Version> WaitForVersion(
+    IClient client,
+    string projectId,
+    string versionId,
+    TimeSpan? timeout = null
+  )
+  {
+    var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromMinutes(2));
+    SpeckleGraphQLException? last = null;
+    while (DateTime.UtcNow < deadline)
+    {
+      try
+      {
+        return await client.Version.Get(versionId, projectId);
+      }
+      catch (SpeckleGraphQLException ex)
+      {
+        last = ex;
+      }
+      await Task.Delay(TimeSpan.FromSeconds(1));
+    }
+    throw new TimeoutException($"Version {versionId} was not born within the timeout", last);
   }
 
   public static async Task<Account> SeedUser()


### PR DESCRIPTION
## Why

The `integration-test-internal` job has failed on every run since 2026-08-03 (last green: run 30804160772). It is not the PRs: the internal server image moved on and the compose file did not.

Breakdown of the 22 failures on a current run (34103975094):

| Family | Tests | Cause |
|---|---|---|
| `LEGACY_SEND_UNSUPPORTED` | 15 | Since server ADR-0003 `versionMutations.create` and the v1 `uploads/process` rail only reserve a version; the bundle-migration worker completes it. The compose file set no `BUNDLE_MIGRATION_TOKEN_SECRET` (the legacy-send switch) and ran no worker. |
| `UNSUPPORTED_FILE_TYPE` (accepted types: none) | 4 | `FileUploadResourceTests` drive the retired file-import rail; a 2026.9 server accepts no file type on it. |
| `CONVERSION_RUNNER_NOT_IN_CLUSTER` | 1 | A bundle without its viewer `.dat` is completed by a one-shot Kubernetes datgen Job. Compose cannot stand in for that. |
| 422 on trigger, `TypeLoader is not initialized` | 2 | The 422 is the same legacy-send rejection on the NDJSON rail. The TypeLoader one looks like a static-init race across parallel test classes and is not addressed here. |

## What

- **`docker-compose-internal.yml`**: sets `BUNDLE_MIGRATION_TOKEN_SECRET` and adds `speckle-bundle-migration-service:latest` (override with `SPECKLE_BUNDLE_MIGRATION_IMAGE`). The worker runs on the host network because the server hands it `CANONICAL_URL` and presigned `S3_PUBLIC_ENDPOINT` URLs, both `127.0.0.1`; redis is published on `127.0.0.1:6379` for it. Fixed `DATGEN_MEM` since a plain container has no cgroup limit to size from.
- **`Fixtures.CreateVersion`** polls `Version.Get` until the version is born (no-op on pre-2026.9 servers, which create it inline); `CreateAndComplete` does the same after `completeWithVersion`.
- **`FileUploadResourceTests`** → `[Trait("Server", "Public")]`.
- **`SendReceiveBundleTests`** → `[Trait("Requires", "DatGen")]`, and both internal filters exclude it. It stays runnable against a cluster-backed server.

## Ordering

The worker image only gets a moving `latest` tag after specklesystems/speckle-server-internal#2825 merges and a main build runs. Until then this job fails at `docker compose up` on the image pull, so expect the first run here to be red for that reason.

## Local runs

`docker compose -f docker-compose-internal.yml up --wait` needs ghcr auth (`read:packages`) and, on macOS, Docker Desktop's host networking enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U8t268L1dgSvGd5Gd9uEr
